### PR TITLE
fix(hover): Comment lost first char

### DIFF
--- a/server/src/test/DocCommentReader.test.ts
+++ b/server/src/test/DocCommentReader.test.ts
@@ -153,6 +153,24 @@ suite('DocCommentReader', () => {
             const doc = DocCommentReader.read(lines, 0);
             assert.strictEqual(doc, null);
         });
+
+        test('does not drop the first character when there is no space after !', () => {
+            const lines = [
+                'bulkfileName        STRING(256)   !Name of file to read from'
+            ];
+            const doc = DocCommentReader.read(lines, 0);
+            assert.ok(doc);
+            assert.strictEqual(doc!.summary, 'Name of file to read from');
+        });
+
+        test('inline fallback works after a double-bang (!!) comment', () => {
+            const lines = [
+                'MyProc   PROCEDURE()  !!something'
+            ];
+            const doc = DocCommentReader.read(lines, 0);
+            assert.ok(doc);
+            assert.strictEqual(doc!.summary, 'something');
+        });
     });
 
     suite('read() - edge cases', () => {

--- a/server/src/utils/DocCommentReader.ts
+++ b/server/src/utils/DocCommentReader.ts
@@ -64,9 +64,12 @@ export class DocCommentReader {
         }
 
         // Fallback: inline ! comment on the declaration line (e.g., "MyProc PROCEDURE() ! does X")
-        // Only match single ! or !! — not !!! (which would have been caught above)
+        // Only match single ! or !! — not !!! (which would have been caught above).
+        // Lookaround instead of a consumed `[^!]` character class — the latter silently ate the
+        // first character of the comment whenever it wasn't a space (e.g. "!Name of file..." lost
+        // the "N"), because that character was matched but never included in the captured group.
         const declLine = fileLines[declarationLine] || '';
-        const inlineMatch = declLine.match(/![^!](.+)$/);
+        const inlineMatch = declLine.match(/(?<!!)!{1,2}(?!!)(.+)$/);
         if (inlineMatch) {
             const text = inlineMatch[1].trim();
             if (text) {


### PR DESCRIPTION
# fix(hover): DocCommentReader inline fallback dropped the comment's first character

## What happened

Hovering a variable whose declaration has a trailing `!comment` with no space right after the `!`
rendered the comment text with its leading character missing. Example:

```clarion
bulkfileName        STRING(256)   !Name of file to read from
```

Hover showed:

```clarion
bulkfileName        STRING(256)   !Name of file to read from
ame of file to read from
```
(doc-comment appendix below the location link — missing the leading "N")

## Root cause

`DocCommentReader.read()`'s inline-`!`-comment fallback used a **consumed** character class to assert
"this isn't a second `!`":

```ts
const inlineMatch = declLine.match(/![^!](.+)$/);
```

`[^!]` matches — and consumes — one character. When that character is the first real letter of the
comment (no space after `!`), it's excluded from the captured group and silently lost. The one existing
test for this path (`! Does something useful`) has a space in that position, so the dropped character
was invisible after `.trim()` — that's why this went unnoticed.

## Fix

Replace the consumed character class with lookaround, so no comment text is ever consumed by the
disambiguation check:

```ts
const inlineMatch = declLine.match(/(?<!!)!{1,2}(?!!)(.+)$/);
```

- `(?<!!)` — not immediately preceded by another `!` (so we start at the true beginning of a bang-run)
- `!{1,2}` — one or two `!` (matches the documented intent: single `!` or `!!`, not `!!!`/`!!!!`)
- `(?!!)` — the bang-run doesn't continue into a third `!` (that's the doc-block marker, already
  handled earlier in the function)
- `(.+)$` — captures everything after, untouched

## Testing

Two regression tests added to `DocCommentReader.test.ts`:
- The exact `bulkfileName` repro (no space after `!`) — asserts the full text survives.
- A double-bang (`!!`) inline case — asserts the `!!`-vs-`!!!` boundary still holds.

`npm run test:server`: all passing, 0 failing (verified in an isolated worktree off
`origin/version-1.0.1`, no unrelated WIP mixed in).

## Scope

Two files only: `server/src/utils/DocCommentReader.ts`, `server/src/test/DocCommentReader.test.ts`.
Unrelated to the in-flight hover-clickable-locations Issue (`issue-hover-clickable-locations.md`) —
found incidentally while live-testing that work, but this is a plain correctness bug fix, not a
look-and-feel change, so it goes out as its own PR rather than folded into that Issue+patch.

We should also think about if it is necessary to duplicate this information in the hover.