### PR TITLE
feat(completion): scope ?Ctrl field-equate completion to the current procedure

### DIFF
--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -2568,6 +2568,28 @@ export class DocumentStructure {
     }
 
     /**
+     * Every WINDOW / APPLICATION / REPORT structure token declared inside
+     * `procedureToken`'s body — the windows whose `?Name` controls are actually
+     * reachable from code in this procedure. Backed by `structuresByType`, no
+     * token re-walk. Scopes field-equate (`?`) completion to the current
+     * procedure instead of every window in the file.
+     */
+    public getContainerStructuresInProcedure(procedureToken: Token): Token[] {
+        if (procedureToken.finishesAt === undefined) return [];
+        const result: Token[] = [];
+        for (const kw of ['WINDOW', 'APPLICATION', 'REPORT'] as const) {
+            const list = this.structuresByType.get(kw);
+            if (!list) continue;
+            for (const t of list) {
+                if (t.line > procedureToken.line && t.line <= procedureToken.finishesAt) {
+                    result.push(t);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Look up a control by its `?Name` (case-insensitive; the leading `?` is required).
      * If `scope` is provided, search only that structure's per-name index. Without
      * `scope`, returns the first hit from the flat index, or null when ambiguous —

--- a/server/src/providers/CompletionProvider.ts
+++ b/server/src/providers/CompletionProvider.ts
@@ -37,11 +37,12 @@ export class CompletionProvider {
     private propertyService = PropertyService.getInstance();
     private eventService = EventService.getInstance();
     private wordCompletion: WordCompletionProvider;
+    private scopeAnalyzer: ScopeAnalyzer;
 
     constructor() {
         const solutionManager = SolutionManager.getInstance();
-        const scopeAnalyzer = new ScopeAnalyzer(this.tokenCache, solutionManager);
-        this.wordCompletion = new WordCompletionProvider(this.tokenCache, scopeAnalyzer);
+        this.scopeAnalyzer = new ScopeAnalyzer(this.tokenCache, solutionManager);
+        this.wordCompletion = new WordCompletionProvider(this.tokenCache, this.scopeAnalyzer);
     }
 
     /**
@@ -65,6 +66,10 @@ export class CompletionProvider {
             // EVENT: completion
             const eventCompletions = this.handleEventCompletion(lineText);
             if (eventCompletions) return eventCompletions;
+
+            // ?Ctrl field-equate completion — fires on a bare '?' or '?partial'
+            const fieldEquateCompletions = this.handleFieldEquateCompletion(lineText, document, position);
+            if (fieldEquateCompletions) return fieldEquateCompletions;
 
             // Member access is not abandoned once the line stops ending in '.'.
             // At a letter-ending position like `SELF.Th` / `oKanban.Ini` the cursor is
@@ -184,6 +189,50 @@ export class CompletionProvider {
             };
             return item;
         });
+    }
+
+    // -------------------------------------------------------------------------
+    // ?Ctrl field-equate completion
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns control-equate completions when the line ends in a bare `?` (or `?partial`),
+     * scoped to WINDOW/APPLICATION/REPORT structures declared inside the CURRENT
+     * PROCEDURE only — a `?OkButton` reference can't reach another procedure's controls,
+     * so cross-procedure names would just be noise. Returns null to fall through when
+     * the line doesn't end in `?...`; returns `[]` (not null) when it does but there's
+     * no containing procedure, so this never falls back to the general word list.
+     */
+    private handleFieldEquateCompletion(
+        lineBeforeCursor: string,
+        document: TextDocument,
+        position: { line: number; character: number }
+    ): CompletionItem[] | null {
+        const m = lineBeforeCursor.match(/\?(\w*)$/);
+        if (!m) return null;
+
+        const partial = m[1].toUpperCase();
+        const proc = this.scopeAnalyzer.getTokenScope(document, position)?.containingProcedure;
+        if (!proc) return [];
+
+        const structure = this.tokenCache.getStructure(document);
+        const seen = new Set<string>();
+        const items: CompletionItem[] = [];
+        for (const win of structure.getContainerStructuresInProcedure(proc)) {
+            for (const ctrl of structure.getControlsInStructure(win)) {
+                const name = ctrl.value.replace(/^\?/, '');
+                const key = name.toUpperCase();
+                if (!key.startsWith(partial) || seen.has(key)) continue;
+                seen.add(key);
+                items.push({
+                    label: ctrl.value,
+                    kind: CompletionItemKind.Constant, // FEQ is a compiler-generated EQUATE, same as a hand-written one
+                    insertText: name, // '?' is already typed
+                    detail: win.value, // WINDOW / APPLICATION / REPORT
+                });
+            }
+        }
+        return items;
     }
 
     // -------------------------------------------------------------------------

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -515,7 +515,7 @@ connection.onInitialize((params) => {
                     retriggerCharacters: [')']
                 },
                 completionProvider: {
-                    triggerCharacters: ['.', ':'],
+                    triggerCharacters: ['.', ':', '?'],
                     resolveProvider: false
                 },
                 documentLinkProvider: { resolveProvider: false },

--- a/server/src/test/CompletionProvider.test.ts
+++ b/server/src/test/CompletionProvider.test.ts
@@ -519,4 +519,83 @@ suite('CompletionProvider — dot-triggered member completion', function () {
                 `Bare 'ins' must not do member completion (no Greeter members), got: [${names.join(', ')}]`);
         });
     });
+
+    // -------------------------------------------------------------------------
+    // ?Ctrl field-equate completion — scoped to windows in the CURRENT PROCEDURE
+    // -------------------------------------------------------------------------
+    suite('onCompletion — ?Ctrl field-equate completion', function () {
+        const CONSTANT = 21; // CompletionItemKind.Constant
+
+        function buildTwoProcedureDoc(uriName: string) {
+            const content = [
+                'MainProc PROCEDURE',
+                "Window WINDOW('Test'),AT(0,0,200,100)",
+                "    BUTTON('OK'),AT(10,10,50,14),USE(?OkButton)",
+                "    BUTTON('Cancel'),AT(70,10,50,14),USE(?CancelButton)",
+                'END',
+                'CODE',
+                '  ?',
+                '',
+                'OtherProc PROCEDURE',
+                "OtherWindow WINDOW('Other'),AT(0,0,100,100)",
+                "    BUTTON('Other'),AT(10,10,50,14),USE(?OtherButton)",
+                'END',
+                'CODE',
+                '  RETURN'
+            ].join('\n');
+            const uri = `file:///C:/temp/${uriName}.clw`;
+            const localDoc = TextDocument.create(uri, 'clarion', 1, content);
+            const cache = TokenCache.getInstance();
+            cache.clearAllTokens();
+            cache.getTokens(localDoc);
+            return localDoc;
+        }
+
+        test('bare "?" surfaces controls only from windows in the current procedure', async function () {
+            this.timeout(10000);
+            const localDoc = buildTwoProcedureDoc('completion-feq-bare');
+            const localProvider = new CompletionProvider();
+            const params = {
+                textDocument: { uri: localDoc.uri },
+                position: { line: 6, character: '  ?'.length },
+                context: { triggerKind: 2, triggerCharacter: '?' }
+            } as any;
+
+            const items = await localProvider.onCompletion(params, localDoc);
+            const names = items.map(i => (i.label as string).toUpperCase());
+
+            assert.ok(names.includes('?OKBUTTON'), `Expected ?OkButton in: [${names.join(', ')}]`);
+            assert.ok(names.includes('?CANCELBUTTON'), `Expected ?CancelButton in: [${names.join(', ')}]`);
+            assert.ok(!names.includes('?OTHERBUTTON'),
+                `?OtherButton belongs to OtherProc's window and must NOT appear, got: [${names.join(', ')}]`);
+
+            items.forEach(i => assert.strictEqual(i.kind, CONSTANT, `Expected Constant kind, got ${i.kind}`));
+            const ok = items.find(i => (i.label as string).toUpperCase() === '?OKBUTTON');
+            assert.strictEqual(ok!.insertText, 'OkButton', 'insertText should omit the already-typed "?"');
+        });
+
+        test('"?" with a partial name filters by the typed prefix', async function () {
+            this.timeout(10000);
+            const localDoc = buildTwoProcedureDoc('completion-feq-partial');
+            const content = localDoc.getText().replace('  ?\n', '  ?Ok\n');
+            const partialDoc = TextDocument.create('file:///C:/temp/completion-feq-partial.clw', 'clarion', 1, content);
+            const cache = TokenCache.getInstance();
+            cache.clearAllTokens();
+            cache.getTokens(partialDoc);
+
+            const localProvider = new CompletionProvider();
+            const params = {
+                textDocument: { uri: partialDoc.uri },
+                position: { line: 6, character: '  ?Ok'.length },
+                context: { triggerKind: 2 }
+            } as any;
+
+            const items = await localProvider.onCompletion(params, partialDoc);
+            const names = items.map(i => (i.label as string).toUpperCase());
+
+            assert.ok(names.includes('?OKBUTTON'), `Expected ?OkButton to match partial "Ok", got: [${names.join(', ')}]`);
+            assert.ok(!names.includes('?CANCELBUTTON'),
+                `?CancelButton should be filtered out by partial "Ok", got: [${names.join(', ')}]`);
+        });
+    });
 });


### PR DESCRIPTION
Typing '?' inside a procedure now offers that procedure's control equates (?OkButton etc.) as completions, scoped to the WINDOW/APPLICATION/REPORT structures declared in the CURRENT procedure only — controls belonging to other procedures' windows are excluded since they aren't reachable from here.

- server.ts: register '?' as a completion trigger character
- DocumentStructure.ts: getContainerStructuresInProcedure() finds container structures declared inside a given procedure's body, backed by the existing structuresByType index (no extra token walk)
- CompletionProvider.ts: handleFieldEquateCompletion() matches a trailing '?'/'?partial', resolves the current procedure via ScopeAnalyzer, and returns only its controls as CompletionItemKind.Constant (a field equate is a compiler-generated EQUATE, same kind already used for hand-written ones)