### PR TITLE
fix(diagnostics): GROUP is valid as a global PROCEDURE/FUNCTION label

### DIFF
--- a/server/src/providers/diagnostics/LabelDiagnostics.ts
+++ b/server/src/providers/diagnostics/LabelDiagnostics.ts
@@ -29,10 +29,19 @@ const FULLY_RESERVED = new Set([
  * CODE and DATA are execution-marker keywords — valid standalone at col 0,
  * and valid as method/field names inside a structure (e.g. CLASS), but
  * invalid as the label of a global PROCEDURE/FUNCTION declaration.
+ *
+ * GROUP is deliberately excluded from this set: unlike the rest, a global
+ * (non-nested) `Group PROCEDURE()` is valid, compiling, runnable Clarion —
+ * confirmed by compiling and running the ClarionAssistant
+ * `group-record-diagnostics-repro` test fixture's case G. This diagnostic
+ * previously false-flagged it. The remaining keywords below are UNVERIFIED
+ * for this same global-scope validity (some, e.g. SELF/PARENT, seem unlikely
+ * to share it) — do not remove any of them without independently confirming
+ * each one compiles as a global PROCEDURE/FUNCTION label first.
  */
 const STRUCTURE_ONLY = new Set([
     'APPLICATION', 'CLASS', 'CODE', 'DATA', 'DETAIL', 'FILE', 'FOOTER',
-    'FORM', 'GROUP', 'HEADER', 'ITEM', 'ITEMIZE',
+    'FORM', 'HEADER', 'ITEM', 'ITEMIZE',
     'JOIN', 'MAP', 'MENU', 'MENUBAR', 'MODULE',
     'OLE', 'OPTION', 'QUEUE', 'PARENT', 'RECORD',
     'REPORT', 'SELF', 'SHEET', 'TAB', 'TOOLBAR',

--- a/server/src/test/DiagnosticProvider.test.ts
+++ b/server/src/test/DiagnosticProvider.test.ts
@@ -2246,6 +2246,14 @@ return:json            EQUATE(1)`;
         assert.strictEqual(diags.length, 1, 'Should flag QUEUE as PROCEDURE label');
     });
 
+    test('GROUP as PROCEDURE label → no error', () => {
+        const code = `GROUP   PROCEDURE()
+  CODE
+  RETURN`;
+        const diags = labelDiags(code);
+        assert.strictEqual(diags.length, 0, 'GROUP is valid as a global PROCEDURE label (confirmed via the group-record-diagnostics-repro test fixture, case G)');
+    });
+
     test('WINDOW as structure label (valid) → no error', () => {
         const code = `TestProc  PROCEDURE()
 WINDOW  WINDOW('Caption'),AT(,,300,200)


### PR DESCRIPTION
GROUP is not a reserved word in Clarion, but validateReservedKeywordLabels' STRUCTURE_ONLY set required it to sit inside an enclosing structure (e.g. a CLASS method) to avoid the "cannot be the label of a PROCEDURE or FUNCTION declaration" diagnostic — it never accounted for GROUP being valid as a label at global, non-nested scope too.

Confirmed by compiling and running a top-level, non-nested `Group PROCEDURE()` (declared in MAP, defined normally, called as Group()) against the real Clarion compiler. Removed GROUP from STRUCTURE_ONLY; its only consumer in this file is this exact PROCEDURE/FUNCTION-label check, so the change is fully isolated.

The other 27 keywords in STRUCTURE_ONLY are unverified for this same global-scope validity and are deliberately left as-is.