### PR TITLE
feat(#200): add document range formatting support

### DIFF
--- a/server/src/ClarionFormatter.ts
+++ b/server/src/ClarionFormatter.ts
@@ -351,6 +351,32 @@ class ClarionFormatter {
         return formattedLines.join(eol);
     }
 
+    public formatRange(startLine: number, endLine: number): string | null {
+        if (startLine < 0 || endLine < 0 || endLine < startLine) {
+            return null;
+        }
+
+        const originalLines = this.text.split(/\r?\n/);
+        if (originalLines.length === 0) {
+            return null;
+        }
+
+        const safeStart = Math.min(startLine, originalLines.length - 1);
+        const safeEnd = Math.min(endLine, originalLines.length - 1);
+        if (safeEnd < safeStart) {
+            return null;
+        }
+
+        const formattedText = this.format();
+        const formattedLines = formattedText.split(/\r?\n/);
+        const eol = this.text.includes('\r\n') ? '\r\n' : '\n';
+
+        const originalRange = originalLines.slice(safeStart, safeEnd + 1).join(eol);
+        const formattedRange = formattedLines.slice(safeStart, safeEnd + 1).join(eol);
+
+        return originalRange === formattedRange ? null : formattedRange;
+    }
+
     public formatDocument(): string {
         return this.format();
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,6 +17,7 @@ process.on('unhandledRejection', (reason, promise) => {
 
 import {
     DocumentFormattingParams,
+    DocumentRangeFormattingParams,
     DocumentSymbolParams,
     DocumentSymbol,
     FoldingRangeParams,
@@ -223,6 +224,7 @@ connection.onInitialize((params) => {
             capabilities: {
                 textDocumentSync: TextDocumentSyncKind.Incremental,
                 documentFormattingProvider: true,
+                documentRangeFormattingProvider: true,
                 documentSymbolProvider: true,
                 foldingRangeProvider: true,
                 colorProvider: true,
@@ -1053,6 +1055,58 @@ connection.onDocumentFormatting((params: DocumentFormattingParams): TextEdit[] =
         return [];
     } catch (error) {
         logger.error(`❌ [DEBUG] Error formatting document: ${error instanceof Error ? error.message : String(error)}`);
+        return [];
+    }
+});
+
+connection.onDocumentRangeFormatting((params: DocumentRangeFormattingParams): TextEdit[] => {
+    try {
+        logger.info(`📐 [DEBUG] Received onDocumentRangeFormatting request for: ${params.textDocument.uri}`);
+        const document = documents.get(params.textDocument.uri);
+        if (!document) {
+            logger.warn(`⚠️ [DEBUG] Document not found for range formatting: ${params.textDocument.uri}`);
+            return [];
+        }
+
+        const uri = document.uri;
+        if (uri.toLowerCase().endsWith('.xml') || uri.toLowerCase().endsWith('.cwproj')) {
+            logger.info(`🔍 [DEBUG] Skipping XML file in onDocumentRangeFormatting: ${uri}`);
+            return [];
+        }
+
+        const text = document.getText();
+        const tokens = getTokens(document);
+        const formatter = new ClarionFormatter(tokens, text, {
+            formattingOptions: params.options
+        });
+
+        if (document.lineCount === 0) {
+            return [];
+        }
+
+        const startLine = Math.max(0, Math.min(params.range.start.line, document.lineCount - 1));
+        const rawEndLine = params.range.end.character === 0
+            ? params.range.end.line - 1
+            : params.range.end.line;
+        const endLine = Math.max(startLine, Math.min(rawEndLine, document.lineCount - 1));
+        const replacement = formatter.formatRange(startLine, endLine);
+        if (replacement === null) {
+            return [];
+        }
+
+        const eol = text.includes('\r\n') ? '\r\n' : '\n';
+        const hasNextLine = endLine + 1 < document.lineCount;
+        const startOffset = document.offsetAt(Position.create(startLine, 0));
+        const endOffset = hasNextLine
+            ? document.offsetAt(Position.create(endLine + 1, 0))
+            : text.length;
+
+        return [TextEdit.replace(
+            Range.create(document.positionAt(startOffset), document.positionAt(endOffset)),
+            hasNextLine ? replacement + eol : replacement
+        )];
+    } catch (error) {
+        logger.error(`❌ [DEBUG] Error range-formatting document: ${error instanceof Error ? error.message : String(error)}`);
         return [];
     }
 });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1089,7 +1089,18 @@ connection.onDocumentRangeFormatting((params: DocumentRangeFormattingParams): Te
             ? params.range.end.line - 1
             : params.range.end.line;
         const endLine = Math.max(startLine, Math.min(rawEndLine, document.lineCount - 1));
-        const replacement = formatter.formatRange(startLine, endLine);
+        let replacement = formatter.formatRange(startLine, endLine);
+
+        // Some clients report selection end at column 0 of the *next* line; others use
+        // the final selected line with non-zero character. If the normalized range no-ops,
+        // retry once with the raw end-line interpretation to avoid false "no change".
+        if (replacement === null) {
+            const altEndLine = Math.max(startLine, Math.min(params.range.end.line, document.lineCount - 1));
+            if (altEndLine !== endLine) {
+                replacement = formatter.formatRange(startLine, altEndLine);
+            }
+        }
+
         if (replacement === null) {
             return [];
         }

--- a/server/src/test/ClarionFormatter.test.ts
+++ b/server/src/test/ClarionFormatter.test.ts
@@ -835,3 +835,52 @@ suite('ClarionFormatter – Bug 6: CLASS keyword aligns with type column in loca
         );
     });
 });
+
+// =============================================================================
+// Issue #200 – Document range formatting
+// =============================================================================
+suite('ClarionFormatter – Issue #200: range formatting', () => {
+    test('[RED] formatRange returns only the formatted selected line span', () => {
+        const code = [
+            'Main PROCEDURE()',
+            'x LONG',
+            '  CODE',
+            'IF x = 1',
+            'x = 2',
+            'END',
+            '  RETURN',
+        ].join('\n');
+
+        const tokens = new ClarionTokenizer(code).tokenize();
+        const formatter = new ClarionFormatter(tokens, code, { indentSize: 4 });
+        const replacement = formatter.formatRange(3, 5);
+        const expectedSlice = formatter
+            .format()
+            .split(/\r?\n/)
+            .slice(3, 6)
+            .join('\n');
+
+        assert.strictEqual(
+            replacement,
+            expectedSlice,
+        );
+    });
+
+    test('[RED] formatRange returns null when selected line span is already formatted', () => {
+        const code = [
+            'Main PROCEDURE()',
+            'x LONG',
+            '  CODE',
+            '    IF x = 1',
+            '        x = 2',
+            '    END',
+            '    RETURN',
+        ].join('\n');
+
+        const tokens = new ClarionTokenizer(code).tokenize();
+        const formatter = new ClarionFormatter(tokens, code, { indentSize: 4 });
+        const replacement = formatter.formatRange(3, 5);
+
+        assert.strictEqual(replacement, null);
+    });
+});


### PR DESCRIPTION
## Summary
- advertise documentRangeFormattingProvider from the server
- implement onDocumentRangeFormatting using full-document formatter context
- emit edits only for selected line span
- add ClarionFormatter range-format RED/GREEN tests
- preserve robust range-end fallback for client selection-end variants

Closes #200