### PR TITLE
Fix Tier 1 routine-local SymbolFinder shadowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Clarion Extension are documented here.
 
 **Bug Fixes**
 
+- 🐛 **`SymbolFinder.findSymbol` now honors Tier 1 routine-local shadowing** (#116): lookups from inside a `ROUTINE` now check that routine's `DATA` section before falling back to procedure-local scope, so Hover/F12/FAR resolve same-name locals to the routine declaration instead of the parent procedure variable.
 - 🐛 **Cross-file overload resolution no longer regresses when a stale/unrelated FRG is already built**: `MethodOverloadResolver` now falls back to the legacy INCLUDE walk when the graph has no edges for the active file, preventing chained/cross-file overload sites from silently dropping back to param-count-only selection after the new no-solution FRG work.
 - 🐛 **Cross-file return-value diagnostics now scan unopened project files deterministically** (#162): `validateDiscardedReturnValues` no longer depends on `TokenCache.getAllCachedUris()` alone; it now includes solution source files and uses shared cross-file loading (live buffer/cache/disk) so warnings do not silently depend on which files are open.
 - 🐛 **F12 on `DO RoutineName` now resolves to the matching `ROUTINE` label in the current procedure scope** (#211): DefinitionProvider now uses `DocumentStructure.findRoutines()` plus parent-scope matching, so routine references in `DO ...` statements navigate correctly and do not bleed into unrelated routines.

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -318,6 +318,7 @@ export class SymbolFinderService {
                         searchWord: word
                     };
                 }
+
             }
 
             // If the current scope is a ROUTINE, also search the parent procedure's data section.
@@ -468,6 +469,73 @@ export class SymbolFinderService {
                 character: varSymbol.range.start.character
             },
             declaration: varSymbol._clarionDeclaration,
+            originalWord: originalWord || word,
+            searchWord: word
+        };
+    }
+
+    /**
+     * Find a routine-local variable declared in a ROUTINE DATA section.
+     *
+     * Tier 1 shadows the parent procedure's locals, so this must run before the
+     * broader procedure-local search whenever the cursor is inside a ROUTINE.
+     */
+    findRoutineLocalVariable(
+        word: string,
+        tokens: Token[],
+        routineToken: Token,
+        document: TextDocument,
+        originalWord?: string
+    ): SymbolInfo | null {
+        if (routineToken.subType !== TokenType.Routine) {
+            return null;
+        }
+
+        const searchText = originalWord || word;
+        const searchLower = searchText.toLowerCase();
+        const routineDataEnd = routineToken.executionMarker?.line ?? routineToken.finishesAt ?? Number.MAX_SAFE_INTEGER;
+
+        const routineVar = tokens.find(t =>
+            t.line > routineToken.line &&
+            t.line < routineDataEnd &&
+            t.start === 0 &&
+            (t.type === TokenType.Label || t.type === TokenType.Variable) &&
+            t.value.toLowerCase() === searchLower
+        );
+
+        if (!routineVar) {
+            return null;
+        }
+
+        const isProcDecl = tokens.some(t =>
+            t.line === routineVar.line &&
+            (t.type === TokenType.Procedure || t.type === TokenType.Function) &&
+            (t.subType === TokenType.MapProcedure ||
+             t.subType === TokenType.GlobalProcedure ||
+             t.subType === TokenType.MethodDeclaration)
+        );
+        if (isProcDecl) {
+            return null;
+        }
+
+        const declaration = tokens
+            .filter(t => t.line === routineVar.line)
+            .map(t => t.value)
+            .join(' ');
+
+        return {
+            token: routineVar,
+            type: SymbolFinderService.extractTypeInfo(routineVar, tokens),
+            scope: {
+                token: routineToken,
+                type: 'local'
+            },
+            location: {
+                uri: document.uri,
+                line: routineVar.line,
+                character: routineVar.start
+            },
+            declaration,
             originalWord: originalWord || word,
             searchWord: word
         };
@@ -1029,6 +1097,14 @@ export class SymbolFinderService {
         
         // Phase 1 fix: Try FULL word first
         logger.info(`Trying full word: "${word}"`);
+
+        if (currentScope.subType === TokenType.Routine) {
+            let result = this.findRoutineLocalVariable(word, tokens, currentScope, document);
+            if (result) {
+                logger.info(`✅ Found as routine-local variable: ${word}`);
+                return result;
+            }
+        }
         
         // 1. Try as parameter
         let result = this.findParameter(word, document, currentScope);
@@ -1081,6 +1157,14 @@ export class SymbolFinderService {
         if (colonIndex > 0) {
             const searchWord = word.substring(colonIndex + 1);
             logger.info(`Full word not found, trying stripped: "${searchWord}"`);
+
+            if (currentScope.subType === TokenType.Routine) {
+                result = this.findRoutineLocalVariable(searchWord, tokens, currentScope, document, word);
+                if (result) {
+                    logger.info(`✅ Found as routine-local variable (stripped): ${searchWord}`);
+                    return result;
+                }
+            }
             
             // Try parameter with stripped word
             result = this.findParameter(searchWord, document, currentScope);

--- a/server/src/test/SymbolFinderService.test.ts
+++ b/server/src/test/SymbolFinderService.test.ts
@@ -455,4 +455,69 @@ Name         STRING(40)
             assert.strictEqual(result.originalWord, 'GRP:Name');
         });
     });
+
+    suite('findSymbol routine-local Tier 1', () => {
+        test('Should resolve a routine-local variable from routine code', async () => {
+            const code = `
+MyProc PROCEDURE()
+ProcVar LONG
+  CODE
+  DO MyRoutine
+MyRoutine ROUTINE
+  DATA
+RoutineVar LONG
+  CODE
+  RoutineVar = 1
+  END`.trim();
+
+            const doc = createDocument(code, 'test://routine-tier1-1.clw');
+            const result = await service.findSymbol('RoutineVar', doc, { line: 8, character: 4 });
+
+            assert.ok(result, 'Should resolve routine-local variable');
+            assert.strictEqual(result?.location.line, 6);
+            assert.strictEqual(result?.scope.token.subType, TokenType.Routine);
+        });
+
+        test('Should prefer routine-local over same-name procedure-local variable', async () => {
+            const code = `
+MyProc PROCEDURE()
+Counter LONG
+  CODE
+  DO MyRoutine
+MyRoutine ROUTINE
+  DATA
+Counter LONG
+  CODE
+  Counter = 1
+  END`.trim();
+
+            const doc = createDocument(code, 'test://routine-tier1-2.clw');
+            const result = await service.findSymbol('Counter', doc, { line: 8, character: 4 });
+
+            assert.ok(result, 'Should resolve shadowing routine-local variable');
+            assert.strictEqual(result?.location.line, 6);
+            assert.strictEqual(result?.scope.token.subType, TokenType.Routine);
+        });
+
+        test('Should still fall back to procedure-local when no routine-local declaration exists', async () => {
+            const code = `
+MyProc PROCEDURE()
+Counter LONG
+  CODE
+  DO MyRoutine
+MyRoutine ROUTINE
+  DATA
+RoutineOnly LONG
+  CODE
+  Counter = 1
+  END`.trim();
+
+            const doc = createDocument(code, 'test://routine-tier1-3.clw');
+            const result = await service.findSymbol('Counter', doc, { line: 8, character: 4 });
+
+            assert.ok(result, 'Should still resolve parent procedure local');
+            assert.strictEqual(result?.location.line, 1);
+            assert.strictEqual(result?.scope.type, 'local');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- add an explicit routine-local lookup in SymbolFinderService before procedure-local fallback
- preserve procedure-local fallback when the routine does not declare the name
- add Tier 1 regression coverage for direct routine-local resolution and same-name shadowing

## Testing
- npm test

Closes #116