### PR TITLE
Fix CLIP hover routing (#213)

### DIFF
--- a/server/src/providers/hover/HoverRouter.ts
+++ b/server/src/providers/hover/HoverRouter.ts
@@ -88,7 +88,7 @@ export class HoverRouter {
         if (symbolHover) return symbolHover;
 
         // 9. Handle attributes
-        const attributeHover = this.handleAttribute(word, line, wordRange, document);
+        const attributeHover = this.handleAttribute(word, line, wordRange, document, position, documentStructure, isInClassBlock);
         if (attributeHover) return attributeHover;
 
         // 9.5 Handle PROP: runtime property equates
@@ -331,8 +331,22 @@ export class HoverRouter {
     /**
      * Handle Clarion attributes
      */
-    private handleAttribute(word: string, line: string, wordRange: any, document: any): Hover | null {
+    private handleAttribute(
+        word: string,
+        line: string,
+        wordRange: any,
+        document: any,
+        position: { line: number; character: number },
+        documentStructure: { getControlContextAt(line: number, character: number): { structureType: string | null; controlType: string | null } },
+        isInClassBlock: boolean
+    ): Hover | null {
         if (!this.attributeService.isAttribute(word)) {
+            return null;
+        }
+
+        const controlContext = documentStructure.getControlContextAt(position.line, position.character);
+        const inDeclarationContext = isInClassBlock || controlContext.structureType !== null || controlContext.controlType !== null;
+        if (!inDeclarationContext) {
             return null;
         }
 

--- a/server/src/test/HoverProvider.CLIP.test.ts
+++ b/server/src/test/HoverProvider.CLIP.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+suite('HoverProvider — CLIP hover routing', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('resolves CLIP() as a builtin function in expressions', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  IF CLIP(LOC:EnrolCode) = ''
+    RETURN
+  END`;
+        const doc = TextDocument.create('test://clip-builtin.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 5));
+
+        assert.ok(hover, 'Should provide hover info');
+        const content = hoverText(hover);
+        assert.ok(content.includes('Built-in Function: CLIP'), 'Should show builtin CLIP hover');
+        assert.ok(!content.includes('OLE control attribute'), 'Should not show attribute hover in expression context');
+    });
+
+    test('resolves CLIP as an attribute in a control declaration', async () => {
+        const code = `MyWindow WINDOW
+  OLECtrl OLE,AT(0,0,100,100),CLIP
+END`;
+        const doc = TextDocument.create('test://clip-attribute.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 30));
+
+        assert.ok(hover, 'Should provide hover info');
+        const content = hoverText(hover);
+        assert.ok(content.includes('Attribute: CLIP'), 'Should show attribute hover in declaration context');
+        assert.ok(content.includes('OLE control attribute'), 'Should show the attribute description');
+    });
+});

--- a/server/src/test/HoverProvider.Refactor.test.ts
+++ b/server/src/test/HoverProvider.Refactor.test.ts
@@ -24,7 +24,15 @@ suite('HoverProvider - DocumentStructure API Integration', () => {
         tokenCache.clearTokens('test://hover2.clw');
         tokenCache.clearTokens('test://hover3.clw');
         tokenCache.clearTokens('test://hover4.clw');
+        tokenCache.clearTokens('test://hover5.clw');
+        tokenCache.clearTokens('test://hover6.clw');
     });
+
+    function hoverText(hover: any): string {
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
 
     suite('MAP procedure hover (declaration → implementation)', () => {
         test('should show implementation hover when hovering on MAP declaration', async () => {
@@ -176,5 +184,6 @@ END`;
                     'Should not show MAP declaration when not in MAP context');
             }
         });
+
     });
 });


### PR DESCRIPTION
Resolve CLIP based on context: expressions like CLIP(LOC:EnrolCode) use builtin docs, while control declaration contexts still surface the CLIP attribute.