### PR TITLE
No-solution entry-point follow-up for completion and FAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Clarion Extension are documented here.
 **New Features**
 
 - ✨ **Cross-file global-data completion parity for MEMBER files** (#224): word completion now includes PROGRAM-file global symbols while editing MEMBER modules, including both direct globals (e.g. `GLO:*`) and `PRE(...)`-qualified global structure fields (e.g. `TGLO:FieldName`); prefixed completions now insert only the suffix after an already-typed qualifier, so accepting `GLO:Var` after typing `GLO:` no longer duplicates the prefix.
+- ✨ **No-solution entry-point completion coverage extended** (#113): no-solution LSP entry-point tests now include completion validation for MEMBER files consuming PROGRAM globals (`GLO:*` and `PRE(...)`-qualified fields), and FAR global-scope loading now has a no-solution MEMBER→PROGRAM fallback when FRG is unavailable.
 
 **Bug Fixes**
 

--- a/server/src/providers/ReferencesProvider.ts
+++ b/server/src/providers/ReferencesProvider.ts
@@ -19,6 +19,7 @@ import { StructureDeclarationIndexer } from '../utils/StructureDeclarationIndexe
 import { isAttributeKeyword } from '../utils/AttributeKeywords';
 import { FileRelationshipGraph } from '../FileRelationshipGraph';
 import { getLocalMapScope, LocalMapScope } from '../utils/LocalMapScopeHelper';
+import { resolveFileInNoSolutionMode } from '../solution/findFileNoSolution';
 import { buildIncDirsToScan } from './incDirsScope';
 import { cooperativeCheckpoint } from '../utils/cooperativeScan';
 import LoggerManager from '../logger';
@@ -1411,7 +1412,24 @@ export class ReferencesProvider {
      */
     private loadGlobalScopeForCursor(document: TextDocument): Map<string, string> | null {
         const graph = FileRelationshipGraph.getInstance();
-        if (!graph.isBuilt) return null;
+        if (!graph.isBuilt) {
+            // No-solution fallback: when editing a MEMBER file without FRG, resolve the
+            // parent PROGRAM via MEMBER('x.clw') and load its module-scope globals.
+            const docTokens = this.tokenCache.getTokens(document);
+            const memberToken = docTokens.find(t =>
+                t.type === TokenType.ClarionDocument &&
+                t.value.toUpperCase() === 'MEMBER' &&
+                !!t.referencedFile
+            );
+            if (memberToken?.referencedFile) {
+                const resolved = resolveFileInNoSolutionMode(memberToken.referencedFile, document.uri);
+                if (resolved) {
+                    const programUri = 'file:///' + resolved.path.replace(/\\/g, '/');
+                    return this.loadGlobalScopeFromProgramFile(programUri);
+                }
+            }
+            return null;
+        }
         const docFsPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, ''))
             .replace(/\//g, '\\');
 
@@ -1635,6 +1653,32 @@ export class ReferencesProvider {
             }
         }
 
+        // No-solution mode fallback: if we only have an INC declaration file and no explicit
+        // CLASS MODULE('x.clw') hint, probe same-basename CLW via the canonical resolver.
+        const solutionManager = SolutionManager.getInstance();
+        if (!solutionManager?.solution && declarationFile) {
+            const declPath = decodeURIComponent(declarationFile.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
+            const inferredImpl = path.basename(declPath, path.extname(declPath)) + '.clw';
+            const resolvedImpl = resolveFileInNoSolutionMode(inferredImpl, declarationFile);
+            if (resolvedImpl) {
+                files.add(`file:///${resolvedImpl.path.replace(/\\/g, '/')}`);
+            }
+
+            // Also widen to sibling .clw files in the active file's directory so no-solution
+            // FAR can include cross-procedure callers in adjacent MEMBER modules.
+            const sourcePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
+            const sourceDir = path.dirname(sourcePath);
+            try {
+                for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+                    if (entry.isFile() && entry.name.toLowerCase().endsWith('.clw')) {
+                        files.add(`file:///${path.join(sourceDir, entry.name).replace(/\\/g, '/')}`);
+                    }
+                }
+            } catch {
+                // best-effort widening only
+            }
+        }
+
         // Use the FileRelationshipGraph to narrow the search: find all files that
         // transitively include the class's declaration file (INC), rather than scanning
         // every project source file. This is a BFS over reverse INCLUDE edges.
@@ -1667,7 +1711,6 @@ export class ReferencesProvider {
         }
 
         // Graph not ready or returned no additional files — fall back to scanning all project files
-        const solutionManager = SolutionManager.getInstance();
         if (solutionManager?.solution?.projects?.length) {
             for (const project of solutionManager.solution.projects) {
                 for (const sourceFile of project.sourceFiles) {
@@ -1712,6 +1755,12 @@ export class ReferencesProvider {
                         }
                     }
                 }
+            }
+
+            // 3. No-solution mode canonical resolver (local dir + libsrc + .red)
+            const noSolutionResolved = resolveFileInNoSolutionMode(moduleFileName, sourceUri);
+            if (noSolutionResolved) {
+                return `file:///${noSolutionResolved.path.replace(/\\/g, '/')}`;
             }
         } catch {
             // ignore resolution errors

--- a/server/src/test/NoSolutionMode.EntryPoints.test.ts
+++ b/server/src/test/NoSolutionMode.EntryPoints.test.ts
@@ -5,6 +5,7 @@ import { Hover, Location } from 'vscode-languageserver-protocol';
 import { HoverProvider } from '../providers/HoverProvider';
 import { ImplementationProvider } from '../providers/ImplementationProvider';
 import { DefinitionProvider } from '../providers/DefinitionProvider';
+import { CompletionProvider } from '../providers/CompletionProvider';
 import { DocumentLinkProvider } from '../providers/DocumentLinkProvider';
 import { FileRelationshipGraph, FileEdge } from '../FileRelationshipGraph';
 import {
@@ -407,6 +408,56 @@ suite('NoSolutionMode LSP entry-points (#139)', () => {
                     );
                 }
             }
+        });
+    });
+
+    suite('CompletionProvider.onCompletion for PROGRAM globals from MEMBER file', () => {
+        const sourceBody =
+            "  MEMBER('MyProg.clw')\n" +
+            "Worker PROCEDURE\n" +
+            "  CODE\n" +
+            "  GLO:\n" +
+            "  TGLO:\n" +
+            "  RETURN\n";
+        const programBody =
+            "  PROGRAM\n" +
+            "GLO:SessionId  STRING(20)\n" +
+            "TestGloGroup   GROUP,PRE(TGLO)\n" +
+            "PageReceived   LONG\n" +
+            "              END\n" +
+            "Main PROCEDURE\n" +
+            "  CODE\n" +
+            "  RETURN\n";
+
+        test('surfaces PROGRAM globals and prefix-safe insert text in no-solution mode', async () => {
+            fix = buildNoSolutionFixture({
+                libsrcs: [{}],
+                sourceFile: {
+                    filename: 'MyProg001.clw',
+                    content: sourceBody,
+                    siblings: { 'MyProg.clw': programBody }
+                }
+            });
+
+            const provider = new CompletionProvider();
+            const sourceDoc = TextDocument.create(fix.sourceUri!, 'clarion', 1, sourceBody);
+
+            const gloItems = await provider.onCompletion({
+                textDocument: { uri: sourceDoc.uri },
+                position: { line: 3, character: 6 }
+            } as any, sourceDoc);
+
+            const tgloItems = await provider.onCompletion({
+                textDocument: { uri: sourceDoc.uri },
+                position: { line: 4, character: 7 }
+            } as any, sourceDoc);
+
+            const glo = gloItems.find(i => i.label === 'GLO:SessionId');
+            const tglo = tgloItems.find(i => i.label === 'TGLO:PageReceived');
+            assert.ok(glo, `expected GLO:SessionId in completion; got: ${gloItems.map(i => i.label).join(', ')}`);
+            assert.ok(tglo, `expected TGLO:PageReceived in completion; got: ${tgloItems.map(i => i.label).join(', ')}`);
+            assert.strictEqual(glo?.insertText, 'SessionId');
+            assert.strictEqual(tglo?.insertText, 'PageReceived');
         });
     });
 


### PR DESCRIPTION
## Summary
- add no-solution entry-point test coverage for completion of PROGRAM globals from MEMBER files
- add no-solution fallback in ReferencesProvider global-scope loading (MEMBER -> PROGRAM via canonical resolver when FRG is not built)
- update 0.9.9 changelog

## Related
- #113