### PR TITLE
Stabilize cross-file diagnostics loading and unopened-file scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Clarion Extension are documented here.
 
 **Bug Fixes**
 
+- 🐛 **Cross-file return-value diagnostics now scan unopened project files deterministically** (#162): `validateDiscardedReturnValues` no longer depends on `TokenCache.getAllCachedUris()` alone; it now includes solution source files and uses shared cross-file loading (live buffer/cache/disk) so warnings do not silently depend on which files are open.
 - 🐛 **F12 on `DO RoutineName` now resolves to the matching `ROUTINE` label in the current procedure scope** (#211): DefinitionProvider now uses `DocumentStructure.findRoutines()` plus parent-scope matching, so routine references in `DO ...` statements navigate correctly and do not bleed into unrelated routines.
 - 🐛 **`CLIP(...)` hover now resolves as a built-in function in expression contexts** (#213): hover routing no longer misclassifies keyword collisions (e.g. `CLIP`) as control attributes outside control declarations.
 - 🐛 **Hover/F12 on structure fields via typed procedure parameters now works** (#215): cases like `Info.Maximized` where `Info` is declared `*WindowInfo` (GROUP/TYPE) now resolve correctly. Parameter type extraction was added for `PROCEDURE(...)` signatures and wired into typed dot-access paths.

--- a/server/src/providers/DiagnosticProvider.ts
+++ b/server/src/providers/DiagnosticProvider.ts
@@ -80,9 +80,10 @@ export class DiagnosticProvider {
     public static async validateDiscardedReturnValues(
         tokens: Token[],
         document: TextDocument,
-        memberLocator: MemberLocatorService
+        memberLocator: MemberLocatorService,
+        getOpenDocumentContent?: (absPath: string) => string | null
     ): Promise<Diagnostic[]> {
-        return _validateDiscardedReturnValues(tokens, document, memberLocator);
+        return _validateDiscardedReturnValues(tokens, document, memberLocator, getOpenDocumentContent);
     }
 
     /**

--- a/server/src/providers/diagnostics/MapDeclarationDiagnostics.ts
+++ b/server/src/providers/diagnostics/MapDeclarationDiagnostics.ts
@@ -378,47 +378,26 @@ export async function validateMissingImplementations(
             continue;
         }
 
-        // Get tokens for the implementation file.
-        // Priority order:
-        //   1. VS Code's live document buffer (always up-to-date, even for unsaved WorkspaceEdits)
-        //   2. TokenCache (may be stale if cache wasn't cleared after a non-structural edit)
-        //   3. Disk (fallback for files not open in editor)
+        // #162 B1 — shared cross-file token loader (live buffer -> cache -> disk).
         let implTokens: Token[];
         let implFileContent: string;
         try {
-            const openText = getOpenDocumentContent?.(clwPath) ?? null;
-            if (openText !== null) {
-                // File is open in VS Code — use the live buffer content directly.
-                implFileContent = openText;
-                const implUri = pathToCanonicalUri(clwPath);
-                const implDoc = TextDocument.create(implUri, 'clarion', 1, openText);
-                implTokens = tokenCache.getTokens(implDoc);
-            } else {
-                // File not open in editor — try TokenCache, then fall back to disk.
-                const normalizedClwPath = clwPath.toLowerCase().replace(/\\/g, '/');
-                const liveUri = tokenCache.getAllCachedUris().find(uri => {
-                    const uriPath = decodeURIComponent(uri.replace(/^file:\/\/\//i, '')).toLowerCase().replace(/\\/g, '/');
-                    return uriPath === normalizedClwPath;
-                });
-                if (liveUri) {
-                    const liveText = tokenCache.getDocumentText(liveUri);
-                    const liveCachedTokens = tokenCache.getTokensByUri(liveUri);
-                    if (liveText && liveCachedTokens) {
-                        implTokens = liveCachedTokens;
-                        implFileContent = liveText;
-                    } else if (liveText) {
-                        const implDoc = TextDocument.create(liveUri, 'clarion', 1, liveText);
-                        implTokens = tokenCache.getTokens(implDoc);
-                        implFileContent = liveText;
-                    } else {
-                        throw new Error('no live text in cache');
-                    }
-                } else {
-                    implFileContent = fs.readFileSync(clwPath, 'utf8');
-                    const implDoc = TextDocument.create(pathToCanonicalUri(clwPath), 'clarion', 1, implFileContent);
-                    implTokens = tokenCache.getTokens(implDoc);
-                }
+            const normalizedClwPath = clwPath.toLowerCase().replace(/\\/g, '/');
+            const liveUri = tokenCache.getAllCachedUris().find(uri => {
+                const uriPath = decodeURIComponent(uri.replace(/^file:\/\/\//i, '')).toLowerCase().replace(/\\/g, '/');
+                return uriPath === normalizedClwPath;
+            });
+            const loaded = CrossFileResolver.loadExternalFileTokens(
+                tokenCache,
+                liveUri ?? pathToCanonicalUri(clwPath),
+                clwPath,
+                getOpenDocumentContent
+            );
+            if (!loaded) {
+                throw new Error('unable to load external file tokens');
             }
+            implTokens = loaded.tokens;
+            implFileContent = loaded.content;
         } catch (err) {
             logger.error(`Error loading implementation file '${clwPath}': ${err instanceof Error ? err.message : String(err)}`);
             continue;

--- a/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
+++ b/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
@@ -7,6 +7,9 @@ import { MemberLocatorService } from '../../services/MemberLocatorService';
 import { TokenCache } from '../../TokenCache';
 import { TokenHelper } from '../../utils/TokenHelper';
 import { DocumentStructure } from '../../DocumentStructure';
+import { SolutionManager } from '../../solution/solutionManager';
+import { CrossFileResolver } from '../../utils/CrossFileResolver';
+import * as path from 'path';
 import LoggerManager from '../../logger';
 
 const logger = LoggerManager.getLogger("ReturnValueDiagnostics");
@@ -82,7 +85,8 @@ function validateCrossFilePlainCalls(
     currentTokens: Token[],
     document: TextDocument,
     docLines: string[],
-    codeRanges: { start: number; end: number }[]
+    codeRanges: { start: number; end: number }[],
+    getOpenDocumentContent?: (absPath: string) => string | null
 ): Diagnostic[] {
     const cache = TokenCache.getInstance();
     const currentUri = document.uri;
@@ -98,9 +102,43 @@ function validateCrossFilePlainCalls(
     const warnableProcs = new Map<string, string>(); // nameUpper → returnType
     const excluded = new Set<string>();
 
+    const filesToScan = new Map<string, { uri: string; fsPath?: string }>();
     for (const uri of cache.getAllCachedUris()) {
-        if (uri === currentUri) continue;
-        const otherTokens = cache.getTokensByUri(uri);
+        if (uri.toLowerCase() === currentUri.toLowerCase()) continue;
+        filesToScan.set(uri.toLowerCase(), { uri });
+    }
+
+    // #162 V1 — include unopened project files, not just TokenCache entries.
+    const solutionManager = SolutionManager.getInstance();
+    if (solutionManager?.solution?.projects?.length) {
+        for (const project of solutionManager.solution.projects) {
+            for (const sourceFile of project.sourceFiles) {
+                const fullPath = path.isAbsolute(sourceFile.relativePath)
+                    ? sourceFile.relativePath
+                    : path.join(project.path, sourceFile.relativePath);
+                const uri = `file:///${fullPath.replace(/\\/g, '/')}`;
+                if (uri.toLowerCase() === currentUri.toLowerCase()) continue;
+                const key = uri.toLowerCase();
+                if (!filesToScan.has(key)) {
+                    filesToScan.set(key, { uri, fsPath: fullPath });
+                }
+            }
+        }
+    }
+
+    for (const { uri, fsPath } of filesToScan.values()) {
+        let otherTokens = cache.getTokensByUri(uri);
+        if (!otherTokens) {
+            const pathFromUri = decodeURIComponent(uri.replace(/^file:\/\/\/?/i, '')).replace(/\//g, '\\');
+            const loaded = CrossFileResolver.loadExternalFileTokens(
+                cache,
+                uri,
+                fsPath ?? pathFromUri,
+                getOpenDocumentContent
+            );
+            if (!loaded) continue;
+            otherTokens = loaded.tokens;
+        }
         if (!otherTokens) continue;
 
         for (let i = 0; i < otherTokens.length; i++) {
@@ -662,7 +700,8 @@ export function validateDiscardedReturnValuesForPlainCalls(
 export async function validateDiscardedReturnValues(
     tokens: Token[],
     document: TextDocument,
-    memberLocator: MemberLocatorService
+    memberLocator: MemberLocatorService,
+    getOpenDocumentContent?: (absPath: string) => string | null
 ): Promise<Diagnostic[]> {
     const fnStart = Date.now();
     const diagnostics: Diagnostic[] = [];
@@ -784,7 +823,7 @@ export async function validateDiscardedReturnValues(
     const dotCallMs = Date.now() - fnStart;
 
     const crossFileStart = Date.now();
-    const crossFileDiags = validateCrossFilePlainCalls(tokens, document, docLines, codeRanges);
+    const crossFileDiags = validateCrossFilePlainCalls(tokens, document, docLines, codeRanges, getOpenDocumentContent);
     diagnostics.push(...crossFileDiags);
     const crossFileMs = Date.now() - crossFileStart;
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -616,7 +616,7 @@ async function validateTextDocument(document: TextDocument, caller: string = 'un
             return result;
         };
         const [discardedReturnDiags, missingIncludeDiags, missingConstantsDiags, missingMapDeclDiags, missingImplDiags, undeclaredVarDiags, ifaceImplDiags] = await Promise.all([
-            timeIt('discardedReturn', DiagnosticProvider.validateDiscardedReturnValues(tokens, document, memberLocator)),
+            timeIt('discardedReturn', DiagnosticProvider.validateDiscardedReturnValues(tokens, document, memberLocator, getOpenDocumentContent)),
             timeIt('missingIncludes', DiagnosticProvider.validateMissingIncludes(tokens, document)),
             timeIt('missingConstants', DiagnosticProvider.validateMissingConstants(tokens, document)),
             timeIt('missingMapDecl', DiagnosticProvider.validateMissingMapDeclarations(tokens, document, getOpenDocumentContent)),

--- a/server/src/test/DiagnosticProvider.test.ts
+++ b/server/src/test/DiagnosticProvider.test.ts
@@ -1807,6 +1807,62 @@ CallerProc  PROCEDURE()
             );
             assert.strictEqual(plain.length, 0, 'void procedure — no warning');
         });
+
+        test('cross-file: unopened project file is scanned via solution sourceFiles', async () => {
+            const fs = require('fs');
+            const os = require('os');
+            const path = require('path');
+            const { SolutionManager } = require('../solution/solutionManager');
+
+            const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-cross-file-162-'));
+            const programPath = path.join(tmpRoot, 'prog.clw');
+            const memberPath = path.join(tmpRoot, 'member.clw');
+            const programCode = `
+  PROGRAM
+  MAP
+TestProc  PROCEDURE(),LONG
+  END
+  CODE
+`;
+            const memberCode = `
+  MEMBER('prog.clw')
+CallerProc  PROCEDURE()
+  CODE
+  TestProc()
+`;
+
+            fs.writeFileSync(programPath, programCode, 'utf8');
+            fs.writeFileSync(memberPath, memberCode, 'utf8');
+
+            const savedSm = (SolutionManager as unknown as { instance: unknown }).instance;
+            try {
+                // Do not pre-populate program tokens in TokenCache — this pins V1:
+                // diagnostics must still discover returning MAP procs from unopened files.
+                TokenCache.getInstance().clearAllTokens();
+                const memberDoc = createDoc(`file:///${memberPath.replace(/\\/g, '/')}`, memberCode);
+                const tokens = TokenCache.getInstance().getTokens(memberDoc);
+
+                const fakeProject = {
+                    path: tmpRoot,
+                    sourceFiles: [{ relativePath: 'prog.clw' }]
+                };
+                const fakeSm = {
+                    solution: { projects: [fakeProject] }
+                };
+                (SolutionManager as unknown as { instance: unknown }).instance = fakeSm;
+
+                const locator = new MemberLocatorService();
+                const diags = await DiagnosticProvider.validateDiscardedReturnValues(tokens, memberDoc, locator);
+                const plain = diags.filter((d: { message: string }) =>
+                    /^Return value of '[A-Za-z_][A-Za-z0-9_]*' is discarded/.test(d.message)
+                );
+                assert.strictEqual(plain.length, 1, 'should warn from unopened project file declaration');
+                assert.ok(plain[0].message.includes("'TestProc'"));
+            } finally {
+                (SolutionManager as unknown as { instance: unknown }).instance = savedSm;
+                try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best effort */ }
+            }
+        });
     });
 
     // ─── CYCLE / BREAK outside LOOP or ACCEPT (issue #64) ───────────────────

--- a/server/src/utils/CrossFileResolver.ts
+++ b/server/src/utils/CrossFileResolver.ts
@@ -80,6 +80,27 @@ export class CrossFileResolver {
     }
 
     /**
+     * #162 B1 — shared cross-file TOKEN loader for diagnostics. Uses the same
+     * live-buffer/cache/disk policy as `loadExternalFileContent`, then tokenizes
+     * through TokenCache so downstream diagnostics get the same token surface they
+     * already consume today.
+     */
+    public static loadExternalFileTokens(
+        tokenCache: TokenCache,
+        uri: string | undefined,
+        fsPath: string,
+        getLiveText?: (fsPath: string) => string | null | undefined
+    ): { content: string; tokens: Token[]; uri: string } | undefined {
+        const content = CrossFileResolver.loadExternalFileContent(tokenCache, uri, fsPath, getLiveText);
+        if (content === undefined) return undefined;
+
+        const resolvedUri = uri ?? pathToCanonicalUri(fsPath);
+        const doc = TextDocument.create(resolvedUri, 'clarion', 1, content);
+        const tokens = tokenCache.getTokens(doc);
+        return { content, tokens, uri: resolvedUri };
+    }
+
+    /**
      * Resolves a filename to an absolute path using RedirectionParser
      * Tries solution-wide redirection first, then falls back to relative path
      * @param filename Unresolved filename (from MEMBER, MODULE, INCLUDE, etc.)


### PR DESCRIPTION
## Summary
- add shared CrossFileResolver.loadExternalFileTokens helper (live buffer -> cache -> disk)
- refactor MapDeclarationDiagnostics.validateMissingImplementations to use shared loader
- extend ReturnValueDiagnostics.validateCrossFilePlainCalls to include unopened solution files (not just cached URIs)
- thread open-document provider through discarded-return diagnostic path
- add regression test for unopened project-file cross-file detection
- update 0.9.9 changelog

## Related
- #162