### PR TITLE
fix: remove TYPE attribute false positives in dot-access and param names

### DIFF
--- a/server/src/providers/diagnostics/AttributeDiagnostics.ts
+++ b/server/src/providers/diagnostics/AttributeDiagnostics.ts
@@ -30,6 +30,7 @@ const VALIDATABLE_CONTROLS = new Set([
  */
 export function validateAttributeApplicability(tokens: Token[], document: TextDocument): Diagnostic[] {
     const diagnostics: Diagnostic[] = [];
+    const lines = document.getText().split(/\r?\n/);
 
     // Build DocumentStructure so we can call getControlContextAt per token
     const structure = new DocumentStructure(tokens);
@@ -103,6 +104,30 @@ export function validateAttributeApplicability(tokens: Token[], document: TextDo
              tokens[i + 2].type === TokenType.FieldEquateLabel ||
              tokens[i + 2].type === TokenType.WindowElement)) {
             continue;
+        }
+
+        // Dot-suffix guard: skip Attribute tokens used as member names in dot access,
+        // e.g. SELF.Sectors.Type or Obj.Item.Type. In these contexts TYPE/ITEM/etc.
+        // are identifiers, not Clarion attribute applications.
+        const lineText = lines[token.line] ?? '';
+        if (token.start > 0 && lineText[token.start - 1] === '.') {
+            continue;
+        }
+
+        // Procedure/function parameter guard: skip Attribute tokens inside the
+        // signature parameter list, e.g. PROCEDURE(STRING Item, STRING Type).
+        // TYPE/ITEM keywords in parameter names are identifiers here, not attributes.
+        const upperLine = lineText.toUpperCase();
+        const procIdx = upperLine.indexOf('PROCEDURE');
+        const funcIdx = upperLine.indexOf('FUNCTION');
+        const sigIdx = procIdx >= 0 ? procIdx : funcIdx;
+        if (sigIdx >= 0) {
+            const openParen = lineText.indexOf('(', sigIdx);
+            const closeParen = openParen >= 0 ? lineText.indexOf(')', openParen + 1) : -1;
+            if (openParen >= 0 && closeParen > openParen &&
+                token.start > openParen && token.start < closeParen) {
+                continue;
+            }
         }
 
         const attrName = token.value.toUpperCase();

--- a/server/src/test/AttributeCompletionsAndDiagnostics.test.ts
+++ b/server/src/test/AttributeCompletionsAndDiagnostics.test.ts
@@ -764,4 +764,32 @@ suite('validateAttributeApplicability', () => {
                 'misapplied CREATE on a |-continuation line of BUTTON must STILL fire (continuation fallback must survive)');
         });
     });
+
+    suite('#219 — TYPE in member access and parameter names is not an attribute', () => {
+        test('no diagnostic for dot-access member suffix ".Type" (abutil-style)', () => {
+            const doc = makeDoc([
+                'MyProc PROCEDURE',
+                '  CODE',
+                "  SELF.FetchQueue('X','Y',SELF.Sectors,SELF.Sectors.Family,SELF.Sectors.Item,SELF.Sectors.Type)",
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.strictEqual(attrDiags.length, 0,
+                `Expected no invalid-attribute-context for SELF.Sectors.Type member access; got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+        });
+
+        test('no diagnostic for parameter name "Type" in PROCEDURE signature', () => {
+            const doc = makeDoc([
+                'GetSector PROCEDURE(STRING Family, STRING Item, STRING Type)',
+                '  CODE',
+                '  RETURN',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.strictEqual(attrDiags.length, 0,
+                `Expected no invalid-attribute-context for PROCEDURE parameter name "Type"; got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+        });
+    });
 });


### PR DESCRIPTION
Fixes false invalid-attribute-context diagnostics in butil.clw where Type is used as a member suffix (SELF.Sectors.Type) or as a PROCEDURE parameter name (STRING Type).

Changes:
- dot-suffix guard in AttributeDiagnostics (	oken.start - 1 === '.')
- PROCEDURE/FUNCTION signature-parameter guard (skip tokens inside ( ... ))
- Added regression tests in AttributeCompletionsAndDiagnostics.test.ts (#219)

Verified directly on C:\clarion\clarion11.1\libsrc\win\abutil.clw: no invalid-attribute-context diagnostics at lines 504/514/520/529/562/576/584.