### PR TITLE
F12 on a parameter can jump to an earlier parameter whose name it's a prefix of

### DIFF
--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -201,7 +201,13 @@ export class SymbolFinderService {
         
         const paramString = match[1];
         const params = paramString.split(',');
-        
+        // Column tracking so indexOf() below resolves each parameter's OWN position,
+        // not the first line-wide substring match — without this, searching for a
+        // parameter whose name is a prefix of an earlier-declared parameter's name
+        // (e.g. "pPar" vs an earlier "pParName") incorrectly resolves to that earlier
+        // parameter's position instead of its own.
+        let currentColumn = procedureLine.indexOf('(') + 1;
+
         for (const param of params) {
             const trimmedParam = param.trim();
             // Strip optional-parameter angle brackets: <Key K> → Key K
@@ -228,7 +234,7 @@ export class SymbolFinderService {
                         type: TokenType.Variable,
                         value: paramName,
                         line: scopeToken.line,
-                        start: procedureLine.indexOf(paramName),
+                        start: procedureLine.indexOf(paramName, currentColumn),
                         maxLabelLength: 0
                     };
                     
@@ -250,8 +256,9 @@ export class SymbolFinderService {
                     };
                 }
             }
+            currentColumn += param.length + 1; // +1 for comma
         }
-        
+
         logger.info(`❌ Parameter "${word}" not found`);
         return null;
     }


### PR DESCRIPTION
## Summary

Fixes F12 (go to definition) landing on the wrong parameter when a parameter's name is a textual prefix of an earlier-declared parameter's name in the same procedure/method signature.

## Root cause

`SymbolFinderService.findParameter(word, document, scopeToken)` resolves a matched parameter's column position via:

```ts
start: procedureLine.indexOf(paramName),
```

`indexOf` with no starting offset always searches from the beginning of the signature line. Given a signature like:

```
PROCEDURE( LONG pIssuer, STRING pTitle, *STRING pParName, *LONG pPar, *LONG pPad )
```

searching for `pPar` (the 4th parameter) via `indexOf("pPar")` finds the *first* textual occurrence of that substring — which is the start of `pParName` (the 3rd parameter), since "pParName" begins with "pPar". F12 on a usage of `pPar` inside the procedure body therefore jumped to `pParName`'s position instead of `pPar`'s own.

This function is called from `DefinitionProvider.provideDefinition` and takes priority over (returns before) a second, already-correct implementation of similar logic in `DefinitionProvider.findParameterDefinition` — that function already tracks a running column offset, but is effectively unreachable dead code for this scenario since `findParameter` answers first whenever the containing scope has an enclosing procedure.

## Fix

Track a running column offset (`currentColumn`), initialized right after the opening `(`, advanced by each raw comma-split segment's length (`param.length + 1` for the comma) after every loop iteration — regardless of whether that iteration matched. Pass `currentColumn` as `indexOf`'s second argument so the search only looks at-or-after the current parameter's own position, never before it. This mirrors the already-correct accumulator pattern in the sibling `DefinitionProvider.findParameterDefinition`.

## Verification

- Reproduced against a real production Clarion signature with two independent collisions in different procedures of the same file:
  - `pPar` vs an earlier `pParName` — before: resolved to `pParName`'s column; after: resolves to `pPar`'s own column.
  - `pPar` vs an earlier `pPartnersName` (different procedure, same collision shape) — same before/after result.
- Confirmed non-colliding parameters (`pIssuer`, `pTitle`, `pParName` itself, `pPad`) still resolve to their own correct positions — no regression.
- Root-caused via live debugging against the real deployed LSP server: verbatim-extracted and directly executed the compiled function in isolation to rule out a stale-build explanation, then added temporary logger instrumentation to trace the actual live call path and confirm `SymbolFinderService.findParameter` (not the other, correctly-implemented `findParameterDefinition`) is what answers this request.
- Independent code-reviewer pass confirmed: offset tracking has no off-by-one (traced against the exact example signature above), unconditional advancement is required and safe (no drift possible since `params` derives character-for-character from the same regex-captured `paramString` used to build `procedureLine`), no other unbounded `indexOf(paramName)`-shaped call exists elsewhere in the file, the non-collision case is unchanged, and the pre-existing `procedureLine.indexOf('(')` origin point is safe (a qualified label can't contain `(`, so it always finds the signature's actual opening paren).

## Out of scope

This fix only addresses `SymbolFinderService.findParameter`. The sibling `DefinitionProvider.findParameterDefinition` already had the correct accumulator pattern and needed no change — left as-is (still effectively dead code for this call path, not touched here to keep this fix minimal and focused).
