### PR TITLE
fix(hover): resolve GROUP(TypeName)/QUEUE(TypeName)/RECORD(TypeName) …

### DIFF
--- a/server/src/test/ChainedPropertyResolver.test.ts
+++ b/server/src/test/ChainedPropertyResolver.test.ts
@@ -93,4 +93,31 @@ suite('ClassMemberResolver.extractClassName', () => {
     test('LIKE alone (no parens) — returns null', () => {
         assert.strictEqual(ClassMemberResolver.extractClassName('LIKE'), null);
     });
+
+    test('GROUP(TypeName) — returns the referenced type name', () => {
+        assert.strictEqual(ClassMemberResolver.extractClassName('GROUP(ConnectionSettingsType)'), 'ConnectionSettingsType');
+    });
+
+    test('GROUP(TypeName) with trailing " END" (verbatim scanned declaration text) — real repro shape', () => {
+        // scanClassBodyForMember captures the whole line after the label, e.g.
+        // "Settings GROUP(ConnectionSettingsType) END" -> typeStr is
+        // "GROUP(ConnectionSettingsType) END", not just the paren part.
+        assert.strictEqual(ClassMemberResolver.extractClassName('GROUP(ConnectionSettingsType) END'), 'ConnectionSettingsType');
+    });
+
+    test('QUEUE(TypeName) — returns the referenced type name', () => {
+        assert.strictEqual(ClassMemberResolver.extractClassName('QUEUE(BaseQueueType)'), 'BaseQueueType');
+    });
+
+    test('RECORD(TypeName) — returns the referenced type name', () => {
+        assert.strictEqual(ClassMemberResolver.extractClassName('RECORD(SomeRecordType)'), 'SomeRecordType');
+    });
+
+    test('GROUP(TypeName) with trailing attributes after the paren', () => {
+        assert.strictEqual(ClassMemberResolver.extractClassName('GROUP(FooType),DIM(2)'), 'FooType');
+    });
+
+    test('GROUP keyword alone still returns null (unaffected by GROUP(TypeName) handling)', () => {
+        assert.strictEqual(ClassMemberResolver.extractClassName('GROUP'), null);
+    });
 });

--- a/server/src/utils/ClassMemberResolver.ts
+++ b/server/src/utils/ClassMemberResolver.ts
@@ -874,6 +874,15 @@ export class ClassMemberResolver {
         const likeMatch = name.match(/^LIKE\s*\(\s*([\w:]+)\s*\)/i);
         if (likeMatch) return likeMatch[1];
 
+        // GROUP(TypeName) / QUEUE(TypeName) / RECORD(TypeName) — structured-type property
+        // (e.g. "Settings GROUP(ConnectionSettingsType) END"): resolve to the referenced
+        // type name, same treatment as LIKE(TypeName) above. Without this, the comma/paren
+        // split below strips down to the bare keyword ("GROUP"), which then matches
+        // CLARION_PRIMITIVES and gets rejected as "not navigable" — breaking chained
+        // hover/member resolution (e.g. SELF.Settings.Address) one level too early.
+        const structRefMatch = name.match(/^(?:GROUP|QUEUE|RECORD)\s*\(\s*([\w:]+)\s*\)/i);
+        if (structRefMatch) return structRefMatch[1];
+
         // Take only the part before comma or parenthesis (attributes/dimensions)
         name = name.split(/[,(]/)[0].trim();
 


### PR DESCRIPTION
## Summary

`ClassMemberResolver.extractClassName()` decides whether an intermediate segment in a chained dot-access expression (e.g. `SELF.Order.MainKey`) is "navigable" — i.e. whether the resolver should keep walking into that segment's declared type to find the next member. It already special-cased `LIKE(TypeName)`, unwrapping the parens to get the referenced type name, but had no equivalent case for a class property declared as `GROUP(TypeName)`, `QUEUE(TypeName)`, or `RECORD(TypeName)` (e.g. `Settings GROUP(ConnectionSettingsType) END`).

Without that case, the type string fell through to the generic `name.split(/[,(]/)[0]` split, which strips everything down to the bare keyword (`GROUP`) — and since `GROUP`/`QUEUE`/`RECORD` are themselves listed in `CLARION_PRIMITIVES`, the type was rejected as "not navigable" and the chain walk aborted right there.

**Impact:** any chained hover/member access one level past a `GROUP`/`QUEUE`/`RECORD`-typed class property silently returns no hover, even though the target field is indexed correctly. Concretely: `SELF.Settings.Address` (where `Settings` is `GROUP(ConnectionSettingsType) END`) resolves hover fine on `SELF` and on `Settings`, but hovering `Address` returns nothing — despite the field being locatable via a plain symbol search without issue. Confirmed the same failure is independent of whether the referenced group type itself is declared with `, TYPE` — the bug is purely in parsing the *usage site's* type string, not the type declaration.

Fix: add a `GROUP|QUEUE|RECORD(TypeName)` case mirroring the existing `LIKE(TypeName)` handling, placed before the generic comma/paren split, so the chain keeps walking into the referenced type's fields.

## Test plan
- [x] `npx tsc -b` — clean compile
- [x] Full test suite: 2346 passing, 0 failing, 4 pending (pre-existing, unrelated) — up from 2340 baseline (6 new `extractClassName` cases added: `GROUP(TypeName)`, `GROUP(TypeName) END` verbatim-scanned-line shape, `QUEUE(TypeName)`, `RECORD(TypeName)`, trailing-attribute form, and a guard that bare `GROUP` alone still returns `null`)
- [x] Manually verified via hover against a real Clarion class with a `GROUP(TypeName)`-typed class property — hover on the chained field access returned nothing before the fix, correctly resolves to the field's declaration after rebuilding and redeploying the LSP into a live Clarion IDE session

🤖 Generated with Claude Code

