### PR TITLE
fix: class-body scanners no longer leak nesting depth on a same-line self-closing GROUP/QUEUE/RECORD

### DIFF
--- a/server/src/test/ClassMemberResolver.SelfClosingNestedGroup.test.ts
+++ b/server/src/test/ClassMemberResolver.SelfClosingNestedGroup.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression coverage for a class-body-scanning bug shared by three independent
+ * scanners in this file (scanClassBodyForAllMembers, scanClassBodyForMember, and
+ * the INCLUDE-file scanner inside ClassMemberResolver.findClassMemberInIncludes)
+ * — a fourth sibling scanner with the identical bug, in MethodOverloadResolver.ts,
+ * has its own dedicated coverage in MethodOverloadResolver.SelfClosingNestedGroup.test.ts.
+ *
+ * An inline GROUP/QUEUE/RECORD class member that closes itself on the SAME line
+ * (e.g. "Foo GROUP(Type),DIM(2) END", or the period form "...,DIM(2).") was
+ * always treated as OPENING a nested scope that never closes, permanently
+ * leaking the nesting-depth counter and hiding every member declared afterward.
+ *
+ * Three distinct failure modes are covered:
+ *   1. Attributes between the type argument and the terminator (a combined
+ *      regex trying to capture both together can let the attrs swallow the
+ *      terminator — mirrors a real fix already shipped for this exact shape
+ *      in ClarionAssistant's separate CodeGraph indexer).
+ *   2. The period ('.') terminator form, which is fully interchangeable with
+ *      END for closing any Clarion structure, but wasn't recognized at all.
+ *   3. A trailing comment on a CRLF-line-ended file (the "CRLF file with a
+ *      commented self-closing GROUP" suite below) — splitting on a bare '\n'
+ *      leaves every line ending in '\r', which silently defeats the comment-
+ *      strip regex's '$' anchor, so the comment is never stripped and the
+ *      self-closing check never sees the line actually end in "END".
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import {
+    ClassMemberResolver,
+    scanClassBodyForMember,
+    scanClassBodyForAllMembers,
+    selectBestMemberOverload,
+} from '../utils/ClassMemberResolver';
+
+let tmpDir: string;
+
+function countParams(line: string): number {
+    const match = line.match(/PROCEDURE\s*\(([^)]*)\)/i);
+    if (!match || !match[1].trim()) return 0;
+    let depth = 0, count = 0;
+    for (const char of match[1]) {
+        if (char === '(') depth++;
+        else if (char === ')') depth--;
+        else if (char === ',' && depth === 0) count++;
+    }
+    return count + 1;
+}
+
+suite('ClassMemberResolver — self-closing nested GROUP with attrs/period terminator', () => {
+
+    suiteSetup(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scr_selfclose_'));
+
+        // OuterClass — a bare multi-line GROUP first (sanity baseline), then a
+        // self-closing single-line GROUP with attributes AND the "END" terminator,
+        // then the same shape with the period terminator, then a real member.
+        fs.writeFileSync(path.join(tmpDir, 'OuterClass.inc'), [
+            'OuterClass CLASS',
+            'MultiLineGroup     GROUP',
+            'InnerField           LONG',
+            '                   END',
+            'AttrEndGroup       GROUP(SmallType),DIM(2) END',
+            'AttrPeriodGroup    GROUP(SmallType),DIM(2).',
+            'AfterGroups        PROCEDURE(),LONG',
+            'END',
+        ].join('\n'));
+    });
+
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    test('scanClassBodyForMember finds a member declared after a same-line "attrs END" self-closing GROUP', () => {
+        const result = scanClassBodyForMember(
+            path.join(tmpDir, 'OuterClass.inc'),
+            'OuterClass', 'AfterGroups', undefined, 'CLASS',
+            countParams, selectBestMemberOverload
+        );
+        assert.ok(result, 'Should find AfterGroups past the self-closing GROUP forms');
+        assert.ok(result!.type.toUpperCase().includes('PROCEDURE'));
+    });
+
+    test('scanClassBodyForAllMembers enumerates the member declared after both self-closing GROUP forms', () => {
+        const results = scanClassBodyForAllMembers(
+            path.join(tmpDir, 'OuterClass.inc'),
+            'OuterClass', 'CLASS'
+        );
+        const names = results.map(r => r.name);
+        assert.ok(names.includes('AfterGroups'), `Expected AfterGroups in [${names.join(', ')}]`);
+    });
+
+    test('scanClassBodyForAllMembers does NOT treat InnerField (inside the genuine multi-line GROUP) as a direct CLASS member', () => {
+        const results = scanClassBodyForAllMembers(
+            path.join(tmpDir, 'OuterClass.inc'),
+            'OuterClass', 'CLASS'
+        );
+        const names = results.map(r => r.name);
+        assert.ok(!names.includes('InnerField'), 'InnerField is nested inside MultiLineGroup, not a direct member');
+    });
+
+    test('ClassMemberResolver.findClassMemberInIncludes (the third scanner) finds a member past both self-closing GROUP forms', () => {
+        const doc = TextDocument.create(
+            `file:///${path.join(tmpDir, 'probe.clw').replace(/\\/g, '/')}`,
+            'clarion', 1,
+            `  INCLUDE('OuterClass.inc'),ONCE\n`
+        );
+        const resolver = new ClassMemberResolver();
+        const result = resolver.findClassMemberInIncludes('OuterClass', 'AfterGroups', doc);
+        assert.ok(result, 'Should find AfterGroups via the INCLUDE-file scanner');
+        assert.ok(result!.type.toUpperCase().includes('PROCEDURE'));
+    });
+
+    // ---------------------------------------------------------------------------
+    // CRLF pin — a self-closing GROUP with a trailing comment, on a file using
+    // Windows CRLF line endings. This is the shape that actually broke: splitting
+    // on a bare '\n' leaves a trailing '\r' on every line, and '\r' blocks the
+    // comment-strip regex's '$' anchor from ever being reached, so the comment is
+    // never stripped and the self-closing check never sees the line end in "END".
+    // An LF-only fixture would pass even under the OLD split('\n'), so this needs
+    // its own CRLF-joined fixture to actually pin the fix.
+    // ---------------------------------------------------------------------------
+    suite('CRLF file with a commented self-closing GROUP', () => {
+        let crlfDir: string;
+
+        suiteSetup(() => {
+            crlfDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scr_selfclose_crlf_'));
+            fs.writeFileSync(path.join(crlfDir, 'CrlfClass.inc'), [
+                'CrlfClass CLASS',
+                'AttrEndGroup       GROUP(SmallType),DIM(2) END  !trailing comment',
+                'AfterGroup         PROCEDURE(),LONG',
+                'END',
+            ].join('\r\n'));
+        });
+
+        suiteTeardown(() => {
+            try { fs.rmSync(crlfDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        test('scanClassBodyForMember finds the member past a commented self-closing GROUP on a CRLF file', () => {
+            const result = scanClassBodyForMember(
+                path.join(crlfDir, 'CrlfClass.inc'),
+                'CrlfClass', 'AfterGroup', undefined, 'CLASS',
+                countParams, selectBestMemberOverload
+            );
+            assert.ok(result, 'Should find AfterGroup past the commented self-closing GROUP on a CRLF file');
+        });
+
+        test('ClassMemberResolver.findClassMemberInIncludes finds the member past a commented self-closing GROUP on a CRLF file', () => {
+            const doc = TextDocument.create(
+                `file:///${path.join(crlfDir, 'probe.clw').replace(/\\/g, '/')}`,
+                'clarion', 1,
+                `  INCLUDE('CrlfClass.inc'),ONCE\n`
+            );
+            const resolver = new ClassMemberResolver();
+            const result = resolver.findClassMemberInIncludes('CrlfClass', 'AfterGroup', doc);
+            assert.ok(result, 'Should find AfterGroup via the INCLUDE-file scanner on a CRLF file');
+        });
+    });
+});

--- a/server/src/test/MethodOverloadResolver.SelfClosingNestedGroup.test.ts
+++ b/server/src/test/MethodOverloadResolver.SelfClosingNestedGroup.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression coverage for MethodOverloadResolver.gatherIncludeMethodDeclarations —
+ * the fourth sibling scanner sharing the class-body self-closing-GROUP bug also
+ * covered (for the other three scanners) in
+ * ClassMemberResolver.SelfClosingNestedGroup.test.ts.
+ *
+ * Before this fix, this scanner had NO nesting-depth tracking at all: it broke
+ * the whole scan on the very first bare "END" line after the CLASS header,
+ * making every method in any class that declares an inline GROUP/QUEUE/RECORD
+ * member before its methods unreachable via this path. Once nesting-depth
+ * tracking was added, a SELF-CLOSING single-line member (e.g.
+ * "Foo GROUP(Type),DIM(2) END", or the period form "...,DIM(2).") still needed
+ * its own net-no-op recognition — otherwise it permanently leaks the depth
+ * counter exactly like the unclosed-multi-line case did.
+ *
+ * Two failure modes are covered here:
+ *   1. Attributes between the type argument and the terminator (both the END
+ *      and period spellings).
+ *   2. A trailing comment on a CRLF-line-ended file — splitting on a bare '\n'
+ *      leaves every line ending in '\r', which silently defeats the comment-
+ *      strip regex's '$' anchor, so the comment is never stripped and the
+ *      self-closing check never sees the line actually end in "END". An
+ *      LF-only fixture would pass even under the OLD split('\n'), so this
+ *      needs its own CRLF-joined fixture to actually pin the fix.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MethodOverloadResolver } from '../utils/MethodOverloadResolver';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function makeDoc(dir: string, filename: string, content: string): TextDocument {
+    const uri = `file:///${path.join(dir, filename).replace(/\\/g, '/')}`;
+    return TextDocument.create(uri, 'clarion', 1, content);
+}
+
+suite('MethodOverloadResolver — self-closing nested GROUP with attrs/period terminator', () => {
+    const tokenCache = TokenCache.getInstance();
+    let resolver: MethodOverloadResolver;
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mor_selfclose_'));
+
+        // OuterClass — a bare multi-line GROUP first (sanity baseline), then a
+        // self-closing single-line GROUP with attributes AND the "END" terminator,
+        // then the same shape with the period terminator, then a real method.
+        fs.writeFileSync(path.join(tmpDir, 'OuterClass.inc'), [
+            'OuterClass CLASS',
+            'MultiLineGroup     GROUP',
+            'InnerField           LONG',
+            '                   END',
+            'AttrEndGroup       GROUP(SmallType),DIM(2) END',
+            'AttrPeriodGroup    GROUP(SmallType),DIM(2).',
+            'AfterGroups        PROCEDURE(),LONG',
+            'END',
+        ].join('\n'));
+    });
+
+    suiteTeardown(() => {
+        tokenCache.clearAllTokens();
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    setup(() => {
+        resolver = new MethodOverloadResolver();
+    });
+
+    test('finds a method declared after a same-line "attrs END" self-closing GROUP', () => {
+        const doc = makeDoc(tmpDir, 'probe1.clw', `  INCLUDE('OuterClass.inc'),ONCE\n`);
+        const tokens = tokenCache.getTokens(doc);
+        const result = resolver.findMethodDeclaration('OuterClass', 'AfterGroups', doc, tokens);
+        assert.ok(result, 'Should find AfterGroups past the self-closing GROUP forms');
+        assert.ok(result!.signature.toUpperCase().includes('PROCEDURE'));
+    });
+
+    test('does NOT treat InnerField (inside the genuine multi-line GROUP) as a direct CLASS method', () => {
+        const doc = makeDoc(tmpDir, 'probe2.clw', `  INCLUDE('OuterClass.inc'),ONCE\n`);
+        const tokens = tokenCache.getTokens(doc);
+        const result = resolver.findMethodDeclaration('OuterClass', 'InnerField', doc, tokens);
+        assert.strictEqual(result, null, 'InnerField is nested inside MultiLineGroup, not a direct CLASS member');
+    });
+
+    // ---------------------------------------------------------------------------
+    // CRLF pin — a self-closing GROUP with a trailing comment, on a file using
+    // Windows CRLF line endings.
+    // ---------------------------------------------------------------------------
+    suite('CRLF file with a commented self-closing GROUP', () => {
+        let crlfDir: string;
+
+        suiteSetup(() => {
+            crlfDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mor_selfclose_crlf_'));
+            fs.writeFileSync(path.join(crlfDir, 'CrlfClass.inc'), [
+                'CrlfClass CLASS',
+                'AttrEndGroup       GROUP(SmallType),DIM(2) END  !trailing comment',
+                'AfterGroup         PROCEDURE(),LONG',
+                'END',
+            ].join('\r\n'));
+        });
+
+        suiteTeardown(() => {
+            try { fs.rmSync(crlfDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        test('finds the method past a commented self-closing GROUP on a CRLF file', () => {
+            const doc = makeDoc(crlfDir, 'probe.clw', `  INCLUDE('CrlfClass.inc'),ONCE\n`);
+            const tokens = tokenCache.getTokens(doc);
+            const result = resolver.findMethodDeclaration('CrlfClass', 'AfterGroup', doc, tokens);
+            assert.ok(result, 'Should find AfterGroup past the commented self-closing GROUP on a CRLF file');
+        });
+    });
+});

--- a/server/src/utils/ClassMemberResolver.ts
+++ b/server/src/utils/ClassMemberResolver.ts
@@ -79,10 +79,17 @@ export function scanClassBodyForAllMembers(
 
                 if (/^(GROUP|QUEUE|RECORD)\b/i.test(stripped) ||
                     /^\w+\s+(GROUP|QUEUE|RECORD)\b/i.test(stripped)) {
-                    nestDepth++;
+                    // Self-closing single-line form (e.g. "Foo GROUP(Type),DIM(2) END" or the
+                    // period form "...,DIM(2).") is a net no-op. Checking end-of-line independently
+                    // of the opening match — rather than one regex trying to capture attributes and
+                    // terminator together — avoids the attrs-swallow-terminator failure mode; "."
+                    // is fully interchangeable with END for closing any Clarion structure.
+                    if (!/(\bEND|\.)\s*$/i.test(stripped)) {
+                        nestDepth++;
+                    }
                     continue;
                 }
-                if (/^END\s*$/i.test(stripped)) {
+                if (/^(END|\.)\s*$/i.test(stripped)) {
                     if (nestDepth > 0) { nestDepth--; continue; }
                     break;
                 }
@@ -163,8 +170,12 @@ export function scanClassBodyForMember(
 
                 if (/^(GROUP|QUEUE|RECORD)\b/i.test(stripped) ||
                     /^\w+\s+(GROUP|QUEUE|RECORD)\b/i.test(stripped)) {
-                    nestDepth++;
-                } else if (/^END\s*$/i.test(stripped)) {
+                    // Self-closing single-line form is a net no-op (see scanClassBodyForAllMembers
+                    // for the full rationale — same attrs-swallow-terminator hazard, same fix).
+                    if (!/(\bEND|\.)\s*$/i.test(stripped)) {
+                        nestDepth++;
+                    }
+                } else if (/^(END|\.)\s*$/i.test(stripped)) {
                     if (nestDepth > 0) { nestDepth--; continue; }
                     break;
                 }
@@ -442,18 +453,21 @@ export class ClassMemberResolver {
             if (resolvedPath) {
                 logger.info(`Resolved to: ${resolvedPath}`);
                 const includeContent = fs.readFileSync(resolvedPath, 'utf8');
-                const includeLines = includeContent.split('\n');
-                
+                // Split on both line-ending styles — a bare '\n' split leaves a trailing '\r' on
+                // every line of a CRLF file, which silently breaks the comment-strip regex below
+                // (its '$' anchor can never reach past a leftover '\r').
+                const includeLines = includeContent.split(/\r?\n/);
+
                 // Find the class/queue/group structure
                 for (let j = 0; j < includeLines.length; j++) {
                     const includeLine = includeLines[j];
                     const classMatch = includeLine.match(new RegExp(`^${className}\\s+(CLASS|QUEUE|GROUP)`, 'i'));
                     if (classMatch) {
                         logger.info(`Found class ${className} in INCLUDE at line ${j}`);
-                        
+
                         // Collect all matching members for overload resolution
                         const candidates: { type: string; line: number; paramCount: number }[] = [];
-                        
+
                         // Find all members with this name
                         // Track nesting depth so nested GROUP/QUEUE/RECORD ENDs don't
                         // terminate the scan prematurely
@@ -462,12 +476,15 @@ export class ClassMemberResolver {
                             const memberLine = includeLines[k];
                             const stripped = memberLine.replace(/\s*!.*$/, '').trim(); // strip comments
 
-                            // Detect nested scope openers (GROUP/QUEUE/RECORD as type keyword)
-                            if (/\b(GROUP|QUEUE|RECORD)\b/i.test(stripped) && !stripped.match(/^\s*END\s*$/i)) {
+                            // Detect nested scope openers (GROUP/QUEUE/RECORD as type keyword), but
+                            // skip a self-closing single-line form (e.g. "Foo GROUP(Type),DIM(2) END"
+                            // or the period form) — a net no-op, not an unclosed nested scope. "." is
+                            // fully interchangeable with END for closing any Clarion structure.
+                            if (/\b(GROUP|QUEUE|RECORD)\b/i.test(stripped) && !/(\bEND|\.)\s*$/i.test(stripped)) {
                                 nestDepth++;
                             }
 
-                            if (/^\s*END\s*$/i.test(stripped)) {
+                            if (/^(END|\.)\s*$/i.test(stripped)) {
                                 if (nestDepth > 0) {
                                     nestDepth--;
                                     continue;

--- a/server/src/utils/MethodOverloadResolver.ts
+++ b/server/src/utils/MethodOverloadResolver.ts
@@ -561,15 +561,43 @@ export class MethodOverloadResolver {
             if (!resolvedPath) continue;
 
             const includeContent = fs.readFileSync(resolvedPath, 'utf8');
-            const includeLines = includeContent.split('\n');
+            // Split on both line-ending styles — a bare '\n' split leaves a trailing '\r' on
+            // every line of a CRLF file, which silently breaks the comment-strip regex below
+            // (its '$' anchor can never reach past a leftover '\r').
+            const includeLines = includeContent.split(/\r?\n/);
 
             for (let j = 0; j < includeLines.length; j++) {
                 const classMatch = includeLines[j].match(new RegExp(`^${className}\\s+CLASS`, 'i'));
                 if (!classMatch) continue;
 
+                // Track nesting depth so an inline GROUP/QUEUE/RECORD class member's OWN
+                // "END" doesn't prematurely terminate the scan of the enclosing CLASS body
+                // (mirrors the established pattern in ClassMemberResolver.scanClassBodyForMember).
+                let nestDepth = 0;
                 for (let k = j + 1; k < includeLines.length; k++) {
                     const methodLine = includeLines[k];
-                    if (methodLine.match(/^\s*END\s*$/i) || methodLine.match(/^END\s*$/i)) break;
+                    const stripped = methodLine.replace(/!.*$/, '').trim();
+
+                    if (/^(GROUP|QUEUE|RECORD)\b/i.test(stripped) ||
+                        /^\w+\s+(GROUP|QUEUE|RECORD)\b/i.test(stripped)) {
+                        // Self-closing single-line form (e.g. "Foo GROUP(Type),DIM(2) END" or the
+                        // period form "...,DIM(2).") is a net no-op. Attributes between the type arg
+                        // and the terminator are legal (GitHub #97 in ClarionAssistant's CodeGraph hit
+                        // the same shape: a combined regex trying to capture attrs+terminator together
+                        // let the attrs alternative swallow the terminator). Checking end-of-line
+                        // independently of the opening match — as done here — sidesteps that class of
+                        // bug entirely, but still must recognize BOTH terminator spellings: "." is fully
+                        // interchangeable with END for closing any Clarion structure.
+                        if (!/(\bEND|\.)\s*$/i.test(stripped)) {
+                            nestDepth++;
+                        }
+                        continue;
+                    }
+                    if (/^(END|\.)\s*$/i.test(stripped)) {
+                        if (nestDepth > 0) { nestDepth--; continue; }
+                        break;
+                    }
+                    if (nestDepth > 0) continue;
 
                     const methodMatch = methodLine.match(new RegExp(`^\\s*(${methodName})\\s+(?:PROCEDURE|FUNCTION)`, 'i'));
                     if (methodMatch) {


### PR DESCRIPTION
# fix: class-body scanners no longer leak nesting depth on a same-line self-closing GROUP/QUEUE/RECORD

## Summary

- Four independent class-body scanners (`ClassMemberResolver.scanClassBodyForAllMembers`, `ClassMemberResolver.scanClassBodyForMember`, the inline scanner inside `ClassMemberResolver.findClassMemberInIncludes`, and `MethodOverloadResolver.gatherIncludeMethodDeclarations`) unconditionally treated an inline `GROUP`/`QUEUE`/`RECORD` class member as *opening* a nested scope — even when it closes itself on the same line (`Foo GROUP(Type),DIM(2) END` or the period form `...,DIM(2).`). With no matching close, the nesting-depth counter leaked permanently, silently hiding every method/property declared afterward in that class.
- `MethodOverloadResolver.gatherIncludeMethodDeclarations` additionally had **zero** nesting-depth tracking at all before this PR — it broke the whole scan on the first bare `END` line after the CLASS header.
- Two of the four scanners split file content on a bare `'\n'`, leaving every line of a CRLF file ending in `\r` — which silently defeats the comment-strip regex's `$` anchor, so a self-closing line *with a trailing comment* never got recognized as self-closing.

Declaring an inline `GROUP`/`QUEUE`/`RECORD` member — often with `DIM(...)` or `PRE(...)` attributes — is idiomatic, common Clarion (config groups, mode flags, cached sub-structures). Any class shaped this way silently lost hover/F12/go-to-implementation navigation for its ENTIRE remaining member list, not a partial degradation.

## Reproduction

Given a class declared in an `.inc` file like this:

```clarion
OuterClass CLASS
AttrGroup       GROUP(SomeType),DIM(2) END   ! self-closing single-line member
AfterGroup      PROCEDURE(),LONG
END
```

- **Before this fix:** F12 / hover / go-to-implementation on `AfterGroup` — from either its implementation elsewhere in a `.clw` file, or from any call site — resolves to nothing. So does every other method declared anywhere after `AttrGroup` in the class, no matter how many there are.
- **After this fix:** navigation to `AfterGroup`'s declaration works correctly, as it would if `AttrGroup` weren't there at all.

The same failure occurs with the period-terminator form (`GROUP(SomeType),DIM(2).`), and — on a CRLF-line-ended file specifically — even with a trailing comment on the self-closing line (`GROUP(SomeType),DIM(2) END  !some comment`), which is the shape that also exposed the separate CRLF/`'\n'`-split bug described above.

Both terminator spellings are confirmed valid, compilable Clarion — verified with a real Clarion compile (0 warnings, 0 errors) of both the `,DIM(2) END` and `,DIM(2).` forms, not just assumed.

## Fix approach

Each scanner now checks two things independently rather than one combined capture:
1. Does this line *open* a `GROUP`/`QUEUE`/`RECORD` member (start-of-line shape)?
2. Does this (comment-stripped) line *also end* in `END` or `.` (both are valid Clarion structure terminators)?

If both are true, it's a net no-op (self-closing), not an unclosed nested scope. This mirrors the fix already shipped for the identical failure shape in a sibling codebase (ClarionAssistant's CodeGraph indexer, their issue #97) — checking start/end shape independently, rather than one regex trying to capture attributes and the terminator together, avoids the "attributes swallow the terminator" failure mode entirely.

The two scanners splitting on bare `'\n'` now split on `/\r?\n/` instead.

## Testing

- Two new test files, each covering: a genuine multi-line GROUP (baseline — confirms nested members are still correctly excluded), a same-line self-closing GROUP with attributes ending in `END`, the same with the period terminator, and a CRLF-line-ended fixture with a trailing comment on the self-closing line (pins the second bug specifically — an LF-only fixture would pass even under the old `split('\n')`).
- Full existing suite (2132 tests) passes with zero regressions.

## Notes

- No behavior change for the common case (a class with no nested GROUP/QUEUE/RECORD members before its methods) — traced through all four scanners to confirm.
- `MethodOverloadResolver.gatherIncludeMethodDeclarations`'s zero-depth-tracking gap and this self-closing fix were found and fixed together in one investigation; splitting them into separate PRs seemed like unnecessary churn since both live in the same tight loop and were verified together.
