### PR TITLE
fix: hover and F12 for GROUP,TYPE parameter field access (#215)

### DIFF
--- a/server/src/providers/DefinitionProvider.ts
+++ b/server/src/providers/DefinitionProvider.ts
@@ -278,8 +278,10 @@ export class DefinitionProvider {
                         const structureNameMatch = beforeDot.match(/(\w+)\s*$/);
                         if (structureNameMatch) {
                             const structureName = structureNameMatch[1];
-                            const typeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document);
-                            const classType = typeInfo?.isClass ? typeInfo.typeName : this.findVariableType(tokens, structureName, position.line);
+                            // Pass position.line so resolveVariableType can also check procedure
+                            // parameters (e.g. `*WindowInfo Info`). Issue #215.
+                            const typeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document, position.line);
+                            const classType = typeInfo?.typeName ?? this.findVariableType(tokens, structureName, position.line, document);
                             if (classType) {
                                 logger.info(`Variable "${structureName}" is type "${classType}", looking for member "${methodName}"`);
                                 // #125 — arg-classification overlay: when the typed-var call has
@@ -765,8 +767,9 @@ export class DefinitionProvider {
                     }
 
                     // Try to find as a typed variable (e.g., otherValue.value where otherValue is StringTheory)
-                    const typeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document);
-                    const classType = typeInfo?.isClass ? typeInfo.typeName : this.findVariableType(tokens, structureName, position.line);
+                    // Pass position.line to also resolve procedure parameters. Issue #215.
+                    const typeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document, position.line);
+                    const classType = typeInfo?.typeName ?? this.findVariableType(tokens, structureName, position.line, document);
                     if (classType) {
                         logger.info(`Variable ${structureName} is of type ${classType}, looking for member ${fieldName}`);
                         const result = await this.findClassMemberInType(tokens, classType, fieldName, document);
@@ -2189,7 +2192,7 @@ export class DefinitionProvider {
         }
     }
 
-    private findVariableType(tokens: Token[], variableName: string, currentLine: number): string | null {
+    private findVariableType(tokens: Token[], variableName: string, currentLine: number, document?: TextDocument): string | null {
         logger.info(`Looking for type of variable ${variableName}`);
 
         // Find the variable declaration
@@ -2203,11 +2206,32 @@ export class DefinitionProvider {
         );
 
         if (varTokens.length === 0) {
-            // Check if it's a parameter
+            // Check if it's a parameter — parse the enclosing procedure's PROCEDURE() signature
             const currentScope = TokenHelper.getInnermostScopeAtLine(tokens, currentLine);
             if (currentScope) {
-                // TODO: Parse parameters to get type - for now return null
-                logger.info('Variable might be a parameter - parameter type detection not yet implemented');
+                const content = document?.getText();
+                if (content) {
+                    const lines = content.split('\n');
+                    const procedureLine = lines[currentScope.line] ?? '';
+                    const sigMatch = procedureLine.match(/PROCEDURE\s*\((.*?)\)/i);
+                    if (sigMatch?.[1]) {
+                        const wordLower = variableName.toLowerCase();
+                        for (const param of sigMatch[1].split(',')) {
+                            const trimmed = param.trim().replace(/^<(.*)>$/, '$1').trim();
+                            const m = trimmed.match(/^([*&]?\s*[\w:]+)\s+([A-Za-z_][\w:]*)(?:\s*=.*)?$/i);
+                            if (!m) continue;
+                            const paramName = m[2];
+                            const pLower = paramName.toLowerCase();
+                            if (pLower === wordLower || pLower.endsWith(':' + wordLower)) {
+                                const typeName = m[1].trim().replace(/^[*&]\s*/, '').trim();
+                                if (typeName) {
+                                    logger.info(`findVariableType: "${variableName}" is parameter of type "${typeName}"`);
+                                    return typeName;
+                                }
+                            }
+                        }
+                    }
+                }
             }
             return null;
         }

--- a/server/src/providers/hover/StructureFieldResolver.ts
+++ b/server/src/providers/hover/StructureFieldResolver.ts
@@ -189,8 +189,10 @@ export class StructureFieldResolver {
                 }
 
                 // Try typed class variable: find what class type structureName is,
-                // then look up the member in that class (e.g., st.GetValue() where st StringTheory)
-                const varTypeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document);
+                // then look up the member in that class (e.g., st.GetValue() where st StringTheory).
+                // Pass position.line so resolveVariableType can also check procedure parameters
+                // (e.g. `*WindowInfo Info` — parameters are not column-0 tokens). Issue #215.
+                const varTypeInfo = await this.memberLocator.resolveVariableType(structureName, tokens, document, position.line);
                 if (varTypeInfo) {
                     const { typeName: varType, isClass, isReference } = varTypeInfo;
                     logger.info(`✅ Variable "${structureName}" has type "${varType}" (isClass=${isClass}, isReference=${isReference}), looking up member "${fieldName}"`);
@@ -270,10 +272,15 @@ export class StructureFieldResolver {
     }
 
     /**
-     * Find a field inside a QUEUE/GROUP/FILE type definition (potentially in INCLUDE files)
-     * and return hover info showing the field declaration.
+     * Find a field inside a QUEUE/GROUP/FILE type definition (potentially in INCLUDE files
+     * or the current document itself).
      */
     private async resolveStructureTypeFieldHover(typeName: string, fieldName: string, document: TextDocument): Promise<Hover | null> {
+        // First: check the current document's own tokens (handles same-file GROUP,TYPE definitions)
+        const currentTokens = this.tokenCache.getTokens(document);
+        const fromCurrentDoc = this.findFieldInTokens(typeName, fieldName, currentTokens, document.uri);
+        if (fromCurrentDoc) return fromCurrentDoc;
+
         const filePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
         const result = await this.findFieldInTypeIncludes(typeName, fieldName, filePath, new Set());
         if (result) return result;
@@ -284,6 +291,54 @@ export class StructureFieldResolver {
             return this.findFieldInTypeIncludes(typeName, fieldName, equatesPath, new Set());
         }
         return null;
+    }
+
+    /**
+     * Searches an already-tokenized token array for a field inside a named GROUP/QUEUE/FILE type.
+     * Used to resolve same-file type definitions without a disk read.
+     */
+    private findFieldInTokens(typeName: string, fieldName: string, tokens: Token[], sourceUri: string): Hover | null {
+        const labelToken = tokens.find(t =>
+            (t.type === TokenType.Label || t.type === TokenType.Variable) &&
+            t.start === 0 &&
+            t.value.toLowerCase() === typeName.toLowerCase()
+        );
+        if (!labelToken) return null;
+
+        const labelIdx = tokens.indexOf(labelToken);
+        let structureEndLine = Number.MAX_VALUE;
+        for (let i = labelIdx + 1; i < tokens.length; i++) {
+            const t = tokens[i];
+            if (t.line !== labelToken.line) break;
+            if (t.type === TokenType.Structure && t.finishesAt !== undefined) {
+                structureEndLine = t.finishesAt;
+                break;
+            }
+        }
+
+        const fieldToken = tokens.find(t =>
+            (t.type === TokenType.Label || t.type === TokenType.Variable) &&
+            t.start === 0 &&
+            t.value.toLowerCase() === fieldName.toLowerCase() &&
+            t.line > labelToken.line &&
+            t.line < structureEndLine
+        );
+        if (!fieldToken) return null;
+
+        const lineTokens = tokens.filter(t => t.line === fieldToken.line);
+        const declaration = lineTokens.map(t => t.value).join('  ').trim();
+        const typeToken = lineTokens.find(t => t.start > fieldToken.start);
+        const fieldType = typeToken?.value ?? 'UNKNOWN';
+        const fileName = path.basename(decodeURIComponent(sourceUri.replace(/^file:\/\/\//, '')).replace(/\//g, path.sep));
+        const markdown = [
+            `**${typeName} Field:** \`${fieldName}\` — \`${fieldType}\``,
+            ``,
+            `\`\`\`clarion`,
+            declaration,
+            `\`\`\``,
+            `${fileName}:${fieldToken.line + 1}`
+        ].join('\n');
+        return { contents: { kind: 'markdown', value: markdown } };
     }
 
     /**

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -103,18 +103,72 @@ export class MemberLocatorService {
 
     /**
      * Resolves the type of a named variable.
-     * Search order: current file → MEMBER parent → INCLUDE chain.
+     * Search order: current file → MEMBER parent → INCLUDE chain → procedure parameters.
      * Returns { typeName, isClass, isReference } or null if not found/unresolvable.
      * isReference is true when the variable was declared as &TypeName (Clarion reference).
+     *
+     * Pass `scopeLine` when the caller has position context — this enables resolving
+     * parameters of the enclosing procedure (e.g. `*WindowInfo Info`), which are not
+     * column-0 tokens and are therefore invisible to `findVariableTokenCrossFile`.
      */
     async resolveVariableType(
         varName: string,
         tokens: Token[],
-        document: TextDocument
+        document: TextDocument,
+        scopeLine?: number
     ): Promise<{ typeName: string; isClass: boolean; isReference: boolean } | null> {
         const found = await this.findVariableTokenCrossFile(varName, tokens, document);
-        if (!found) return null;
+        if (!found) {
+            if (scopeLine !== undefined) {
+                return this.resolveParameterType(varName, document, scopeLine);
+            }
+            return null;
+        }
         return this.extractTypeFromToken(found.token, found.tokens);
+    }
+
+    /**
+     * Resolves the type of `varName` as a procedure parameter by parsing the
+     * PROCEDURE(...) header of the scope that encloses `scopeLine`.
+     * Handles `*TypeName` (pass-by-address GROUP/QUEUE) and `&TypeName` (reference)
+     * prefixes, stripping them to obtain the bare type name.
+     */
+    private resolveParameterType(
+        varName: string,
+        document: TextDocument,
+        scopeLine: number
+    ): { typeName: string; isClass: boolean; isReference: boolean } | null {
+        const structure = this.tokenCache.getStructure(document);
+        const scopeToken = TokenHelper.getInnermostScopeAtLine(structure, scopeLine);
+        if (!scopeToken) return null;
+
+        const lines = document.getText().split('\n');
+        const procedureLine = lines[scopeToken.line];
+        if (!procedureLine) return null;
+
+        const sigMatch = procedureLine.match(/PROCEDURE\s*\((.*?)\)/i);
+        if (!sigMatch || !sigMatch[1]) return null;
+
+        const wordLower = varName.toLowerCase();
+        for (const param of sigMatch[1].split(',')) {
+            const trimmed = param.trim().replace(/^<(.*)>$/, '$1').trim();
+            // [*&]? TYPE NAME [= default]  or  <*TYPE NAME>
+            const m = trimmed.match(/^([*&]?\s*[\w:]+)\s+([A-Za-z_][\w:]*)(?:\s*=.*)?$/i);
+            if (!m) continue;
+
+            const rawType = m[1].trim();
+            const paramName = m[2];
+            const pLower = paramName.toLowerCase();
+            if (pLower !== wordLower && !pLower.endsWith(':' + wordLower)) continue;
+
+            const isRef = rawType.startsWith('&');
+            const typeName = rawType.replace(/^[*&]\s*/, '').trim();
+            if (!typeName) continue;
+
+            logger.info(`resolveParameterType: "${varName}" → type "${typeName}" (isRef=${isRef})`);
+            return { typeName, isClass: false, isReference: isRef };
+        }
+        return null;
     }
 
     /**

--- a/server/src/test/HoverProvider.GroupTypeParam.test.ts
+++ b/server/src/test/HoverProvider.GroupTypeParam.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for issue #215 — hover on structure fields accessed through GROUP,TYPE parameters
+ * (e.g. `Info.Maximized` where `Info` is declared `*WindowInfo` in the PROCEDURE header).
+ */
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+suite('HoverProvider — GROUP,TYPE parameter field access (#215)', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        return typeof hover?.contents === 'string'
+            ? hover.contents
+            : hover?.contents && 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('provides hover for field accessed on *GROUP,TYPE parameter (Info.Maximized)', async () => {
+        const code = [
+            'WindowInfo         GROUP,TYPE',
+            'X                    SIGNED',
+            'Y                    SIGNED',
+            'Maximized            BYTE',
+            'Minimized            BYTE',
+            '  END',
+            '',
+            'TestProc PROCEDURE(STRING ProcName, *WindowInfo Info)',
+            'CODE',
+            '  IF Info.Maximized',
+            '    RETURN',
+            '  END',
+        ].join('\n');
+
+        const doc = TextDocument.create('test://group-param-#215.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        // Line 9: "  IF Info.Maximized" — "Maximized" starts at char 10
+        const hover = await provider.provideHover(doc, Position.create(9, 12));
+        assert.ok(hover !== null && hover !== undefined, 'Should provide hover for "Maximized" field accessed via *GROUP,TYPE parameter');
+        const text = hoverText(hover);
+        assert.ok(text.toLowerCase().includes('maximized'), `Hover should mention "Maximized", got: ${text}`);
+    });
+
+    test('provides hover for field accessed on *GROUP,TYPE parameter (pass-by-value variant)', async () => {
+        const code = [
+            'MyGroup            GROUP,TYPE',
+            'Count                SHORT',
+            'Total                LONG',
+            '  END',
+            '',
+            'CalcProc PROCEDURE(*MyGroup G)',
+            'CODE',
+            '  G.Count += 1',
+        ].join('\n');
+
+        const doc = TextDocument.create('test://group-param2-#215.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        // Line 7: "  G.Count += 1" — "Count" starts at char 4
+        const hover = await provider.provideHover(doc, Position.create(7, 5));
+        assert.ok(hover !== null && hover !== undefined, 'Should provide hover for field "Count" accessed via *GROUP,TYPE parameter');
+        const text = hoverText(hover);
+        assert.ok(text.toLowerCase().includes('count'), `Hover should mention "Count", got: ${text}`);
+    });
+});


### PR DESCRIPTION
Fixes #215

Root cause: parameters like `*WindowInfo Info` were invisible to resolveVariableType (only searched column-0 tokens). Also implements the long-standing TODO in DefinitionProvider.findVariableType.

Changes: MemberLocatorService gets resolveParameterType() fallback; StructureFieldResolver gets findFieldInTokens() for same-file types; DefinitionProvider implements parameter type TODO.

1795 passing, 0 regressions.