### PR TITLE
fix: correct GROUP,TYPE parameter hover - isClass:true + scope-aware lookup (#215)

### DIFF
--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -117,7 +117,7 @@ export class MemberLocatorService {
         document: TextDocument,
         scopeLine?: number
     ): Promise<{ typeName: string; isClass: boolean; isReference: boolean } | null> {
-        const found = await this.findVariableTokenCrossFile(varName, tokens, document);
+        const found = await this.findVariableTokenCrossFile(varName, tokens, document, scopeLine);
         if (!found) {
             if (scopeLine !== undefined) {
                 return this.resolveParameterType(varName, document, scopeLine);
@@ -166,7 +166,9 @@ export class MemberLocatorService {
             if (!typeName) continue;
 
             logger.info(`resolveParameterType: "${varName}" → type "${typeName}" (isRef=${isRef})`);
-            return { typeName, isClass: false, isReference: isRef };
+            // Treat the resolved parameter type as a user-defined type (isClass: true) so callers
+            // route through findMemberInClass which has SDI support for GROUP/QUEUE/CLASS types.
+            return { typeName, isClass: true, isReference: isRef };
         }
         return null;
     }
@@ -301,10 +303,36 @@ export class MemberLocatorService {
     private async findVariableTokenCrossFile(
         varName: string,
         tokens: Token[],
-        document: TextDocument
+        document: TextDocument,
+        scopeLine?: number
     ): Promise<{ token: Token; tokens: Token[]; doc: TextDocument } | null> {
+        const varNameLower = varName.toLowerCase();
+
+        // When scopeLine is known, build a set of "other procedure" line ranges to skip.
+        // This prevents picking up a same-named local variable from a sibling procedure
+        // (e.g. `Info` at line 932 inside INIClass.Update when we're inside INIClass.UpdateWindowInfo).
+        let excludedRanges: Array<{ start: number; end: number }> = [];
+        if (scopeLine !== undefined) {
+            const structure = this.tokenCache.getStructure(document);
+            const currentScope = TokenHelper.getInnermostScopeAtLine(structure, scopeLine);
+            const currentScopeLine = currentScope?.line;
+            excludedRanges = tokens
+                .filter(t =>
+                    TokenHelper.isProcedureOrFunction(t) &&
+                    t.finishesAt !== undefined &&
+                    t.line !== currentScopeLine
+                )
+                .map(t => ({ start: t.line, end: t.finishesAt! }));
+        }
+        const isExcluded = (line: number): boolean =>
+            excludedRanges.some(r => line > r.start && line <= r.end);
+
         // 1. Current file (column 0 label or structure)
-        const local = tokens.find(t => t.start === 0 && this.tokenMatchesName(t, varName.toLowerCase()));
+        const local = tokens.find(t =>
+            t.start === 0 &&
+            this.tokenMatchesName(t, varNameLower) &&
+            !isExcluded(t.line)
+        );
         if (local) return { token: local, tokens, doc: document };
 
         const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');

--- a/server/src/test/HoverProvider.GroupTypeParam.test.ts
+++ b/server/src/test/HoverProvider.GroupTypeParam.test.ts
@@ -75,4 +75,38 @@ suite('HoverProvider — GROUP,TYPE parameter field access (#215)', () => {
         const text = hoverText(hover);
         assert.ok(text.toLowerCase().includes('count'), `Hover should mention "Count", got: ${text}`);
     });
+
+    test('does not bleed into sibling procedure when same-named local var exists (abutil.clw pattern)', async () => {
+        // Mirrors the abutil.clw case: TestClass.Update has `Info LIKE(WindowInfo),AUTO` as a local
+        // variable, while TestClass.UpdateWindowInfo has `*WindowInfo Info` as a parameter.
+        // Hovering on Info.Maximized inside UpdateWindowInfo must NOT pick up the sibling's local.
+        const code = [
+            'WindowInfo         GROUP,TYPE',
+            'Maximized            BYTE',
+            'Minimized            BYTE',
+            '  END',
+            '',
+            'TestClass.Update PROCEDURE()',
+            'Info               LIKE(WindowInfo),AUTO',
+            '  CODE',
+            '  Info.Maximized = 1',
+            '',
+            'TestClass.UpdateWindowInfo PROCEDURE(*WindowInfo Info)',
+            '  CODE',
+            '  IF Info.Maximized',
+            '    RETURN',
+            '  END',
+        ].join('\n');
+
+        const doc = TextDocument.create('test://sibling-scope-#215.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        // Line 12: "  IF Info.Maximized" — cursor on "Maximized"
+        // "  IF Info.Maximized" → 0=sp,1=sp,2=I,3=F,4=sp,5=I,6=n,7=f,8=o,9=.,10=M...
+        const hover = await provider.provideHover(doc, Position.create(12, 12));
+        assert.ok(hover !== null && hover !== undefined,
+            'Should provide hover for "Maximized" even when same-named local exists in sibling procedure');
+        const text = hoverText(hover);
+        assert.ok(text.toLowerCase().includes('maximized'), `Hover should mention "Maximized", got: ${text}`);
+    });
 });


### PR DESCRIPTION
Follow-up to PR #216 (issue #215). Two additional fixes:

1. **isClass:false bypass**: resolveParameterType was returning isClass:false, skipping findMemberInClass (SDI-backed). Changed to isClass:true so GROUP/QUEUE types found via *Param syntax route through the SDI.

2. **Wrong scope for same-named variables** (abutil.clw bug): findVariableTokenCrossFile had no scope filtering and picked up Info at line 932 (local of INIClass.Update) when looking up Info for INIClass.UpdateWindowInfo. Added excluded-range filtering when scopeLine is provided.

1796 passing.