### PR TITLE
fix(document-symbols): unbounded MAP/MODULE scan corrupting the outline

### DIFF
--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -1501,12 +1501,34 @@ export class DocumentStructure {
             }
         }
 
+        // ✅ Assign the structure's label from the preceding same-line token before any
+        // early return below. A structure that closes on the same line (endsOnSameLine,
+        // checked further down) used to return before label assignment ran, so single-line
+        // declarations like "fq QUEUE(FILE:Queue) END" never got their label ("fq") attached
+        // to the token — the outline showed a bare "QUEUE" node instead of "QUEUE (fq)".
+        const sameLine = this.tokensByLine.get(token.line) || [];
+        const structureIndex = sameLine.indexOf(token);
+        if (structureIndex > 0) {
+            const prevToken = sameLine[structureIndex - 1];
+            if (prevToken.type === TokenType.Label) {
+                token.label = prevToken.value;
+            } else if (
+                structureIndex === 1 &&
+                prevToken.type === TokenType.Variable &&
+                (token.value.toUpperCase() === 'LOOP' || token.value.toUpperCase() === 'ACCEPT')
+            ) {
+                // Issue #65: indented `Label LOOP` / `Label ACCEPT` inside CODE
+                // sections — the tokenizer only emits TokenType.Label at column 0,
+                // so an indented loop label arrives as a leading Variable. Promote
+                // it so BREAK <Label> / CYCLE <Label> can resolve to this loop.
+                token.label = prevToken.value;
+            }
+        }
+
         // ✅ Check if structure ends on the same line (single-line declaration)
         // Examples: "AnswerDateTime GROUP(DateTimeType)." or "MyGroup GROUP;END"
         // Also applies to single-line control flow: "IF condition THEN statement." or "IF x THEN y END"
         // Handles line continuation: "IF x THEN | \n statement."
-        const sameLine = this.tokensByLine.get(token.line) || [];
-        const structureIndex = sameLine.indexOf(token);
         let endsOnSameLine = false;
         let continuationLine = token.line;
         
@@ -1609,25 +1631,7 @@ export class DocumentStructure {
             if (DOCSTRUCT_TRACE) logger.info(`🔗 Structure ${token.value} at Line ${token.line} parented to procedure ${parentProcedure.value}`);
         }
 
-        // 🚀 PERFORMANCE: Use tokensByLine to find previous token
-        const lineTokens = this.tokensByLine.get(token.line) || [];
-        const tokenIndex = lineTokens.indexOf(token);
-        if (tokenIndex > 0) {
-            const prevToken = lineTokens[tokenIndex - 1];
-            if (prevToken.type === TokenType.Label) {
-                token.label = prevToken.value;
-            } else if (
-                tokenIndex === 1 &&
-                prevToken.type === TokenType.Variable &&
-                (token.value.toUpperCase() === 'LOOP' || token.value.toUpperCase() === 'ACCEPT')
-            ) {
-                // Issue #65: indented `Label LOOP` / `Label ACCEPT` inside CODE
-                // sections — the tokenizer only emits TokenType.Label at column 0,
-                // so an indented loop label arrives as a leading Variable. Promote
-                // it so BREAK <Label> / CYCLE <Label> can resolve to this loop.
-                token.label = prevToken.value;
-            }
-        }
+        // (label already assigned above, before the endsOnSameLine early return)
         if (DOCSTRUCT_TRACE) logger.info(`🧱 Opened ${token.value} at Line ${token.line} ${token.label}`);
 
         // ✅ Extract structure prefix if present (PRE)

--- a/server/src/providers/ClarionDocumentSymbolProvider.ts
+++ b/server/src/providers/ClarionDocumentSymbolProvider.ts
@@ -414,22 +414,22 @@ export class ClarionDocumentSymbolProvider {
                 
                 // Special handling for MAP and MODULE structures
                 if (value.toUpperCase() === "MAP" || value.toUpperCase() === "MODULE") {
-                    // Look ahead for procedure declarations inside this structure
+                    // Look ahead for procedure declarations inside this structure.
+                    // Bound the scan with the structure's own finishesAt — already computed by the
+                    // tokenizer with correct nesting depth — instead of re-deriving the end here.
+                    // The previous approach accepted an END only if no Structure token had been seen
+                    // since: a nested MODULE inside a MAP (or any nested structure) is itself a
+                    // Structure token, so that condition could never become true again once one
+                    // appeared, and the scan ran unbounded through the rest of the file — mis-marking
+                    // later identifier-followed-by-paren tokens (e.g. WINDOW attributes like FONT(...),
+                    // VALUE(...), FROM(...)) as MAP/MODULE procedures.
                     let j = i + 1;
-                    let endFound = false;
                     let lastProcedureLine = -1; // Track the line of the last identified procedure
-                    
-                    while (j < tokens.length && !endFound) {
+                    const scanEndLine = finishesAt ?? line;
+
+                    while (j < tokens.length && tokens[j].line <= scanEndLine) {
                         const nextToken = tokens[j];
-                        
-                        // Stop if we hit an END statement for this structure
-                        if (nextToken.type === TokenType.EndStatement &&
-                            nextToken.line > line &&
-                            !tokens.slice(i+1, j).some(t => t.type === TokenType.Structure)) {
-                            endFound = true;
-                            break;
-                        }
-                        
+
                         // If we find a procedure declaration with PROCEDURE or FUNCTION keyword, mark it
                         if (nextToken.type === TokenType.Keyword &&
                             ProcedureUtils.isProcedureKeyword(nextToken.value)) {

--- a/server/src/test/DocumentSymbol.MapModuleLookahead382.test.ts
+++ b/server/src/test/DocumentSymbol.MapModuleLookahead382.test.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import { ClarionTokenizer } from '../ClarionTokenizer';
+import { ClarionDocumentSymbolProvider, ClarionDocumentSymbol } from '../providers/ClarionDocumentSymbolProvider';
+import { setServerInitialized } from '../serverState';
+
+/**
+ * #382 — the MAP/MODULE shorthand-procedure lookahead accepted an EndStatement as
+ * the structure's true end only if no Structure token had been seen since. A
+ * MODULE nested inside a MAP is itself a Structure token, so once one appeared the
+ * condition could never become true again and the scan ran unbounded through the
+ * rest of the file: any later identifier immediately followed by `(` — e.g. WINDOW
+ * attributes like FONT(...), VALUE(...), FROM(...) — was misclassified as a
+ * MAP/MODULE procedure and surfaced as a stray outline entry.
+ *
+ * The fix bounds the scan with the structure's own `finishesAt` (computed by the
+ * tokenizer with correct nesting depth). These tests pin exactly the trigger
+ * shape: a MAP containing a nested MODULE, followed by non-procedure tokens.
+ */
+suite('DocumentSymbols — MAP/MODULE lookahead is bounded (#382)', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true); // provideDocumentSymbols returns [] otherwise
+    });
+
+    function collectNames(symbols: ClarionDocumentSymbol[], out: string[] = []): string[] {
+        for (const s of symbols) {
+            out.push(s.name);
+            if (s.children?.length) collectNames(s.children, out);
+        }
+        return out;
+    }
+
+    function getSymbols(code: string): ClarionDocumentSymbol[] {
+        const tokens = new ClarionTokenizer(code).tokenize();
+        return new ClarionDocumentSymbolProvider().provideDocumentSymbols(tokens, 'test://mapmodule382.clw');
+    }
+
+    test('WINDOW attributes after a MAP with a nested MODULE are not misclassified as MAP procedures', () => {
+        const code = `
+  PROGRAM
+  MAP
+    MODULE('winapi')
+GetTickCount(),LONG,PASCAL
+    END
+Proc1(),LONG
+  END
+
+Main PROCEDURE
+Win WINDOW('Test'),AT(,,200,100),FONT('Segoe UI',9),GRAY
+      STRING('Hi'),AT(10,10),USE(?Str1),FONT('Arial',10)
+      LIST,AT(10,30),USE(?List1),FROM(SomeQueue)
+    END
+  CODE
+  RETURN
+`;
+        const symbols = getSymbols(code);
+        const names = collectNames(symbols);
+
+        // The old unbounded scan surfaced these attribute keywords as stray
+        // MAP-procedure outline entries once the nested MODULE poisoned the
+        // END-detection condition. Match the exact procedure-symbol shapes
+        // (`FONT`, `FONT(...)`, `FONT (...)`) — a WINDOW control's own symbol
+        // name can legitimately CONTAIN an attribute keyword (`GRAY STRING(...)`).
+        for (const stray of ['FONT', 'AT', 'USE', 'FROM']) {
+            assert.ok(!names.some(n => n === stray || n.startsWith(`${stray}(`) || n.startsWith(`${stray} (`)),
+                `WINDOW attribute "${stray}" must not appear as an outline symbol; got: ${JSON.stringify(names)}`);
+        }
+    });
+
+    test('real prototypes inside the MAP and nested MODULE still index', () => {
+        const code = `
+  PROGRAM
+  MAP
+    MODULE('winapi')
+GetTickCount(),LONG,PASCAL
+    END
+Proc1(),LONG
+  END
+
+Main PROCEDURE
+Win WINDOW('Test'),AT(,,200,100),FONT('Segoe UI',9),GRAY
+    END
+  CODE
+  RETURN
+`;
+        const symbols = getSymbols(code);
+        const names = collectNames(symbols);
+
+        assert.ok(names.some(n => n === 'GetTickCount' || n.startsWith('GetTickCount')),
+            `the nested MODULE's prototype must still be in the outline; got: ${JSON.stringify(names)}`);
+        assert.ok(names.some(n => n === 'Proc1' || n.startsWith('Proc1')),
+            `the MAP's own prototype must still be in the outline; got: ${JSON.stringify(names)}`);
+    });
+});


### PR DESCRIPTION
## Summary

Two document-symbol (outline) bugs found while auditing a real production `.clw` file's `Document Structure (outline)` panel for a `WINDOW` procedure — one of them significant beyond just that outline, since it silently corrupted symbol classification for the rest of the file once triggered.

1. **`ClarionDocumentSymbolProvider.ts` — unbounded MAP/MODULE lookahead.** When the parser hits a `MAP`/`MODULE` structure, it scans forward to find shorthand procedure declarations, accepting an `EndStatement` as the structure's true end only if no `Structure` token had been seen since. A `MODULE(...)` nested inside a `MAP` is itself a `Structure` token, so once one appeared, that condition could never become true again — the scan ran unbounded through the rest of the file. Any later identifier immediately followed by `(` (e.g. `WINDOW` attributes like `FONT(...)`, `VALUE(...)`, `FROM(...)`) got misclassified as a MAP/MODULE procedure and surfaced as a stray top-level outline entry, for every symbol after that point in the file — not just inside the offending `WINDOW`.

   Fix: bound the lookahead with the structure's own `finishesAt`, which the tokenizer already computes with correct nesting depth and which the rest of the codebase (e.g. `MapProcedureResolver`) already relies on — instead of re-deriving the end with the broken heuristic.

2. **`DocumentStructure.ts` — single-line structure declarations never got a label.** `handleStructureToken()` computes `endsOnSameLine` for structures that open and close on one line (e.g. `fq QUEUE(FILE:Queue) END`) and returns early — before reaching the code further down that reads the preceding same-line token and assigns `token.label`. Multi-line structures worked fine; any single-line `QUEUE`/`GROUP`/etc. never got its declared name attached, so the outline showed a bare `"QUEUE"` node instead of `"QUEUE (fq)"`.

   Fix: hoisted the label-assignment block (including the #65 LOOP/ACCEPT special case) to run before the `endsOnSameLine` check, and removed the now-dead duplicate copy that used to sit after the early return.

The detail-text change was split out of this PR per review — it's proposed separately as its own
look-and-feel issue with a ready patch.

   Disabled (commented out, not deleted, for a cheap revert if some consumer turns out to need it) the three call sites that set this text.

Checked git history before writing (1) and (2): both bugs were introduced together, from scratch, in the single commit that created `DocumentStructure.ts` (#280) — not a regression of previously-correct behavior, and no existing helper elsewhere in the codebase does the same job that could have been reused instead.

## Test plan
- [x] New regression test `DocumentSymbol.MapModuleLookahead382.test.ts` pinning the exact trigger shape — a MAP containing a nested MODULE, followed by a WINDOW: attribute keywords (`FONT`/`AT`/`USE`/`FROM`) must not appear as outline symbols. Fails against the unbounded scan (verified by reverting just the provider: the old code emits stray `FONT`, `FONT`, `FROM` entries), and a companion case confirms the MAP's own prototype and the nested MODULE's prototype still index.
- [x] `npx tsc -b` — clean compile
- [x] Full test suite: 2385 passing, 0 failing, 4 pending (pre-existing, unrelated), rebased onto `origin/version-1.0.2`
- [x] Verified directly against a real production `.clw` file (tokenizer + provider run outside the test suite): no stray `FONT`/`VALUE`/`FROM` entries, no bare `QUEUE` nodes (1488 symbols checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
