### PR TITLE
Fix sibling MEMBER module-scope symbol lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Clarion Extension are documented here.
 - ✨ **Cross-file global-data completion parity for MEMBER files** (#224): word completion now includes PROGRAM-file global symbols while editing MEMBER modules, including both direct globals (e.g. `GLO:*`) and `PRE(...)`-qualified global structure fields (e.g. `TGLO:FieldName`); prefixed completions now insert only the suffix after an already-typed qualifier, so accepting `GLO:Var` after typing `GLO:` no longer duplicates the prefix.
 - ✨ **No-solution entry-point completion coverage extended** (#113): no-solution LSP entry-point tests now include completion validation for MEMBER files consuming PROGRAM globals (`GLO:*` and `PRE(...)`-qualified fields), and FAR global-scope loading now has a no-solution MEMBER→PROGRAM fallback when FRG is unavailable.
 - ✨ **Lazy no-solution FRG substrate for DocumentLink / FAR / completion** (#140): `FileRelationshipGraph` now builds on demand around the active no-solution document using its reachable INCLUDE/MEMBER/MODULE neighborhood plus nearby libsrc/source directories, so INCLUDE links, cross-MEMBER global FAR, and MEMBER→PROGRAM completion all reuse the same graph-backed file relationships even with no `.sln` loaded.
+- ✨ **Sibling MEMBER module-scope symbol resolution** (#118): `SymbolFinderService` now walks FRG MEMBER edges to resolve module-scope declarations from sibling MEMBER files of the same PROGRAM, which restores Hover/F12/FAR and the undeclared-variable hybrid path for Tier 5b cross-MEMBER module data.
 
 **Bug Fixes**
 

--- a/server/src/providers/ReferencesProvider.ts
+++ b/server/src/providers/ReferencesProvider.ts
@@ -51,8 +51,7 @@ export function canonicalLocationKey(uri: string, line: number): string {
 }
 
 function fsPathToUri(filePath: string): string {
-    const encoded = filePath.replace(/\\/g, '/').replace(/^([a-zA-Z]):/, (_, d) => d + '%3A');
-    return `file:///${encoded}`;
+    return `file:///${filePath.replace(/\\/g, '/')}`;
 }
 
 type OverloadFilter = {
@@ -2522,6 +2521,18 @@ export class ReferencesProvider {
                 // Non-MEMBER file procedure declaration at module level (PROGRAM file MAP entry) —
                 // fall through to global search so all call sites are found.
             } else {
+                if (isMember && !isProcDecl && graph.isBuilt) {
+                    const declaringPath = decodeURIComponent(symbolInfo.location.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
+                    const programFile = graph.getProgramFile(declaringPath);
+                    if (programFile) {
+                        const siblingMemberUris = graph.getMemberFiles(programFile)
+                            .map(memberFile => fsPathToUri(memberFile.replace(/\//g, '\\')));
+                        if (siblingMemberUris.length > 0) {
+                            logger.test(`[FAR] Scope="module" cross-MEMBER variable → searching ${siblingMemberUris.length} sibling MEMBER file(s)`);
+                            return siblingMemberUris;
+                        }
+                    }
+                }
                 // MEMBER-file module symbols are visible only within that MEMBER module.
                 // PROGRAM-file module-level data (non-procedure) also stays local.
                 logger.test(`[FAR] Scope="module" → searching only declaring file: ${path.basename(decodeURIComponent(symbolInfo.location.uri))}`);

--- a/server/src/providers/WordCompletionProvider.ts
+++ b/server/src/providers/WordCompletionProvider.ts
@@ -197,9 +197,9 @@ export class WordCompletionProvider {
         const graph = FileRelationshipGraph.getInstance();
         graph.ensureNoSolutionGraphForDocument(document);
         const currentPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
-        const programPath = graph.isBuilt
+        const programPath = (graph.isBuilt
             ? graph.getProgramFile(currentPath)
-            : this.getProgramFileFromTokens(tokens);  // fallback while graph is building
+            : undefined) ?? this.getProgramFileFromTokens(tokens);
 
         if (programPath) {
             const result = this.getTokensForFile(programPath);
@@ -224,10 +224,10 @@ export class WordCompletionProvider {
      */
     private getTokensForFile(filePath: string): { tokens: Token[], doc: TextDocument } | null {
         const uri = 'file:///' + filePath.replace(/\\/g, '/');
-        const cached = this.tokenCache.getTokensByUri(uri) ?? this.tokenCache.getTokensByUri(uri.toLowerCase());
+        const cached = this.tokenCache.getTokensByUriCaseInsensitive(uri);
         if (cached && cached.length > 0) {
             // Build a minimal doc just for line-text lookups (text comes from cache)
-            const text = this.tokenCache.getDocumentText(uri) ?? this.tokenCache.getDocumentText(uri.toLowerCase()) ?? '';
+            const text = this.tokenCache.getDocumentTextByUriCaseInsensitive(uri) ?? '';
             const doc = TextDocument.create(uri, 'clarion', 1, text);
             return { tokens: cached, doc };
         }
@@ -416,9 +416,9 @@ export class WordCompletionProvider {
         const graph = FileRelationshipGraph.getInstance();
         graph.ensureNoSolutionGraphForDocument(document);
         const currentPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
-        const programPathRaw = graph.isBuilt
+        const programPathRaw = (graph.isBuilt
             ? graph.getProgramFile(currentPath)
-            : this.getProgramFileFromTokens(tokens);
+            : undefined) ?? this.getProgramFileFromTokens(tokens);
         const programPath = programPathRaw
             ? (path.isAbsolute(programPathRaw) ? programPathRaw : path.join(path.dirname(currentPath), programPathRaw))
             : undefined;

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -20,6 +20,7 @@ import { TokenCache } from '../TokenCache';
 import { ScopeAnalyzer } from '../utils/ScopeAnalyzer';
 import { TokenHelper } from '../utils/TokenHelper';
 import { SolutionManager } from '../solution/solutionManager';
+import { FileRelationshipGraph } from '../FileRelationshipGraph';
 import { StructureDeclarationIndexer, scanSourceForDeclarations, StructureDeclarationInfo } from '../utils/StructureDeclarationIndexer';
 import { cooperativeCheckpoint } from '../utils/cooperativeScan';
 import LoggerManager from '../logger';
@@ -534,6 +535,51 @@ export class SymbolFinderService {
             searchWord: word
         };
     }
+
+    /**
+     * Find a module-scope variable declared in a sibling MEMBER file of the same PROGRAM.
+     *
+     * Uses FRG MEMBER edges to enumerate sibling MEMBER files, then scans each file's
+     * module scope (between MEMBER and first PROCEDURE) for a matching column-0 label.
+     */
+    public async findModuleVariableInSiblingMembers(
+        word: string,
+        document: TextDocument,
+        _position: { line: number; character: number }
+    ): Promise<SymbolInfo | null> {
+        const graph = FileRelationshipGraph.getInstance();
+        graph.ensureNoSolutionGraphForDocument(document);
+
+        if (!graph.isBuilt) {
+            return null;
+        }
+
+        const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '')).replace(/\//g, '\\');
+        const programFile = graph.getProgramFile(currentFilePath);
+        if (!programFile) {
+            return null;
+        }
+
+        const visited = new Set<string>();
+        for (const memberFile of graph.getMemberFiles(programFile)) {
+            const normMember = memberFile.toLowerCase().replace(/\\/g, '/');
+            if (visited.has(normMember)) continue;
+            visited.add(normMember);
+
+            const memberPath = memberFile.replace(/\//g, '\\');
+            if (memberPath.toLowerCase() === currentFilePath.toLowerCase()) continue;
+
+            const sibling = this.loadTokensForFile(memberPath);
+            if (!sibling) continue;
+
+            const result = this.findModuleVariable(word, sibling.tokens, sibling.document);
+            if (result) {
+                return result;
+            }
+        }
+
+        return null;
+    }
     
     /**
      * Find a structure field or sub-structure accessed via PRE:Field notation.
@@ -908,6 +954,35 @@ export class SymbolFinderService {
             return null;
         }
     }
+
+    private loadTokensForFile(filePath: string): { document: TextDocument; tokens: Token[] } | null {
+        const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+
+        let tokens: Token[] | null = this.tokenCache.getTokensByUriCaseInsensitive(uri);
+        let doc: TextDocument | null = null;
+        if (tokens) {
+            const cachedText = this.tokenCache.getDocumentTextByUriCaseInsensitive(uri);
+            if (cachedText !== null) {
+                doc = TextDocument.create(uri, 'clarion', 1, cachedText);
+            }
+        }
+
+        try {
+            if (!tokens || !doc) {
+                if (!fs.existsSync(filePath)) {
+                    return null;
+                }
+                const contents = fs.readFileSync(filePath, 'utf-8');
+                doc = TextDocument.create(uri, 'clarion', 1, contents);
+                tokens = this.tokenCache.getTokens(doc);
+            }
+
+            return { document: doc, tokens };
+        } catch (err) {
+            logger.error(`Error loading sibling MEMBER file ${filePath}: ${err}`);
+            return null;
+        }
+    }
     
     /**
      * Search for a variable/symbol with full word first, then fallback to stripped prefix
@@ -937,6 +1012,9 @@ export class SymbolFinderService {
             // Try module variable
             const moduleResult = this.findModuleVariable(word, tokens, document);
             if (moduleResult) return moduleResult;
+
+            const siblingModuleResult = await this.findModuleVariableInSiblingMembers(word, document, position);
+            if (siblingModuleResult) return siblingModuleResult;
             
             // Try global variable
             const globalResult = await this.findGlobalVariable(word, tokens, document);
@@ -970,6 +1048,12 @@ export class SymbolFinderService {
         result = this.findModuleVariable(word, tokens, document);
         if (result) {
             logger.info(`✅ Found as module variable: ${word}`);
+            return result;
+        }
+
+        result = await this.findModuleVariableInSiblingMembers(word, document, position);
+        if (result) {
+            logger.info(`✅ Found as sibling MEMBER module variable: ${word}`);
             return result;
         }
         
@@ -1017,6 +1101,13 @@ export class SymbolFinderService {
             result = this.findModuleVariable(searchWord, tokens, document);
             if (result) {
                 logger.info(`✅ Found as module variable (stripped): ${searchWord}`);
+                result.originalWord = word;
+                return result;
+            }
+
+            result = await this.findModuleVariableInSiblingMembers(searchWord, document, position);
+            if (result) {
+                logger.info(`✅ Found as sibling MEMBER module variable (stripped): ${searchWord}`);
                 result.originalWord = word;
                 return result;
             }

--- a/server/src/test/ReferencesProvider.SiblingMemberModuleScope.test.ts
+++ b/server/src/test/ReferencesProvider.SiblingMemberModuleScope.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { ReferencesProvider } from '../providers/ReferencesProvider';
+import { setServerInitialized } from '../serverState';
+import {
+    buildMultiFileFixture,
+    teardownMultiFileFixture
+} from './helpers/MultiFileFARFixture';
+
+suite('ReferencesProvider — sibling MEMBER module-scope', () => {
+    setup(() => {
+        setServerInitialized(true);
+    });
+
+    teardown(() => {
+        teardownMultiFileFixture();
+    });
+
+    test('finds declaration and sibling MEMBER usage for module-scope variable', async () => {
+        const fixture = buildMultiFileFixture({
+            files: {
+                'main.clw': [
+                    '  PROGRAM',
+                    '  MAP',
+                    '  END',
+                    '  CODE',
+                    '  RETURN',
+                ].join('\n'),
+                'MemberA.clw': [
+                    "  MEMBER('main.clw')",
+                    'SharedValue LONG',
+                    'ProcA PROCEDURE',
+                    '  CODE',
+                    '  SharedValue = 10',
+                    '  RETURN',
+                ].join('\n'),
+                'MemberB.clw': [
+                    "  MEMBER('main.clw')",
+                    'ProcB PROCEDURE',
+                    '  CODE',
+                    '  SharedValue = 20',
+                    '  RETURN',
+                ].join('\n'),
+            },
+            frg: { programFile: 'main.clw', memberFiles: ['MemberA.clw', 'MemberB.clw'] }
+        });
+
+        const provider = new ReferencesProvider();
+        const refs = await provider.provideReferences(
+            fixture.documents['MemberB.clw'],
+            { line: 3, character: 4 },
+            { includeDeclaration: true }
+        );
+
+        assert.ok(refs, 'FAR should return references for sibling MEMBER module-scope variable');
+        const basenames = refs!.map(r => path.basename(decodeURIComponent(r.uri)).toLowerCase());
+        assert.ok(basenames.includes('membera.clw'), `expected declaration/member-A refs, got ${basenames.join(', ')}`);
+        assert.ok(basenames.includes('memberb.clw'), `expected current MEMBER usage, got ${basenames.join(', ')}`);
+    });
+});

--- a/server/src/test/SymbolFinderService.test.ts
+++ b/server/src/test/SymbolFinderService.test.ts
@@ -14,6 +14,10 @@ import { SolutionManager } from '../solution/solutionManager';
 import { TokenHelper } from '../utils/TokenHelper';
 import { setServerInitialized } from '../serverState';
 import { TokenType } from '../tokenizer/TokenTypes';
+import {
+    buildMultiFileFixture,
+    teardownMultiFileFixture
+} from './helpers/MultiFileFARFixture';
 
 suite('SymbolFinderService Tests', () => {
     let service: SymbolFinderService;
@@ -37,6 +41,7 @@ suite('SymbolFinderService Tests', () => {
         tokenCache.clearTokens('test://symbol3.clw');
         tokenCache.clearTokens('test://symbol4.clw');
         tokenCache.clearTokens('test://symbol5.clw');
+        teardownMultiFileFixture();
     });
 
     function createDocument(code: string, uri: string = 'test://symbol1.clw'): TextDocument {
@@ -325,6 +330,79 @@ MyProc PROCEDURE()
             const result = service.findModuleVariable('NonExistent', tokens, doc);
             
             assert.strictEqual(result, null, 'Should return null');
+        });
+    });
+
+    suite('findModuleVariableInSiblingMembers', () => {
+        test('Should find module-scope declaration in sibling MEMBER file', async () => {
+            const fixture = buildMultiFileFixture({
+                files: {
+                    'main.clw': [
+                        '  PROGRAM',
+                        '  MAP',
+                        '  END',
+                        '  CODE',
+                        '  RETURN',
+                    ].join('\n'),
+                    'MemberA.clw': [
+                        "  MEMBER('main.clw')",
+                        'SharedValue LONG',
+                        'ProcA PROCEDURE',
+                        '  CODE',
+                        '  RETURN',
+                    ].join('\n'),
+                    'MemberB.clw': [
+                        "  MEMBER('main.clw')",
+                        'ProcB PROCEDURE',
+                        '  CODE',
+                        '  SharedValue = 1',
+                        '  RETURN',
+                    ].join('\n'),
+                },
+                frg: { programFile: 'main.clw', memberFiles: ['MemberA.clw', 'MemberB.clw'] }
+            });
+
+            const memberBDoc = fixture.documents['MemberB.clw'];
+            const result = await service.findModuleVariableInSiblingMembers('SharedValue', memberBDoc, { line: 3, character: 3 });
+
+            assert.ok(result, 'Should find sibling MEMBER module-scope variable');
+            assert.strictEqual(result?.location.uri.toLowerCase(), fixture.uris['MemberA.clw'].toLowerCase());
+            assert.strictEqual(result?.location.line, 1);
+            assert.strictEqual(result?.scope.type, 'module');
+        });
+
+        test('Should return null when sibling MEMBER declaration does not exist', async () => {
+            const fixture = buildMultiFileFixture({
+                files: {
+                    'main.clw': [
+                        '  PROGRAM',
+                        '  MAP',
+                        '  END',
+                        '  CODE',
+                        '  RETURN',
+                    ].join('\n'),
+                    'MemberA.clw': [
+                        "  MEMBER('main.clw')",
+                        'OtherValue LONG',
+                        'ProcA PROCEDURE',
+                        '  CODE',
+                        '  RETURN',
+                    ].join('\n'),
+                    'MemberB.clw': [
+                        "  MEMBER('main.clw')",
+                        'ProcB PROCEDURE',
+                        '  CODE',
+                        '  MissingValue = 1',
+                        '  RETURN',
+                    ].join('\n'),
+                },
+                frg: { programFile: 'main.clw', memberFiles: ['MemberA.clw', 'MemberB.clw'] }
+            });
+
+            const memberBDoc = fixture.documents['MemberB.clw'];
+            const result = await service.findModuleVariableInSiblingMembers('MissingValue', memberBDoc, { line: 3, character: 3 });
+
+            assert.strictEqual(result, null, 'Should return null for undeclared sibling MEMBER variable');
         });
     });
 

--- a/server/src/test/UndeclaredVariableDiagnostics.CrossFile.test.ts
+++ b/server/src/test/UndeclaredVariableDiagnostics.CrossFile.test.ts
@@ -172,7 +172,7 @@ suite('UndeclaredVariableDiagnostics — cross-file scope (6b40d7da, #115)', () 
      * flips GREEN with no diagnostic changes — the SymbolFinder fall-through
      * wired in #115 picks up the new tier transparently.
      */
-    test.skip('Tier 5b BUG PIN — cross-file MEMBER MODULE-scope → no fire', async () => {
+    test('Tier 5b BUG PIN — cross-file MEMBER MODULE-scope → no fire', async () => {
         const fixture = buildMultiFileFixture({
             files: {
                 'main.clw': [


### PR DESCRIPTION
## Summary
- teach SymbolFinderService to resolve module-scope variables from sibling MEMBER files of the same PROGRAM
- widen FAR for that MEMBER-to-MEMBER module-scope case and normalize FRG-derived URIs back to the repo's file URI shape
- harden PROGRAM->MEMBER word completion fallback when the lazy FRG graph is built but does not have a usable program edge

## Testing
- npm test

Closes #118