### PR TITLE
Add PROGRAM global prefix completion in MEMBER files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Clarion Extension are documented here.
 
 ### [0.9.9] - Unreleased
 
+**New Features**
+
+- ✨ **Cross-file global-data completion parity for MEMBER files** (#224): word completion now includes PROGRAM-file global symbols while editing MEMBER modules, including both direct globals (e.g. `GLO:*`) and `PRE(...)`-qualified global structure fields (e.g. `TGLO:FieldName`); prefixed completions now insert only the suffix after an already-typed qualifier, so accepting `GLO:Var` after typing `GLO:` no longer duplicates the prefix.
+
 **Bug Fixes**
 
 - 🐛 **F12 on `DO RoutineName` now resolves to the matching `ROUTINE` label in the current procedure scope** (#211): DefinitionProvider now uses `DocumentStructure.findRoutines()` plus parent-scope matching, so routine references in `DO ...` statements navigate correctly and do not bleed into unrelated routines.
@@ -16,6 +20,10 @@ All notable changes to the Clarion Extension are documented here.
 - 🐛 **Parameter hover on declaration lines now prefers the declaration scope** (#217): hovering `Info` directly in `PROCEDURE(... *WindowInfo Info)` no longer resolves to a same-named local from a sibling procedure.
 - 🐛 **Real-world `abutil.clw` dot-access fixes (expression-safe chain detection + MEMBER-parent type resolution)** (#219): typed member access inside expressions like `CHOOSE(NOT Info.Maximized, ...)` now resolves correctly for both hover and F12; lookup now properly reaches MEMBER parent/include layouts and GROUP/QUEUE type members.
 - 🐛 **Removed false `invalid-attribute-context` diagnostics for `Type` identifier usage** (#220): diagnostics now skip attribute validation when keyword-like tokens are used as dot-member suffixes (e.g. `SELF.Sectors.Type`) or as parameter names inside `PROCEDURE(...)` / `FUNCTION(...)` signatures.
+
+**Performance**
+
+- ⚡ **#187 high-priority search-loop cooperation + cancellation wiring landed**: `WorkspaceSymbolProvider`, `ImplementationProvider`/`ClassMemberResolver` cross-file implementation scans, and `ReferencesProvider` now share cooperative checkpoints and honor LSP cancellation tokens, so superseded Ctrl+T/Ctrl+F12/FAR requests bail early instead of running full solution scans to completion.
 
 ---
 

--- a/server/src/providers/WordCompletionProvider.ts
+++ b/server/src/providers/WordCompletionProvider.ts
@@ -2,6 +2,7 @@ import { CompletionItem, CompletionItemKind } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position } from 'vscode-languageserver';
 import * as fs from 'fs';
+import * as path from 'path';
 import { TokenCache } from '../TokenCache';
 import { FileRelationshipGraph } from '../FileRelationshipGraph';
 import { ScopeAnalyzer } from '../utils/ScopeAnalyzer';
@@ -109,6 +110,7 @@ export class WordCompletionProvider {
             // C. Variables / Labels
             // ----------------------------------------------------------------
             this.collectVariables(tokens, scope, procDeclLines, add);
+            this.collectProgramGlobalDataSymbols(tokens, document, add);
 
             // ----------------------------------------------------------------
             // D. Parameters from PROCEDURE(...) signature
@@ -152,7 +154,23 @@ export class WordCompletionProvider {
             // ----------------------------------------------------------------
             if (!partial) return Array.from(seen.values());
             const up = partial.toUpperCase();
-            return Array.from(seen.values()).filter(c => (c.label as string).toUpperCase().startsWith(up));
+            const filtered = Array.from(seen.values()).filter(c => (c.label as string).toUpperCase().startsWith(up));
+
+            // If user already typed a prefix-style qualifier (e.g. "GLO:" or "TGLO:"),
+            // only insert the suffix so selection doesn't duplicate the qualifier.
+            if (partial.includes(':')) {
+                return filtered.map(item => {
+                    const label = String(item.label);
+                    if (label.length > partial.length && label.toUpperCase().startsWith(up)) {
+                        return {
+                            ...item,
+                            insertText: label.substring(partial.length),
+                        };
+                    }
+                    return item;
+                });
+            }
+            return filtered;
 
         } catch (err) {
             logger.error(`WordCompletionProvider error: ${err instanceof Error ? err.message : String(err)}`);
@@ -312,6 +330,7 @@ export class WordCompletionProvider {
             }
             // And file-level globals/equates
             this.collectGlobalLabels(tokens, procDeclLines, isLabel, add);
+            this.collectGlobalPrefixedFields(tokens, add);
             return;
         }
 
@@ -338,11 +357,13 @@ export class WordCompletionProvider {
 
             // Also collect file-level labels (global equates, constants declared before first proc)
             this.collectGlobalLabels(tokens, procDeclLines, isLabel, add);
+            this.collectGlobalPrefixedFields(tokens, add);
             return;
         }
 
         // Global scope: collect Label tokens before the first procedure
         this.collectGlobalLabels(tokens, procDeclLines, isLabel, add);
+        this.collectGlobalPrefixedFields(tokens, add);
     }
 
     /** Collect Label tokens before the first procedure (file-level equates, constants, globals). */
@@ -362,6 +383,66 @@ export class WordCompletionProvider {
                 add(t.value, CompletionItemKind.Variable);
             }
         }
+    }
+
+    /** Collect PRE-qualified structure fields in global scope as Prefix:Field labels. */
+    private collectGlobalPrefixedFields(
+        tokens: Token[],
+        add: (label: string, kind: CompletionItemKind, detail?: string) => void
+    ): void {
+        const firstProcLine = tokens.find(t =>
+            TokenHelper.isProcedureOrFunction(t) &&
+            (t.subType === TokenType.GlobalProcedure || t.subType === TokenType.MethodImplementation)
+        )?.line ?? Number.MAX_SAFE_INTEGER;
+
+        for (const t of tokens) {
+            if (
+                t.isStructureField &&
+                !!t.structurePrefix &&
+                t.line < firstProcLine
+            ) {
+                add(`${t.structurePrefix}:${t.value}`, CompletionItemKind.Variable, 'prefixed field');
+            }
+        }
+    }
+
+    /** Add PROGRAM-file global labels + PRE-qualified fields for MEMBER-file completion parity. */
+    private collectProgramGlobalDataSymbols(
+        tokens: Token[],
+        document: TextDocument,
+        add: (label: string, kind: CompletionItemKind, detail?: string) => void
+    ): void {
+        const graph = FileRelationshipGraph.getInstance();
+        const currentPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
+        const programPathRaw = graph.isBuilt
+            ? graph.getProgramFile(currentPath)
+            : this.getProgramFileFromTokens(tokens);
+        const programPath = programPathRaw
+            ? (path.isAbsolute(programPathRaw) ? programPathRaw : path.join(path.dirname(currentPath), programPathRaw))
+            : undefined;
+
+        if (!programPath) return;
+
+        const result = this.getTokensForFile(programPath);
+        if (!result || result.tokens.length === 0) return;
+
+        const programTokens = result.tokens;
+        const procDeclLines = new Set<number>();
+        for (const t of programTokens) {
+            if (TokenHelper.isProcedureOrFunction(t) || t.type === TokenType.Routine) {
+                procDeclLines.add(t.line);
+            }
+        }
+
+        const isLabel = (t: Token) =>
+            (t.type === TokenType.Label || t.type === TokenType.Variable) &&
+            t.start === 0 &&
+            !t.isStructureField &&
+            (!t.parent || t.parent.type !== TokenType.Structure) &&
+            !procDeclLines.has(t.line);
+
+        this.collectGlobalLabels(programTokens, procDeclLines, isLabel, add);
+        this.collectGlobalPrefixedFields(programTokens, add);
     }
 
     /** Collect Label tokens in a procedure's data section (between PROCEDURE line and CODE). */

--- a/server/src/test/WordCompletionProvider.test.ts
+++ b/server/src/test/WordCompletionProvider.test.ts
@@ -311,6 +311,56 @@ suite('WordCompletionProvider', () => {
         });
     });
 
+    suite('Cross-file global data (PROGRAM -> MEMBER)', () => {
+        test('surfaces PROGRAM globals with prefix names in MEMBER file', async () => {
+            const programUri = 'file:///C:/temp/testingdirectsecureserver.clw';
+            const memberUri = 'file:///C:/temp/testingdirectsecureserver001.clw';
+
+            const programDoc = TextDocument.create(programUri, 'clarion', 1, [
+                'TestingDirectSecureServer PROGRAM',
+                'GLO:SessionId   STRING(20)',
+                'SrvData         GROUP,PRE(TGLO)',
+                'PageReceived    LONG',
+                'SocketCount     LONG',
+                '               END',
+                '',
+                'Main PROCEDURE()',
+                'CODE',
+                'END',
+            ].join('\n'));
+
+            const memberDoc = TextDocument.create(memberUri, 'clarion', 1, [
+                '  MEMBER(\'C:\\temp\\testingdirectsecureserver.clw\')',
+                '',
+                'Worker PROCEDURE()',
+                'CODE',
+                '  GLO:',
+                '  TGLO:',
+                'END',
+            ].join('\n'));
+
+            const cache = TokenCache.getInstance();
+            cache.getTokens(programDoc);
+            cache.getTokens(memberDoc);
+
+            const scopeAnalyzer = new ScopeAnalyzer(cache, SolutionManager.getInstance());
+            const provider = new WordCompletionProvider(cache, scopeAnalyzer);
+
+            const gloItems = await provider.provide(memberDoc, { line: 4, character: 6 }, 'GLO:');
+            const tgloItems = await provider.provide(memberDoc, { line: 5, character: 7 }, 'TGLO:');
+            const gloLabels = gloItems.map(i => i.label);
+            const tgloLabels = tgloItems.map(i => i.label);
+            const gloItem = gloItems.find(i => i.label === 'GLO:SessionId');
+            const tgloItem = tgloItems.find(i => i.label === 'TGLO:PageReceived');
+
+            assert.ok(gloLabels.includes('GLO:SessionId'), `Expected GLO:SessionId in: ${gloLabels.join(', ')}`);
+            assert.ok(tgloLabels.includes('TGLO:PageReceived'), `Expected TGLO:PageReceived in: ${tgloLabels.join(', ')}`);
+            assert.ok(tgloLabels.includes('TGLO:SocketCount'), `Expected TGLO:SocketCount in: ${tgloLabels.join(', ')}`);
+            assert.strictEqual(gloItem?.insertText, 'SessionId', `Expected suffix insertText for GLO:, got: ${gloItem?.insertText}`);
+            assert.strictEqual(tgloItem?.insertText, 'PageReceived', `Expected suffix insertText for TGLO:, got: ${tgloItem?.insertText}`);
+        });
+    });
+
     suite('No completions in comments or strings', () => {
         test('returns results regardless — comment guard is in CompletionProvider', async () => {
             // WordCompletionProvider itself has no comment guard (CompletionProvider handles it)


### PR DESCRIPTION
## Summary
- include PROGRAM-file globals in MEMBER-file word completion
- include PRE-qualified global structure fields (e.g. TGLO:Field)
- avoid prefix duplication by inserting only the suffix when a qualifier (e.g. GLO:) is already typed
- add regression coverage in WordCompletionProvider tests
- update 0.9.9 changelog

## Issue
Closes #224