### PR TITLE
fix(hover): TOOLBAR-as-label and NULL-as-constant hover misclassification

### DIFF
--- a/server/src/providers/hover/HoverContextBuilder.ts
+++ b/server/src/providers/hover/HoverContextBuilder.ts
@@ -32,6 +32,7 @@ export interface HoverContext {
     isInWindowContext: boolean;
     isInClassBlock: boolean;
     hasLabelBefore: boolean;
+    isFollowedByIdentifier: boolean;
 }
 
 /**
@@ -93,6 +94,17 @@ export class HoverContextBuilder {
             t.start < wordRange.start.character
         );
         
+        // Check if the word is immediately followed (after whitespace) by ANOTHER identifier
+        // — e.g. "Toolbar              ToolbarClass" (a plain label declaration with an
+        // explicit type). A genuine structure/control keyword used bare (e.g.
+        // "TOOLBAR,USE(?Toolbar1)") is always followed by '(', ',', '!' (comment) or
+        // end-of-line — never by a second bare identifier. This distinguishes "this word
+        // IS the label" from "this word is a real keyword/control reference", mirroring
+        // the same fix already applied in ClarionTokenizer.ts (PR #378),
+        // ModernEmbeditorDiagnostics.cs, and clarion-language.js.
+        const afterWord = line.slice(wordRange.end.character);
+        const isFollowedByIdentifier = /^\s*[A-Za-z_]/.test(afterWord);
+
         // Check if we're in a WINDOW/REPORT/APPLICATION structure (indicates control context)
         const isInWindowContext = documentStructure.isInWindowStructure(position.line);
         
@@ -121,7 +133,8 @@ export class HoverContextBuilder {
             isInMapBlock,
             isInWindowContext,
             isInClassBlock,
-            hasLabelBefore
+            hasLabelBefore,
+            isFollowedByIdentifier
         };
     }
 }

--- a/server/src/providers/hover/HoverFormatter.ts
+++ b/server/src/providers/hover/HoverFormatter.ts
@@ -861,19 +861,30 @@ export class HoverFormatter {
         };
     }
 
-    /** Returns a display noun for the declaration type (e.g. CLASS → "class", GROUP → "group"). */
+    /**
+     * Returns a display noun for the declaration type (e.g. CLASS → "class", GROUP → "group").
+     *
+     * Uses a word-boundary check (\b), NOT .startsWith() — a custom class/type name that
+     * happens to start with one of these keywords as a text prefix (ToolbarClass,
+     * WindowManager — the ABC framework's OWN base window-manager class, used in almost
+     * every "ThisWindow CLASS(WindowManager)" declaration — ReportGenerator, GroupBox, …)
+     * would otherwise match by pure substring coincidence and get the wrong noun. \b
+     * correctly still matches the legitimate attribute-list forms this is meant to catch
+     * (e.g. "CLASS(WindowManager)", "GROUP,OVER(x)") since '(' and ',' are non-word
+     * characters, so a boundary exists right after the keyword either way.
+     */
     private getTypeNoun(type: string): string {
         const upper = type.trimStart().toUpperCase();
-        if (upper.startsWith('CLASS'))     return 'class';
-        if (upper.startsWith('GROUP'))     return 'group';
-        if (upper.startsWith('QUEUE'))     return 'queue';
-        if (upper.startsWith('FILE'))      return 'file';
-        if (upper.startsWith('VIEW'))      return 'view';
-        if (upper.startsWith('REPORT'))    return 'report';
-        if (upper.startsWith('WINDOW'))    return 'window';
-        if (upper.startsWith('MENU'))      return 'menu';
-        if (upper.startsWith('TOOLBAR'))   return 'toolbar';
-        if (upper.startsWith('INTERFACE')) return 'interface';
+        if (/^CLASS\b/.test(upper))     return 'class';
+        if (/^GROUP\b/.test(upper))     return 'group';
+        if (/^QUEUE\b/.test(upper))     return 'queue';
+        if (/^FILE\b/.test(upper))      return 'file';
+        if (/^VIEW\b/.test(upper))      return 'view';
+        if (/^REPORT\b/.test(upper))    return 'report';
+        if (/^WINDOW\b/.test(upper))    return 'window';
+        if (/^MENU\b/.test(upper))      return 'menu';
+        if (/^TOOLBAR\b/.test(upper))   return 'toolbar';
+        if (/^INTERFACE\b/.test(upper)) return 'interface';
         return 'variable';
     }
 }

--- a/server/src/providers/hover/HoverRouter.ts
+++ b/server/src/providers/hover/HoverRouter.ts
@@ -54,7 +54,7 @@ export class HoverRouter {
      * Route hover request to appropriate resolver
      */
     async route(context: HoverContext): Promise<Hover | null> {
-        const { word, wordRange, line, document, position, tokens, documentStructure, isInMapBlock, isInWindowContext, isInClassBlock, hasLabelBefore } = context;
+        const { word, wordRange, line, document, position, tokens, documentStructure, isInMapBlock, isInWindowContext, isInClassBlock, hasLabelBefore, isFollowedByIdentifier } = context;
 
         // Per-step timing — the outer HoverProvider trace buckets this whole call as
         // one `router` stage; this names WHICH router step is slow so the ~700ms
@@ -121,7 +121,7 @@ export class HoverRouter {
             }
 
             // 8. Handle data types and controls
-            const symbolHover = this.symbolResolver.resolve(word, { hasLabelBefore, isInWindowContext });
+            const symbolHover = this.symbolResolver.resolve(word, { hasLabelBefore, isInWindowContext, isFollowedByIdentifier });
             mark('symbol');
             if (symbolHover) return symbolHover;
 
@@ -460,8 +460,28 @@ export class HoverRouter {
             return null;
         }
 
-        logger.info(`Found built-in function: ${word}`);
         const signatures = this.builtinService.getSignatures(word);
+
+        // Some built-ins (NULL is the prototypical case) are legitimately BOTH a function
+        // call (NULL(field) -> LONG) and a bare constant/keyword (a &= NULL, IF a &= NULL).
+        // Showing the function-call signature card for the bare usage is misleading — only
+        // render it when the word is actually immediately followed by '(' (skipping
+        // whitespace); otherwise fall back to a plain constant-style card using the same
+        // description text (clarion-builtins.json descriptions already cover both meanings).
+        const isActualCall = /^\s*\(/.test(line.slice(wordRange.end.character));
+        if (!isActualCall) {
+            logger.info(`Word ${word} matches a built-in but isn't called (no '(' follows) - showing constant hover`);
+            const doc = signatures[0]?.documentation;
+            const description = typeof doc === 'string' ? doc : (doc?.value ?? '');
+            return this.formatter.formatKeyword({
+                name: word.toUpperCase(),
+                category: 'Built-in constant',
+                description,
+                syntax: word.toUpperCase()
+            });
+        }
+
+        logger.info(`Found built-in function: ${word}`);
         const paramCount = this.countFunctionParameters(line, word, wordRange, document);
         logger.info(`Parameter count in call: ${paramCount}`);
 

--- a/server/src/providers/hover/SymbolHoverResolver.ts
+++ b/server/src/providers/hover/SymbolHoverResolver.ts
@@ -12,6 +12,7 @@ logger.setLevel("error");
 export interface HoverContext {
     hasLabelBefore: boolean;
     isInWindowContext: boolean;
+    isFollowedByIdentifier: boolean;
 }
 
 /**
@@ -29,6 +30,19 @@ export class SymbolHoverResolver {
      * Returns first matching hover or null
      */
     resolve(word: string, context: HoverContext): Hover | null {
+        // A bare word immediately followed by another identifier is a label with an
+        // explicit type ("Toolbar              ToolbarClass"), never a real
+        // control/data-type keyword reference — those always take '(', ',', '!' or
+        // end-of-line right after. checkDataType/checkControl below are pure name
+        // lookups with no positional awareness, so without this guard a custom class
+        // whose name happens to start with a control's name (ToolbarClass, MenuHandler,
+        // …) always wins the control lookup by elimination once the type fails the
+        // (much narrower) built-in-data-type check. Skip straight to downstream
+        // variable resolution instead of guessing.
+        if (context.isFollowedByIdentifier) {
+            return null;
+        }
+
         const checkDataTypeFirst = context.hasLabelBefore || !context.isInWindowContext;
 
         if (checkDataTypeFirst) {


### PR DESCRIPTION
## Summary

Two independent hover-resolution bugs found while chasing the same underlying pattern as #378 (structure keyword used as a plain label), in code paths that don't touch `ClarionTokenizer.ts` at all — plus a follow-up fix to a latent version of the same class of bug found while verifying the first one.

1. **`SymbolHoverResolver`**: a bare word immediately followed by another identifier (e.g. `Toolbar              ToolbarClass` — the ABC toolbar template's own instance-variable declaration) is a label with an explicit custom type, never a real control/data-type reference. `checkDataType`/`checkControl` are pure name lookups with no positional awareness, so a custom class name that happens to start with a control's name (`ToolbarClass` vs `TOOLBAR`) always won the control lookup by elimination once the (much narrower) built-in-data-type check failed. Hovering over `Toolbar` showed the built-in TOOLBAR control's documentation instead of describing the variable.

   Fix: new `isFollowedByIdentifier` context flag (computed in `HoverContextBuilder`, same tight-lookahead shape as the other fixes in this family) short-circuits `SymbolHoverResolver.resolve` so downstream variable resolution takes over instead of guessing.

2. **`HoverRouter.handleBuiltin`**: `NULL` (and any similarly dual-purpose built-in) is legitimately both a function call (`NULL(field) -> LONG`) and a bare constant/keyword (`a &= NULL`, `IF a &= NULL`). The function-call signature card was rendered unconditionally whenever the word matched a built-in name, regardless of whether it was actually being called.

   Fix: only render the function-signature card when the word is immediately followed by `(`; otherwise fall back to a simple constant-style card using the same `clarion-builtins.json` description text (which already documents both meanings).

3. **Follow-up — `HoverFormatter.getTypeNoun`**: once (1) was fixed, hovering over `Toolbar` correctly fell through to variable-hover formatting, which exposed a third, previously-masked bug: `getTypeNoun` derived a display noun from the declared type text using `.startsWith()` instead of a word-boundary check, so `"ToolbarClass".startsWith("TOOLBAR")` matched and the hover showed "Local procedure toolbar" instead of "Local procedure variable". The same `.startsWith()` pattern was used for all nine other keyword checks in that function (`WINDOW`, `REPORT`, `GROUP`, `CLASS`, etc.) — a custom type literally named `WindowManager` (the ABC framework's own base window-manager class, used in almost every `ThisWindow CLASS(WindowManager)` declaration) would have hit the identical bug.

   Fix: all ten checks now use a `\b` word-boundary regex instead of `.startsWith()`.

## Test plan
- [x] `npx tsc -b` — clean compile after each commit
- [x] Full test suite: 2336 passing, 0 failing, 4 pending (pre-existing, unrelated) — re-verified after both commits
- [x] Manually verified via `lsp_hover` against a live Clarion window procedure containing `Toolbar ToolbarClass` and `a &= NULL` / `IF a &= NULL` usages, confirmed live in the running IDE after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
