### PR TITLE
Fix/colon prefix dot access hover

### DIFF
--- a/server/src/providers/hover/StructureFieldResolver.ts
+++ b/server/src/providers/hover/StructureFieldResolver.ts
@@ -174,7 +174,7 @@ export class StructureFieldResolver {
         } else {
             // variable.member - structure field access (e.g., MyGroup.MyVar)
             // or typed class variable access (e.g., st.GetValue() where st is StringTheory)
-            const structureNameMatch = beforeDot.match(/(\w+)\s*$/);
+            const structureNameMatch = beforeDot.match(/([\w:]+)\s*$/);
             if (structureNameMatch) {
                 const structureName = structureNameMatch[1];
                 logger.info(`Detected structure field access: ${structureName}.${word}`);

--- a/server/src/test/ColonAndPreDotAccessInteraction.test.ts
+++ b/server/src/test/ColonAndPreDotAccessInteraction.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Adversarial regression check for the colon-prefix dot-access fix: makes sure
+ * widening the backward word-scan / structureNameMatch regex to accept ':' does
+ * NOT change behavior for the pre-existing, already-working colon scenario —
+ * GROUP PRE(...) prefixed field access via dot notation — when it coexists in
+ * the same file as the colon-prefixed global dot-access chain this PR fixes.
+ *
+ * Note: GROUP PRE(...) field access is unaffected by either change in this PR.
+ * The dot-chain form (Config.Nested.Setting) is a plain Label/'.'/Label sequence
+ * with no ':' anywhere in it, so the widened regexes never come into play.
+ */
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { setServerInitialized } from '../serverState';
+
+const CODE = `
+   PROGRAM
+
+HelperClass   CLASS
+DoWork          PROCEDURE(LONG p1),LONG
+              END
+
+GLOB:Helper   &HelperClass
+
+HelperClass.DoWork PROCEDURE(LONG p1)
+  CODE
+  RETURN p1
+  END
+
+MyProc PROCEDURE()
+Config      GROUP,PRE(CFG)
+Nested        GROUP,PRE(NST)
+Setting         LONG
+              END
+            END
+  CODE
+  GLOB:Helper.DoWork(1)
+  Config.Nested.Setting = 5
+  END
+`;
+
+suite('Colon-prefix fix does not regress PRE() prefix / nested-group dot access', () => {
+    setup(() => {
+        setServerInitialized(true);
+    });
+
+    function lineOf(needle: string): number {
+        return CODE.split('\n').findIndex(l => l.includes(needle));
+    }
+
+    test('nested PRE()\'d group field via full dot chain still resolves', async () => {
+        const uri = 'test://NestedPreDotChain.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('Config.Nested.Setting = 5');
+        const character = CODE.split('\n')[line].lastIndexOf('Setting');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for Config.Nested.Setting');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('Setting'), `Hover should mention Setting (got: ${value})`);
+    });
+
+    test('colon-prefixed global method call in the same file still resolves (no crosstalk with PRE groups)', async () => {
+        const uri = 'test://AdjacentColonGlobal.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('GLOB:Helper.DoWork(1)');
+        const character = CODE.split('\n')[line].indexOf('DoWork');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for GLOB:Helper.DoWork(1)');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('HelperClass'), `Hover should attribute to HelperClass (got: ${value})`);
+    });
+});

--- a/server/src/test/ColonPrefixedGlobalDotAccessHover.test.ts
+++ b/server/src/test/ColonPrefixedGlobalDotAccessHover.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Clarion allows a literal colon inside an identifier (e.g. GLOB:Thing), a common
+ * naming convention for globals that is unrelated to GROUP/QUEUE PRE(...) prefixing.
+ *
+ * Two independent spots stripped that colon-prefixed segment when hovering a
+ * property/method reached via dot access on such a variable:
+ *   - TokenHelper.getWordRangeAtPosition's backward scan (building the hover "word")
+ *   - StructureFieldResolver.resolveFieldAccess's structureNameMatch regex (extracting
+ *     the receiver name to type-resolve)
+ *
+ * Either bug alone drops the "GLOB:" prefix down to "Thing", which then fails to
+ * match the actual declared variable "GLOB:Thing" — so the receiver's type never
+ * resolves and the member lookup silently returns no hover. A property access can
+ * accidentally still show *something* via an unrelated bare-name fallback elsewhere
+ * in the resolution ladder, which is why this went unnoticed for properties but not
+ * for method calls (which have no such fallback).
+ */
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { setServerInitialized } from '../serverState';
+
+const CODE = `
+   PROGRAM
+
+HelperClass   CLASS
+Prop            LONG
+DoWork            PROCEDURE(LONG p1, LONG p2),LONG
+              END
+
+HelperClass.DoWork PROCEDURE(LONG p1, LONG p2)
+  CODE
+  RETURN p1 + p2
+
+GLOB:Helper   &HelperClass
+
+  CODE
+  GLOB:Helper.Prop = 1
+  GLOB:Helper.DoWork(1, 2)
+`;
+
+suite('Colon-prefixed global variable — dot-access hover', () => {
+    setup(() => {
+        setServerInitialized(true);
+    });
+
+    function lineOf(needle: string): number {
+        return CODE.split('\n').findIndex(l => l.includes(needle));
+    }
+
+    test('hovering a METHOD reached via GLOB:Prefixed.Method(...) resolves the class member', async () => {
+        const uri = 'test://ColonPrefixMethod.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('GLOB:Helper.DoWork(1, 2)');
+        const character = CODE.split('\n')[line].indexOf('DoWork');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for GLOB:Helper.DoWork(...)');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('DoWork'), `Hover should mention DoWork (got: ${value})`);
+        assert.ok(value.includes('HelperClass'), `Hover should attribute the method to HelperClass (got: ${value})`);
+    });
+
+    test('hovering a PROPERTY reached via GLOB:Prefixed.Property resolves via the real class-member path', async () => {
+        const uri = 'test://ColonPrefixProperty.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('GLOB:Helper.Prop = 1');
+        const character = CODE.split('\n')[line].indexOf('Prop');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for GLOB:Helper.Prop');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('Prop'), `Hover should mention Prop (got: ${value})`);
+        assert.ok(value.includes('HelperClass'), `Hover should attribute the property to HelperClass (got: ${value})`);
+    });
+});

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -329,7 +329,7 @@ export class TokenHelper {
             start = wordStart - 1; // Include the dot
             while (start > 0) {
                 const char = line.charAt(start - 1);
-                if (this.isWordCharacter(char)) {
+                if (this.isWordCharacter(char) || (includeColons && char === ':')) {
                     start--;
                 } else {
                     break;


### PR DESCRIPTION
## Summary

Clarion allows a literal `:` inside an identifier — a common naming convention for globals (`GLOB:Thing`), separate from GROUP/QUEUE `PRE(...)` prefixing. Hovering a **method** reached via dot access on such a variable produced no hover at all; hovering a **property** the same way happened to still show something, which made this look property-safe / method-only at first. It isn't — both are broken the same way, one just has a lucky fallback masking it.

```clarion
MyGlobals   CLASS
Setting       LONG
DoWork          PROCEDURE(LONG p1),LONG
            END

GLOB:Config &MyGlobals

  CODE
  GLOB:Config.Setting = 1        ! hover on Setting: happens to still show something
  GLOB:Config.DoWork(1)          ! hover on DoWork: nothing
```

## Root cause

Two independent spots drop the colon-prefixed segment before the receiver's type ever gets resolved:

1. **`TokenHelper.getWordRangeAtPosition`** — the forward scan (finding the word    under the cursor) explicitly allows `:`    (`includeColons`), but the backward scana few lines below it (walking left to include the prefix before a dot, e.g. for
   `GLOB:Config.DoWork`) only allows `[A-Za-z0-9_]`. For a colon-containing prefix, this produces the wrong compound hover "word" (`Config.DoWork` instead of `GLOB:Config.DoWork`).
2. **`StructureFieldResolver.resolveFieldAccess`** — `structureNameMatch = beforeDot.match(/(\w+)\s*$/)` has the same gap: `\w` excludes `:`, so the receiver name extracted for variable-type resolution is truncated to `Config`, which doesn't
   match the actual declaration `GLOB:Config`. `resolveVariableType` then fails and the whole "look up this member in its class" path never runs.

Either bug alone is enough to break it. Why properties still "worked": a property access can incidentally be caught by a later, unrelated bare-name fallback further down the hover resolution ladder (a plain "does any symbol have this exact name
anywhere reachable" search) — which finds the property by coincidence, not because the receiver's type was correctly resolved. A method call has no equivalent fallback, so it just returns null. That's also why this could silently point at the *wrong* declaration if two unrelated classes happened to declare a same-named property — the accidental match isn't scoped to the receiver's real type at all. 

Fixed both spots to allow `:` consistently, matching how the rest of the file already treats colon-containing identifiers.

### Possibly related earlier work

Not a regression of either of these as far as I can tell — cited for anyone triaging future colon/prefix hover reports, since this is the third or so bug in this general area:

- **v0.7.1** (`CHANGELOG-full.md`) — "PREFIX and Structure Field Access
  Improvements" added dedicated support for `LOC:MyVar` / `MyGroup.MyVar` / bare
  access for GROUP `PRE(...)` fields, plus a companion "word extraction for dot
  notation" fix in this same `getWordRangeAtPosition` area. That work covers
  structure-PRE prefixes specifically; a colon that's simply part of a global's own
  name (no `PRE(...)` involved) falls through the same code but isn't a PRE-prefix
  case, so it wasn't covered.
- **[Unreleased] / 0.8.4** — "Fixed: Colon-handling in labels" (F12 now works on
  `BRW1::View:Browse`-style labels) is the same *symptom family* (colon dropped
  during identifier handling) but in the Go to Definition label-search path, not
  hover's dot-access chain.

Might be worth a "colon-in-identifiers" sweep across the remaining resolvers at some point, since this pattern (`\w+`-style regex, or a hand-rolled word-character check) recurs independently in at least three unrelated files now.

## Test plan
- [x] `npx tsc -b` — clean compile
- [x] Added `ColonPrefixedGlobalDotAccessHover.test.ts` — synthetic CLASS + colon-prefixed global reference, one method-call case and one property-access case; both fail without the fix (confirmed by temporarily reverting it) and pass with it
- [x] Added `ColonAndPreDotAccessInteraction.test.ts` — adversarial check that widening both regexes to accept `:` doesn't regress the pre-existing GROUP `PRE(...)` dot-access case (`Config.Nested.Setting`, no `:` anywhere in that chain) when it coexists in the same file as the colon-prefixed global fix above. Also confirmed by reasoning over the code: multi-segment chains (2+ dots) never hit either changed regex at all — `ChainedPropertyResolver` already splits on `.` and passes the un-truncated segment straight into `resolveVariableType`, both before and after this PR.
- [x] Full test suite: 2344 passing, 0 failing, 4 pending (pre-existing, unrelated)
- [x] Manually verified via a direct `HoverProvider.provideHover` harness against a real-world `.clw` file with a colon-prefixed global class instance, confirmed the method-call hover now resolves (including correctly picking the right overload/class when another unrelated class declares a same-named method) and the property hover now goes through the real class-member path instead of the coincidental fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
