### PR TITLE
Add lazy no-solution FRG build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Clarion Extension are documented here.
 
 - ✨ **Cross-file global-data completion parity for MEMBER files** (#224): word completion now includes PROGRAM-file global symbols while editing MEMBER modules, including both direct globals (e.g. `GLO:*`) and `PRE(...)`-qualified global structure fields (e.g. `TGLO:FieldName`); prefixed completions now insert only the suffix after an already-typed qualifier, so accepting `GLO:Var` after typing `GLO:` no longer duplicates the prefix.
 - ✨ **No-solution entry-point completion coverage extended** (#113): no-solution LSP entry-point tests now include completion validation for MEMBER files consuming PROGRAM globals (`GLO:*` and `PRE(...)`-qualified fields), and FAR global-scope loading now has a no-solution MEMBER→PROGRAM fallback when FRG is unavailable.
+- ✨ **Lazy no-solution FRG substrate for DocumentLink / FAR / completion** (#140): `FileRelationshipGraph` now builds on demand around the active no-solution document using its reachable INCLUDE/MEMBER/MODULE neighborhood plus nearby libsrc/source directories, so INCLUDE links, cross-MEMBER global FAR, and MEMBER→PROGRAM completion all reuse the same graph-backed file relationships even with no `.sln` loaded.
 
 **Bug Fixes**
 

--- a/server/src/FileRelationshipGraph.ts
+++ b/server/src/FileRelationshipGraph.ts
@@ -13,9 +13,12 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TokenType } from './ClarionTokenizer';
 import { TokenCache } from './TokenCache';
 import { SolutionManager } from './solution/solutionManager';
+import { serverSettings } from './serverSettings';
+import { resolveFileInNoSolutionMode } from './solution/findFileNoSolution';
 import LoggerManager from './logger';
 
 const logger = LoggerManager.getLogger("FileRelationshipGraph");
@@ -52,6 +55,10 @@ export class FileRelationshipGraph {
     private _buildDurationMs: number | undefined;
     private _buildStartTime: Date | undefined;
     private _buildEndTime: Date | undefined;
+    private _buildMode: 'solution' | 'no-solution' | null = null;
+    private _noSolutionSignature: string | undefined;
+    private _noSolutionSourceFile: string | undefined;
+    private _noSolutionSourceUri: string | undefined;
 
     private constructor() {}
 
@@ -88,6 +95,10 @@ export class FileRelationshipGraph {
         this.forwardEdges.clear();
         this.reverseEdges.clear();
         this.classModuleIndex.clear();
+        this._buildMode = 'solution';
+        this._noSolutionSignature = undefined;
+        this._noSolutionSourceFile = undefined;
+        this._noSolutionSourceUri = undefined;
 
         const buildStart = Date.now();
         const visited = new Set<string>();
@@ -134,6 +145,18 @@ export class FileRelationshipGraph {
      * No-op while the background build is running — the build will capture the latest state.
      */
     public async updateFile(uri: string): Promise<void> {
+        if (this._buildMode === 'no-solution' && this._noSolutionSourceFile && this._noSolutionSourceUri) {
+            const tokenCache = TokenCache.getInstance();
+            const sourceText = tokenCache.getDocumentText(this._noSolutionSourceUri)
+                ?? tokenCache.getDocumentText(this.pathToUri(this.denormalizePath(this._noSolutionSourceFile)))
+                ?? (fs.existsSync(this.denormalizePath(this._noSolutionSourceFile))
+                    ? fs.readFileSync(this.denormalizePath(this._noSolutionSourceFile), 'utf-8')
+                    : '');
+            const sourceDoc = TextDocument.create(this._noSolutionSourceUri, 'clarion', 1, sourceText);
+            this.buildNoSolutionGraph(this._noSolutionSourceFile, sourceDoc);
+            return;
+        }
+
         if (this._building) return;
         const filePath = this.normalizePath(this.uriToPath(uri));
 
@@ -170,7 +193,41 @@ export class FileRelationshipGraph {
         this.classModuleIndex.clear();
         this._built = false;
         this._building = false;
+        this._buildDurationMs = undefined;
+        this._buildStartTime = undefined;
+        this._buildEndTime = undefined;
+        this._buildMode = null;
+        this._noSolutionSignature = undefined;
+        this._noSolutionSourceFile = undefined;
+        this._noSolutionSourceUri = undefined;
         logger.debug(`🔄 [FRG] FileRelationshipGraph reset`);
+    }
+
+    /**
+     * Lazily builds a bounded FRG for no-solution mode around the active document.
+     *
+     * The build is intentionally narrower than the full solution walk: it seeds
+     * from the active document, follows resolved INCLUDE/MEMBER/MODULE targets,
+     * and non-recursively scans the active/source/libsrc directories so reverse
+     * INCLUDE and sibling MEMBER edges exist for nearby cross-file features.
+     */
+    public ensureNoSolutionGraphForDocument(document: TextDocument): void {
+        if (SolutionManager.getInstance()?.solution) return;
+
+        const sourcePath = this.normalizePath(this.uriToPath(document.uri));
+        if (this._built && this.forwardEdges.has(sourcePath)) {
+            return;
+        }
+        const signature = this.getNoSolutionSignature(sourcePath);
+        if (
+            this._built &&
+            this._buildMode === 'no-solution' &&
+            this._noSolutionSignature === signature
+        ) {
+            return;
+        }
+
+        this.buildNoSolutionGraph(sourcePath, document);
     }
 
     /**
@@ -193,6 +250,67 @@ export class FileRelationshipGraph {
             });
         }
         this._built = true;
+    }
+
+    private buildNoSolutionGraph(sourcePath: string, sourceDocument?: TextDocument): void {
+        this._building = true;
+        this._built = false;
+        this._buildDurationMs = undefined;
+        this._buildStartTime = new Date();
+        this._buildEndTime = undefined;
+        this.forwardEdges.clear();
+        this.reverseEdges.clear();
+        this.classModuleIndex.clear();
+        this._buildMode = 'no-solution';
+        this._noSolutionSignature = this.getNoSolutionSignature(sourcePath);
+        this._noSolutionSourceFile = sourcePath;
+        this._noSolutionSourceUri = sourceDocument?.uri ?? this.pathToUri(this.denormalizePath(sourcePath));
+
+        const buildStart = Date.now();
+        const visitedFiles = new Set<string>();
+        const queuedFiles = new Set<string>();
+        const scannedDirs = new Set<string>();
+        const queue: string[] = [];
+
+        const enqueueFile = (filePath: string | undefined | null) => {
+            if (!filePath) return;
+            const norm = this.normalizePath(filePath);
+            if (visitedFiles.has(norm) || queuedFiles.has(norm)) return;
+            queuedFiles.add(norm);
+            queue.push(norm);
+        };
+
+        enqueueFile(sourcePath);
+        this.enqueueDirectoryFiles(path.dirname(this.denormalizePath(sourcePath)), enqueueFile, scannedDirs);
+        for (const libsrcDir of serverSettings.libsrcPaths ?? []) {
+            this.enqueueDirectoryFiles(libsrcDir, enqueueFile, scannedDirs);
+        }
+
+        while (queue.length > 0) {
+            const filePath = queue.shift()!;
+            queuedFiles.delete(filePath);
+            if (visitedFiles.has(filePath)) continue;
+            visitedFiles.add(filePath);
+
+            this.enqueueDirectoryFiles(path.dirname(this.denormalizePath(filePath)), enqueueFile, scannedDirs);
+
+            const discovered = (
+                sourceDocument &&
+                filePath === sourcePath
+            )
+                ? this.processOpenDocument(sourcePath, sourceDocument)
+                : this.processFileSync(filePath);
+
+            for (const target of discovered) {
+                enqueueFile(target);
+                this.enqueueDirectoryFiles(path.dirname(this.denormalizePath(target)), enqueueFile, scannedDirs);
+            }
+        }
+
+        this._buildDurationMs = Date.now() - buildStart;
+        this._buildEndTime = new Date();
+        this._built = true;
+        this._building = false;
     }
 
     // ── Core processor ─────────────────────────────────────────────────────────
@@ -233,6 +351,41 @@ export class FileRelationshipGraph {
         } catch {
             return [];
         }
+    }
+
+    private processFileSync(filePath: string, originalUri?: string): string[] {
+        const tokenCache = TokenCache.getInstance();
+
+        let tokens = originalUri ? tokenCache.getTokensByUri(originalUri) : null;
+        if (!tokens || tokens.length === 0) {
+            const uri = this.pathToUri(this.denormalizePath(filePath));
+            tokens = tokenCache.getTokensByUri(uri);
+        }
+        if (!tokens || tokens.length === 0) {
+            const uriAlt = 'file:///' + this.denormalizePath(filePath).replace(/\\/g, '/');
+            tokens = tokenCache.getTokensByUri(uriAlt) ?? null;
+        }
+        if (tokens && tokens.length > 0) {
+            return this.processFileFromTokens(filePath, tokens);
+        }
+
+        try {
+            const actualPath = this.denormalizePath(filePath);
+            if (!fs.existsSync(actualPath)) return [];
+            const content = fs.readFileSync(actualPath, 'utf-8');
+            return this.processFileFromText(filePath, content);
+        } catch {
+            return [];
+        }
+    }
+
+    private processOpenDocument(filePath: string, document: TextDocument): string[] {
+        const tokenCache = TokenCache.getInstance();
+        const tokens = tokenCache.getTokensByUri(document.uri);
+        if (tokens && tokens.length > 0) {
+            return this.processFileFromTokens(filePath, tokens);
+        }
+        return this.processFileFromText(filePath, document.getText());
     }
 
     /**
@@ -509,6 +662,53 @@ export class FileRelationshipGraph {
         return filePath.toLowerCase().replace(/\\/g, '/');
     }
 
+    private denormalizePath(filePath: string): string {
+        return filePath.replace(/\//g, '\\');
+    }
+
+    private getNoSolutionSignature(sourcePath: string): string {
+        const libs = [...(serverSettings.libsrcPaths ?? [])]
+            .map(p => this.normalizePath(p))
+            .sort()
+            .join(';');
+        const exts = [...(serverSettings.defaultLookupExtensions ?? [])]
+            .map(ext => ext.toLowerCase())
+            .sort()
+            .join(';');
+        return [
+            sourcePath,
+            this.normalizePath(serverSettings.redirectionFile || ''),
+            libs,
+            exts
+        ].join('|');
+    }
+
+    private enqueueDirectoryFiles(
+        dirPath: string,
+        enqueueFile: (filePath: string) => void,
+        scannedDirs: Set<string>
+    ): void {
+        if (!dirPath) return;
+        const normalizedDir = this.normalizePath(dirPath);
+        if (scannedDirs.has(normalizedDir)) return;
+        scannedDirs.add(normalizedDir);
+
+        try {
+            const clarionExts = new Set(
+                ['.clw', '.inc', ...(serverSettings.defaultLookupExtensions ?? [])]
+                    .map(ext => ext.toLowerCase())
+            );
+            for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+                if (!entry.isFile()) continue;
+                const ext = path.extname(entry.name).toLowerCase();
+                if (!clarionExts.has(ext)) continue;
+                enqueueFile(path.join(dirPath, entry.name));
+            }
+        } catch {
+            // best-effort directory widening only
+        }
+    }
+
     private pathToUri(filePath: string): string {
         // Percent-encode the drive colon to match VS Code's URI format
         const encoded = filePath.replace(/\\/g, '/').replace(/^([a-zA-Z]):/, (_, d) => d + '%3A');
@@ -540,6 +740,12 @@ export class FileRelationshipGraph {
                     return resolved.path;
                 }
             }
+        }
+
+        const sourceUri = this.pathToUri(this.denormalizePath(this.normalizePath(_fromFile)));
+        const noSolutionHit = resolveFileInNoSolutionMode(filename, sourceUri);
+        if (noSolutionHit?.path && fs.existsSync(noSolutionHit.path)) {
+            return noSolutionHit.path;
         }
 
         return null;

--- a/server/src/providers/DocumentLinkProvider.ts
+++ b/server/src/providers/DocumentLinkProvider.ts
@@ -23,6 +23,7 @@ export class DocumentLinkProvider {
 
     provideDocumentLinks(document: TextDocument): DocumentLink[] {
         const frg = FileRelationshipGraph.getInstance();
+        frg.ensureNoSolutionGraphForDocument(document);
         if (!frg.isBuilt) return [];
 
         const filePath = uriToFsPath(document.uri);

--- a/server/src/providers/ReferencesProvider.ts
+++ b/server/src/providers/ReferencesProvider.ts
@@ -50,6 +50,11 @@ export function canonicalLocationKey(uri: string, line: number): string {
     return `${normUri}:${line}`;
 }
 
+function fsPathToUri(filePath: string): string {
+    const encoded = filePath.replace(/\\/g, '/').replace(/^([a-zA-Z]):/, (_, d) => d + '%3A');
+    return `file:///${encoded}`;
+}
+
 type OverloadFilter = {
     minArgs: number;
     maxArgs: number;
@@ -2475,6 +2480,11 @@ export class ReferencesProvider {
      */
     private getFilesToSearch(symbolInfo: SymbolInfo, currentDocument: TextDocument): string[] {
         const scopeType = symbolInfo.scope.type;
+        const solutionManager = SolutionManager.getInstance();
+        const graph = FileRelationshipGraph.getInstance();
+        if (!solutionManager?.solution) {
+            graph.ensureNoSolutionGraphForDocument(currentDocument);
+        }
 
         if (scopeType === 'local' || scopeType === 'parameter' || scopeType === 'routine') {
             logger.test(`[FAR] Scope="${scopeType}" → searching only current file`);
@@ -2489,7 +2499,6 @@ export class ReferencesProvider {
                 // For a MAP-declared procedure, its implementation lives in a MODULE target file.
                 const declaringFilePath = decodeURIComponent(symbolInfo.location.uri.replace(/^file:\/\/\//i, ''))
                     .replace(/\\/g, '/').toLowerCase();
-                const graph = FileRelationshipGraph.getInstance();
                 const implFiles: string[] = [symbolInfo.location.uri];
 
                 if (graph.isBuilt) {
@@ -2521,7 +2530,6 @@ export class ReferencesProvider {
         }
 
         // Global (or MEMBER-file procedure): all project source files when a solution is loaded
-        const solutionManager = SolutionManager.getInstance();
         const alwaysInclude = new Set<string>([
             currentDocument.uri,
             symbolInfo.location.uri  // always search the declaration file
@@ -2571,9 +2579,66 @@ export class ReferencesProvider {
             return allFiles;
         }
 
-        logger.test(`[FAR] Scope="${scopeType}" → global but NO solution loaded, searching ${[...alwaysInclude].length} file(s)`);
+        const noSolutionFiles = this.getNoSolutionConnectedFiles(alwaysInclude, currentDocument);
+        logger.test(`[FAR] Scope="${scopeType}" → global but NO solution loaded, searching ${noSolutionFiles.length} connected file(s)`);
 
-        return [...alwaysInclude];
+        return noSolutionFiles;
+    }
+
+    private getNoSolutionConnectedFiles(seedUris: Set<string>, currentDocument: TextDocument): string[] {
+        const graph = FileRelationshipGraph.getInstance();
+        graph.ensureNoSolutionGraphForDocument(currentDocument);
+        if (!graph.isBuilt) {
+            return [...seedUris];
+        }
+
+        const results = new Set<string>(seedUris);
+        const visited = new Set<string>();
+        const queue: string[] = [...seedUris].map(uri =>
+            decodeURIComponent(uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\')
+        );
+
+        const enqueueFsPath = (filePath: string | undefined) => {
+            if (!filePath) return;
+            const uri = fsPathToUri(filePath);
+            if (!results.has(uri)) {
+                results.add(uri);
+            }
+            const norm = filePath.toLowerCase().replace(/\\/g, '/');
+            if (!visited.has(norm)) {
+                queue.push(filePath.replace(/\//g, '\\'));
+            }
+        };
+
+        while (queue.length > 0) {
+            const current = queue.shift()!;
+            const normCurrent = current.toLowerCase().replace(/\\/g, '/');
+            if (visited.has(normCurrent)) continue;
+            visited.add(normCurrent);
+
+            const programFile = graph.getProgramFile(current);
+            if (programFile) {
+                enqueueFsPath(programFile);
+                for (const memberFile of graph.getMemberFiles(programFile)) {
+                    enqueueFsPath(memberFile);
+                }
+            }
+
+            for (const memberFile of graph.getMemberFiles(current)) {
+                enqueueFsPath(memberFile);
+            }
+
+            for (const edge of graph.getReverseIncludes(current)) {
+                enqueueFsPath(edge.fromFile);
+            }
+
+            for (const edge of graph.getForwardEdges(current)) {
+                if (edge.type === 'IMPLICIT_INCLUDE') continue;
+                enqueueFsPath(edge.toFile);
+            }
+        }
+
+        return Array.from(results);
     }
 
     /**

--- a/server/src/providers/WordCompletionProvider.ts
+++ b/server/src/providers/WordCompletionProvider.ts
@@ -195,6 +195,7 @@ export class WordCompletionProvider {
         // All procedures declared in ANY MODULE in the program's MAP are globally
         // accessible — the module/DLL name is irrelevant for completion purposes.
         const graph = FileRelationshipGraph.getInstance();
+        graph.ensureNoSolutionGraphForDocument(document);
         const currentPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
         const programPath = graph.isBuilt
             ? graph.getProgramFile(currentPath)
@@ -413,6 +414,7 @@ export class WordCompletionProvider {
         add: (label: string, kind: CompletionItemKind, detail?: string) => void
     ): void {
         const graph = FileRelationshipGraph.getInstance();
+        graph.ensureNoSolutionGraphForDocument(document);
         const currentPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
         const programPathRaw = graph.isBuilt
             ? graph.getProgramFile(currentPath)

--- a/server/src/test/NoSolutionMode.EntryPoints.test.ts
+++ b/server/src/test/NoSolutionMode.EntryPoints.test.ts
@@ -7,7 +7,8 @@ import { ImplementationProvider } from '../providers/ImplementationProvider';
 import { DefinitionProvider } from '../providers/DefinitionProvider';
 import { CompletionProvider } from '../providers/CompletionProvider';
 import { DocumentLinkProvider } from '../providers/DocumentLinkProvider';
-import { FileRelationshipGraph, FileEdge } from '../FileRelationshipGraph';
+import { ReferencesProvider } from '../providers/ReferencesProvider';
+import { FileRelationshipGraph } from '../FileRelationshipGraph';
 import {
     NoSolutionFixture,
     buildNoSolutionFixture,
@@ -458,6 +459,54 @@ suite('NoSolutionMode LSP entry-points (#139)', () => {
             assert.ok(tglo, `expected TGLO:PageReceived in completion; got: ${tgloItems.map(i => i.label).join(', ')}`);
             assert.strictEqual(glo?.insertText, 'SessionId');
             assert.strictEqual(tglo?.insertText, 'PageReceived');
+            assert.ok(FileRelationshipGraph.getInstance().isBuilt, 'completion should lazily build the FRG in no-solution mode');
+        });
+    });
+
+    suite('ReferencesProvider.provideReferences for no-solution global scope', () => {
+        test('includes sibling MEMBER callers connected through PROGRAM and INCLUDE edges', async () => {
+            const programBody =
+                "  PROGRAM\n" +
+                "GLO:SessionId  STRING(20)\n" +
+                "Main PROCEDURE\n" +
+                "  CODE\n" +
+                "  RETURN\n";
+            const memberOneBody =
+                "  MEMBER('MyProg.clw')\n" +
+                "WorkerOne PROCEDURE\n" +
+                "  CODE\n" +
+                "  GLO:SessionId = 'one'\n" +
+                "  RETURN\n";
+            const memberTwoBody =
+                "  MEMBER('MyProg.clw')\n" +
+                "WorkerTwo PROCEDURE\n" +
+                "  CODE\n" +
+                "  GLO:SessionId = 'two'\n" +
+                "  RETURN\n";
+
+            fix = buildNoSolutionFixture({
+                libsrcs: [{}],
+                sourceFile: {
+                    filename: 'MyProg001.clw',
+                    content: memberOneBody,
+                    siblings: {
+                        'MyProg.clw': programBody,
+                        'MyProg002.clw': memberTwoBody
+                    }
+                }
+            });
+
+            const provider = new ReferencesProvider();
+            const sourceDoc = TextDocument.create(fix.sourceUri!, 'clarion', 1, memberOneBody);
+            const position = cursorPositionOf(memberOneBody, 'GLO:SessionId');
+
+            const refs = await provider.provideReferences(sourceDoc, position, { includeDeclaration: true });
+
+            assert.ok(refs && refs.length >= 3, `expected declaration + two member references, got: ${(refs ?? []).map(r => r.uri).join(', ')}`);
+            const basenames = refs!.map(r => path.basename(fsPathFromUri(r.uri)).toLowerCase());
+            assert.ok(basenames.includes('myprog.clw'), 'references should include the PROGRAM/global declaration file');
+            assert.ok(basenames.includes('myprog001.clw'), 'references should include the current MEMBER file');
+            assert.ok(basenames.includes('myprog002.clw'), 'references should include the sibling MEMBER caller');
         });
     });
 
@@ -474,22 +523,12 @@ suite('NoSolutionMode LSP entry-points (#139)', () => {
                 sourceFile: { filename: 'MyProg.clw', content: sourceBody }
             });
 
-            const frg = FileRelationshipGraph.getInstance();
-            frg.reset();
-            frg.seedEdgesForTest([
-                {
-                    type: 'INCLUDE',
-                    fromFile: fix.sourceFile!,
-                    toFile: path.join(fix.libsrcDirs[0], 'MyClass.inc'),
-                    fromLine: 1
-                } as FileEdge
-            ]);
-
             const provider = new DocumentLinkProvider();
             const sourceDoc = TextDocument.create(fix.sourceUri!, 'clarion', 1, sourceBody);
             const links = provider.provideDocumentLinks(sourceDoc);
 
             assert.ok(links.length >= 1, 'provideDocumentLinks must return at least one link for INCLUDE in no-solution mode');
+            assert.ok(FileRelationshipGraph.getInstance().isBuilt, 'document links should lazily build the FRG in no-solution mode');
 
             const includeLink = links.find(link =>
                 !!link.target && path.basename(fsPathFromUri(link.target)).toLowerCase() === 'myclass.inc'


### PR DESCRIPTION
## Summary
- add a bounded lazy no-solution FileRelationshipGraph build around the active document and nearby source/libsrc files
- use that graph for no-solution document links and global-scope FAR widening, while letting completion participate in the same substrate
- add no-solution regression coverage for completion, FAR, and document links; update the changelog

## Validation
- npm run compile:dev
- npm test

Closes #140