### PR TITLE
fix: resolve Info.Maximized in expression contexts and MEMBER-parent types

### DIFF
--- a/server/src/providers/DefinitionProvider.ts
+++ b/server/src/providers/DefinitionProvider.ts
@@ -133,6 +133,8 @@ export class DefinitionProvider {
                 const beforeDot = ChainedPropertyResolver.extractChain(rawBeforeDot);
                 const afterDot = line.substring(dotBeforeIndex + 1).trim();
                 const methodMatch = afterDot.match(/^(\w+)/);
+                const isPureChain = /^[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/i.test(beforeDot.trim());
+                const isSelfParentChain = isPureChain && /^\s*(self|parent)\b/i.test(beforeDot);
                 
                 // Extract just the method name from word if it includes the prefix (e.g., "self.SaveFile" -> "SaveFile")
                 let methodName = word;
@@ -204,7 +206,7 @@ export class DefinitionProvider {
                     }
 
                     // Chained access: SELF.Order.MainKey or PARENT.Foo.Bar
-                    if (/^\s*(self|parent)\b/i.test(beforeDot) && beforeDot.includes('.')) {
+                    if (isSelfParentChain && beforeDot.includes('.')) {
                         // #131 — arg-classification overlay for chained calls like
                         // SELF.inner.SetValue(args). Resolve the chain to the class that
                         // owns the final member, then pick the matching overload by argument
@@ -233,7 +235,7 @@ export class DefinitionProvider {
                     }
 
                     // SELF.property or PARENT.property (no parentheses) — find the class member declaration
-                    if (!hasParentheses && /^\s*(self|parent)\b/i.test(beforeDot)) {
+                    if (!hasParentheses && isSelfParentChain) {
                         const isSelf = /\bself$/i.test(beforeDot);
                         logger.info(`F12 on ${isSelf ? 'SELF' : 'PARENT'} property: ${methodName}`);
                         const memberInfo = isSelf
@@ -246,9 +248,9 @@ export class DefinitionProvider {
                     }
 
                     // Typed variable member: st.GetValue() where st is declared as "st StringTheory"
-                    if (!/^\s*(self|parent)\b/i.test(beforeDot)) {
+                    if (!isSelfParentChain) {
                         // Multi-segment variable chain: variable.property.method
-                        if (beforeDot.includes('.')) {
+                        if (isPureChain && beforeDot.includes('.')) {
                             // #131 — arg-classification overlay for typed-var chained calls
                             // like outer.inner.SetValue(args). Same gap and same fix as the
                             // SELF/PARENT chained branch above: resolve the chain's final

--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -160,6 +160,17 @@ export class HoverProvider {
             if (fieldHover) { return fieldHover; }
 
             // currentScope already destructured above from context
+            // If cursor is on a PROCEDURE/FUNCTION declaration line, prioritize that exact
+            // declaration scope for parameter hover (works even when currentScope is null
+            // on declaration lines before CODE).
+            const declarationScope = tokens.find(t =>
+                TokenHelper.isProcedureOrFunction(t) &&
+                t.line === position.line
+            );
+            if (declarationScope) {
+                const declarationParamHover = this.variableResolver.findParameterHover(word, document, declarationScope);
+                if (declarationParamHover) return declarationParamHover;
+            }
 
             if (!currentScope) {
                 // Check for global variable (in current file or MEMBER parent)
@@ -178,18 +189,6 @@ export class HoverProvider {
             }
 
             logger.info(`Current scope: ${currentScope.value}`);
-
-            // If cursor is on a PROCEDURE/FUNCTION declaration line, prioritize that exact
-            // declaration scope for parameter hover before falling back to currentScope.
-            // This prevents sibling-procedure locals with the same name from winning.
-            const declarationScope = tokens.find(t =>
-                TokenHelper.isProcedureOrFunction(t) &&
-                t.line === position.line
-            );
-            if (declarationScope) {
-                const declarationParamHover = this.variableResolver.findParameterHover(word, document, declarationScope);
-                if (declarationParamHover) return declarationParamHover;
-            }
 
             // First, try searching with the full word (handles labels with colons like BRW1::View:Browse)
             logger.info(`Checking if ${word} (full word) is a parameter...`);

--- a/server/src/providers/hover/StructureFieldResolver.ts
+++ b/server/src/providers/hover/StructureFieldResolver.ts
@@ -126,6 +126,8 @@ export class StructureFieldResolver {
         // Handles: "self", "address(self", "x = self", etc.
         const isSelfMember = /\bself$/i.test(beforeDot);
         const isParentMember = /\bparent$/i.test(beforeDot);
+        const isPureChain = /^[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/i.test(beforeDot.trim());
+        const isSelfOrParentChain = isPureChain && /^\s*(self|parent)\b/i.test(beforeDot);
         logger.info(`resolveFieldAccess: Checking if beforeDot ends with 'self': "${beforeDot}" matches \\bself$ = ${isSelfMember}`);
         
         // This is a member access (hovering over the field after the dot)
@@ -147,7 +149,7 @@ export class StructureFieldResolver {
                 logger.info(`PARENT method call detected with ${paramCount} parameters`);
             }
             return await this.methodResolver.resolveParentMethodCall(fieldName, document, position, line, paramCount);
-        } else if (/^\s*(self|parent)\b/i.test(beforeDot) && beforeDot.includes('.')) {
+        } else if (isSelfOrParentChain && beforeDot.includes('.')) {
             // Chained access: SELF.Order.MainKey or PARENT.Foo.Bar
             let paramCount: number | undefined;
             if (hasParentheses) {
@@ -157,7 +159,7 @@ export class StructureFieldResolver {
             if (chainedInfo) {
                 return this.methodResolver.resolveChainedMethodCall(fieldName, chainedInfo, document, paramCount, position);
             }
-        } else if (beforeDot.includes('.')) {
+        } else if (isPureChain && beforeDot.includes('.')) {
             // Multi-segment variable chain: variable.property.method (e.g., thisStartup.Settings.PutGlobalSetting)
             let paramCount: number | undefined;
             if (hasParentheses) {

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -186,8 +186,11 @@ export class MemberLocatorService {
         const docPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
         const tokens = this.tokenCache.getTokensByUri(document.uri) ?? this.tokenCache.getTokens(document);
 
-        // 0. Current document tokens (class defined in the same file)
-        const fromCurrentDoc = await this.scanBodyForMember(docPath, className, memberName, paramCount, 'CLASS');
+        // 0. Current document tokens (keep CLASS path behavior; add GROUP/QUEUE fallback)
+        const fromCurrentDoc =
+            await this.scanBodyForMember(docPath, className, memberName, paramCount, 'CLASS') ??
+            await this.scanBodyForMember(docPath, className, memberName, paramCount, 'GROUP') ??
+            await this.scanBodyForMember(docPath, className, memberName, paramCount, 'QUEUE');
         if (fromCurrentDoc) return fromCurrentDoc;
 
         // 1. Walk INCLUDE chain reachable from this document
@@ -196,6 +199,32 @@ export class MemberLocatorService {
             new Set([docPath.toLowerCase()])
         );
         if (fromInclude) return fromInclude;
+
+        // 1.5 MEMBER parent file + its INCLUDE chain (common libsrc .clw layout)
+        const memberToken = tokens.find(t => t.value?.toUpperCase() === 'MEMBER' && t.line < 5 && t.referencedFile);
+        if (memberToken?.referencedFile) {
+            const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath));
+            if (parentPath) {
+                const parentData = await this.loadDocument(parentPath);
+                if (parentData) {
+                    const fromMemberParent =
+                        this.findMemberFromTokens(parentData.tokens, parentData.doc, parentPath, className, memberName, paramCount, 'CLASS') ??
+                        this.findMemberFromTokens(parentData.tokens, parentData.doc, parentPath, className, memberName, paramCount, 'GROUP') ??
+                        this.findMemberFromTokens(parentData.tokens, parentData.doc, parentPath, className, memberName, paramCount, 'QUEUE');
+                    if (fromMemberParent) return fromMemberParent;
+
+                    const fromMemberIncludes = await this.findInIncludeChain(
+                        className,
+                        memberName,
+                        parentData.tokens,
+                        path.dirname(parentPath),
+                        paramCount,
+                        new Set([docPath.toLowerCase(), parentPath.toLowerCase()])
+                    );
+                    if (fromMemberIncludes) return fromMemberIncludes;
+                }
+            }
+        }
 
         // 2. StructureDeclarationIndexer (covers libsrc / accessory paths) + parent chain
         await this.ensureIndexBuilt();
@@ -947,17 +976,33 @@ export class MemberLocatorService {
             // 🚀 Load once — use tokens for member lookup, then recurse into nested INCLUDEs
             const data = await this.loadDocument(resolvedPath);
             if (data) {
-                const result = this.findMemberFromTokens(data.tokens, data.doc, resolvedPath, className, memberName, paramCount);
+                const result =
+                    this.findMemberFromTokens(data.tokens, data.doc, resolvedPath, className, memberName, paramCount, 'CLASS') ??
+                    this.findMemberFromTokens(data.tokens, data.doc, resolvedPath, className, memberName, paramCount, 'GROUP') ??
+                    this.findMemberFromTokens(data.tokens, data.doc, resolvedPath, className, memberName, paramCount, 'QUEUE');
                 if (result) return result;
                 // Fallback to disk scan for edge cases — prefer live editor text if file is open
                 const diskUri = `file:///${resolvedPath.replace(/\\/g, '/')}`;
                 const liveContent = this.tokenCache.getDocumentText(diskUri) ?? undefined;
-                const diskResult = scanClassBodyForMember(
-                    resolvedPath, className, memberName, paramCount, 'CLASS',
-                    (line) => this.countParamsInDecl(line),
-                    (candidates: OverloadCandidate[], pc) => selectBestMemberOverload(candidates, pc),
-                    liveContent
-                );
+                const diskResult =
+                    scanClassBodyForMember(
+                        resolvedPath, className, memberName, paramCount, 'CLASS',
+                        (line) => this.countParamsInDecl(line),
+                        (candidates: OverloadCandidate[], pc) => selectBestMemberOverload(candidates, pc),
+                        liveContent
+                    ) ??
+                    scanClassBodyForMember(
+                        resolvedPath, className, memberName, paramCount, 'GROUP',
+                        (line) => this.countParamsInDecl(line),
+                        (candidates: OverloadCandidate[], pc) => selectBestMemberOverload(candidates, pc),
+                        liveContent
+                    ) ??
+                    scanClassBodyForMember(
+                        resolvedPath, className, memberName, paramCount, 'QUEUE',
+                        (line) => this.countParamsInDecl(line),
+                        (candidates: OverloadCandidate[], pc) => selectBestMemberOverload(candidates, pc),
+                        liveContent
+                    );
                 if (diskResult) return diskResult;
 
                 const nested = await this.findInIncludeChain(


### PR DESCRIPTION
Fixes the real-world abutil.clw repro.

- Hover/F12 on Info.Maximized inside SELF.Update(... CHOOSE (NOT Info.Maximized ...)) now resolves correctly
- Hover on parameter Info in PROCEDURE(... *WindowInfo Info) no longer bleeds to sibling local Info

Key changes:
1. Dot-access parsing in Hover/Definition now distinguishes pure dot chains from expression prefixes.
2. Declaration-line parameter hover runs before currentScope-null early return.
3. MemberLocatorService findMemberInClass now searches MEMBER parent + includes and scans CLASS/GROUP/QUEUE in include chain.

Validated directly against C:\clarion\clarion11.1\libsrc\win\abutil.clw:
- line 963 Maximized hover and F12 -> ABUTIL.INC field
- line 956 parameter Info hover -> parameter info (not line 932 local).