### PR TITLE
fix: prefer declaration scope for parameter hover on PROCEDURE line

### DIFF
--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -179,6 +179,18 @@ export class HoverProvider {
 
             logger.info(`Current scope: ${currentScope.value}`);
 
+            // If cursor is on a PROCEDURE/FUNCTION declaration line, prioritize that exact
+            // declaration scope for parameter hover before falling back to currentScope.
+            // This prevents sibling-procedure locals with the same name from winning.
+            const declarationScope = tokens.find(t =>
+                TokenHelper.isProcedureOrFunction(t) &&
+                t.line === position.line
+            );
+            if (declarationScope) {
+                const declarationParamHover = this.variableResolver.findParameterHover(word, document, declarationScope);
+                if (declarationParamHover) return declarationParamHover;
+            }
+
             // First, try searching with the full word (handles labels with colons like BRW1::View:Browse)
             logger.info(`Checking if ${word} (full word) is a parameter...`);
             let parameterHover = this.variableResolver.findParameterHover(word, document, currentScope);

--- a/server/src/test/HoverProvider.Parameters.test.ts
+++ b/server/src/test/HoverProvider.Parameters.test.ts
@@ -124,6 +124,28 @@ suite('HoverProvider – Parameters and Local Variables', () => {
             const text = getHoverText(hover);
             assert.ok(text.includes('pCount') || text.includes('LONG'), `Got: ${text}`);
         });
+
+        test('hover on parameter name in PROCEDURE declaration prefers declaration scope', async () => {
+            const codeWithSibling = [
+                'FirstProc PROCEDURE()',
+                'Info      LONG',
+                '  CODE',
+                '  RETURN',
+                '',
+                'SecondProc PROCEDURE(STRING Name, *WindowInfo Info)',
+                '  CODE',
+                '  RETURN',
+            ].join('\n');
+
+            const doc = TextDocument.create('test://hover-params-decl.clw', 'clarion', 1, codeWithSibling);
+            // Line 5: "SecondProc PROCEDURE(STRING Name, *WindowInfo Info)"
+            // Hover on "Info" parameter in the declaration (not usage in CODE)
+            const position = Position.create(5, 47);
+            const hover = await provider.provideHover(doc, position);
+            assert.ok(hover, 'Should provide hover for parameter name in declaration');
+            const text = getHoverText(hover);
+            assert.ok(text.includes('WindowInfo') || text.includes('Info'), `Got: ${text}`);
+        });
     });
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Follow-up fix for parameter hover scoping.

When hovering a parameter name directly on a PROCEDURE/FUNCTION declaration line, resolution now checks that exact declaration scope first, preventing sibling-procedure locals with the same name from being selected.

Includes regression test in HoverProvider.Parameters.test.ts.

1797 passing.