### PR TITLE
Implement DO routine definition lookup (#211)

### DIFF
--- a/server/src/providers/DefinitionProvider.ts
+++ b/server/src/providers/DefinitionProvider.ts
@@ -309,6 +309,24 @@ export class DefinitionProvider {
                 }
             }
 
+            // ✅ #211 DO routine reference: F12 on routine name in `DO RoutineName` → ROUTINE label
+            const doRoutineMatch = line.match(/\bDO\s+(\w+)/i);
+            if (doRoutineMatch) {
+                const routineName = doRoutineMatch[1];
+                if (routineName.toLowerCase() === word.toLowerCase()) {
+                    const routineStart = line.indexOf(routineName, line.toUpperCase().indexOf('DO'));
+                    const routineEnd = routineStart + routineName.length;
+                    if (position.character >= routineStart && position.character <= routineEnd) {
+                        logger.info(`F12 on routine reference: DO ${routineName} — looking for ROUTINE label`);
+                        const routineLocation = this.findRoutineDefinition(routineName, document, position, tokens);
+                        if (routineLocation) {
+                            logger.info(`✅ Found ROUTINE '${routineName}' definition`);
+                            return routineLocation;
+                        }
+                    }
+                }
+            }
+
             // ✅ IMPLEMENTS(InterfaceName) navigation: F12 on interface name → INTERFACE declaration
             const implementsMatch = line.match(/\bIMPLEMENTS\s*\(\s*(\w+)\s*\)/gi);
             if (implementsMatch) {
@@ -2343,6 +2361,43 @@ export class DefinitionProvider {
 
         logger.info(`📋 SCOPE-FILTER: Returning ${accessible.length} candidates (sorted by scope distance)`);
         return accessible;
+    }
+
+    /**
+     * #211 — Resolves F12 on a routine name in a `DO RoutineName` statement to the `RoutineName ROUTINE` label
+     * Routines are procedure-local labels; this method scopes the search to the enclosing procedure only.
+     * @param routineName The name of the routine to find (case-insensitive)
+     * @param document The text document
+     * @param position The position of the DO reference
+     * @param tokens The tokens array
+     * @returns A Location pointing to the routine definition, or null if not found
+     */
+    private findRoutineDefinition(routineName: string, document: TextDocument, position: Position, tokens: Token[]): Location | null {
+        logger.info(`🔍 [#211] Resolving DO routine reference: "${routineName}"`);
+        
+        const structure = this.tokenCache.getStructure(document);
+        
+        const enclosingProc = TokenHelper.getInnermostScopeAtLine(structure, position.line);
+        if (!enclosingProc || !TokenHelper.isProcedureOrFunction(enclosingProc)) {
+            logger.info(`❌ No enclosing procedure found at line ${position.line}`);
+            return null;
+        }
+        
+        logger.info(`Found enclosing procedure: "${enclosingProc.value}" (lines ${enclosingProc.line}-${enclosingProc.finishesAt})`);
+
+        const routineTokens = structure.findRoutines(routineName).filter(routineToken => {
+            const parentScope = TokenHelper.getParentScopeOfRoutine(structure, routineToken);
+            return parentScope?.line === enclosingProc.line && parentScope?.value.toUpperCase() === enclosingProc.value.toUpperCase();
+        });
+
+        if (routineTokens.length === 0) {
+            logger.info(`❌ No ROUTINE label found for "${routineName}" in procedure "${enclosingProc.value}"`);
+            return null;
+        }
+
+        const routineToken = routineTokens[0];
+        logger.info(`✅ Found ROUTINE "${routineName}" at line ${routineToken.line}`);
+        return Location.create(document.uri, Range.create(routineToken.line, 0, routineToken.line, routineToken.value.length));
     }
 
 }

--- a/server/src/test/DefinitionProvider.DoRoutine.test.ts
+++ b/server/src/test/DefinitionProvider.DoRoutine.test.ts
@@ -1,0 +1,113 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DefinitionProvider } from '../providers/DefinitionProvider';
+import { TokenCache } from '../TokenCache';
+
+suite('DefinitionProvider — DO Routine References (#211)', () => {
+    let docCounter = 0;
+
+    setup(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    function createDocument(code: string, uri: string = `test://do-routine-${++docCounter}.clw`): TextDocument {
+        return TextDocument.create(uri, 'clarion', 1, code);
+    }
+
+    function getLocationLine(result: any): number {
+        if (!result) return -1;
+        if (Array.isArray(result)) {
+            return result.length > 0 ? result[0].range.start.line : -1;
+        }
+        return result.range.start.line;
+    }
+
+    test('resolves DO routine references to the matching ROUTINE label', async () => {
+        const code = `MyProc PROCEDURE()
+  CODE
+  DO ProcessData
+ProcessData ROUTINE
+  RETURN
+END`;
+        const doc = createDocument(code);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new DefinitionProvider();
+        const result = await provider.provideDefinition(doc, { line: 2, character: 8 });
+
+        assert.strictEqual(getLocationLine(result), 3);
+    });
+
+    test('matches routine names case-insensitively', async () => {
+        const code = `MyProc PROCEDURE()
+  CODE
+  DO processdata
+ProcessData ROUTINE
+  RETURN
+END`;
+        const doc = createDocument(code);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new DefinitionProvider();
+        const result = await provider.provideDefinition(doc, { line: 2, character: 8 });
+
+        assert.strictEqual(getLocationLine(result), 3);
+    });
+
+    test('keeps routine lookup inside the enclosing procedure', async () => {
+        const code = `MyProc PROCEDURE()
+  CODE
+  DO MyRoutine
+MyRoutine ROUTINE
+  RETURN
+END
+
+OtherProc PROCEDURE()
+  CODE
+  DO MyRoutine
+MyRoutine ROUTINE
+  RETURN
+END`;
+        const doc = createDocument(code);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new DefinitionProvider();
+
+        const first = await provider.provideDefinition(doc, { line: 2, character: 8 });
+        assert.strictEqual(getLocationLine(first), 3);
+
+        const second = await provider.provideDefinition(doc, { line: 9, character: 8 });
+        assert.strictEqual(getLocationLine(second), 10);
+    });
+
+    test('returns null when the routine is not present in the procedure', async () => {
+        const code = `MyProc PROCEDURE()
+  CODE
+  DO UndefinedRoutine
+END`;
+        const doc = createDocument(code);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new DefinitionProvider();
+        const result = await provider.provideDefinition(doc, { line: 2, character: 8 });
+
+        assert.strictEqual(result, null);
+    });
+
+    test('finds routines defined before the DO statement', async () => {
+        const code = `MyProc PROCEDURE()
+  CODE
+ProcessData ROUTINE
+  RETURN
+  DO ProcessData
+  RETURN
+END`;
+        const doc = createDocument(code);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new DefinitionProvider();
+        const result = await provider.provideDefinition(doc, { line: 4, character: 8 });
+
+        assert.strictEqual(getLocationLine(result), 2);
+    });
+});


### PR DESCRIPTION
Adds F12 navigation for DO routine references, resolving to the matching ROUTINE label within the enclosing procedure. Includes tests for case-insensitive matching, scope isolation, and missing routines.