### PR TITLE
Fix/member header via include

### DIFF
--- a/server/src/providers/hover/VariableHoverResolver.ts
+++ b/server/src/providers/hover/VariableHoverResolver.ts
@@ -268,12 +268,25 @@ export class VariableHoverResolver {
         const isProcedure = ProcedureUtils.isProcedureKeyword(typeInfo); // #247: PROCEDURE ≡ FUNCTION
         const isEquate = typeInfo === 'EQUATE';
 
+        // #350-adjacent — a PRE:Field reference (e.g. EVL:Lic) resolves through the same
+        // global-variable path as a true global scalar, but the token is actually a field of a
+        // PRE()'d FILE/QUEUE/GROUP (StructureProcessor stamps isStructureField/structureParent on
+        // it). Label it as a structure field — matching the "`X` Field:" wording
+        // StructureFieldResolver already uses for dot-notation access to the same field — instead
+        // of the generic "🌍 Global variable", which loses exactly the context the developer needs
+        // to tell a real global apart from a structure field reached via its PRE prefix.
+        const structureParentName = (globalVar as any).isStructureField
+            ? ((globalVar as any).structureParent?.label ?? (globalVar as any).structureParent?.value)
+            : undefined;
+
         if (isClassProperty) {
             const classLabel = containingClassName ? `Class property of \`${containingClassName}\`` : 'Class property';
             markdown.push(`🔷 ${classLabel}`);
         } else if (isInterfaceMethod) {
             const ifaceLabel = containingInterfaceName ? `Interface method of \`${containingInterfaceName}\`` : 'Interface method';
             markdown.push(`🔌 ${ifaceLabel}`);
+        } else if (structureParentName) {
+            markdown.push(`🔷 \`${structureParentName}\` field`);
         } else if (scopeInfo) {
             const scopeIcon = scopeInfo.type === 'global' ? '🌍' : '📦';
             const scopeLabel = isProcedure

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -1749,8 +1749,8 @@ export class MemberLocatorService {
      * direct-fix-sites.
      */
     /**
-     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
-     * targets when no literal MEMBER statement is present locally.
+     * Resolves the MEMBER token for a file, following its FIRST statement into an
+     * INCLUDE'd shim when no literal MEMBER statement is present locally.
      *
      * Project convention seen across many member modules: the real MEMBER('program')
      * statement lives in a small generated shim file reached via e.g. INCLUDE('member.clw')
@@ -1759,9 +1759,13 @@ export class MemberLocatorService {
      * TokenHelper.findMemberHeaderToken() only sees literal tokens in the tokens it's given,
      * so it can never find a MEMBER hidden behind that indirection on its own.
      *
-     * Only looks one INCLUDE hop deep — matches the shim-file convention; a MEMBER statement
-     * buried deeper than that would be unusual. Takes the first MEMBER token found across the
-     * direct includes, in document order.
+     * Because MEMBER/PROGRAM must be the first statement of the compiled token stream
+     * (see TokenHelper.findShimIncludeToken), only the FIRST statement of each file is
+     * ever consulted: if it isn't an INCLUDE, the file cannot be a shim-headed member
+     * module and the walk stops immediately — the common miss (a definition include, a
+     * PROGRAM file, plain data) costs zero file reads. Each hop reads exactly one file;
+     * MAX_SHIM_HOPS bounds the legal-but-rare chained-shim case and a visited set stops
+     * include cycles.
      *
      * `fromFile` (the CURRENT file's own path, not the include target) must be threaded through
      * to resolveFilePath's owner-project-first redirection (#328) — some projects use a DIFFERENT
@@ -1770,33 +1774,32 @@ export class MemberLocatorService {
      * Omitting it makes redirection fall back to an unscoped solution-wide walk that can resolve to
      * the WRONG project's shim.
      */
+    private static readonly MAX_SHIM_HOPS = 3;
     private async resolveMemberHeaderToken(tokens: Token[], fromDir: string, fromFile?: string): Promise<Token | undefined> {
-        const direct = TokenHelper.findMemberHeaderToken(tokens);
-        if (direct) return direct;
+        const visited = new Set<string>();
+        for (let hop = 0; hop <= MemberLocatorService.MAX_SHIM_HOPS; hop++) {
+            const direct = TokenHelper.findMemberHeaderToken(tokens);
+            if (direct) return direct;
 
-        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
-        for (const inc of includeTokens) {
-            const resolvedPath = this.resolveFilePath(inc.referencedFile!, fromDir, fromFile);
-            if (!resolvedPath) continue;
+            const shimInclude = TokenHelper.findShimIncludeToken(tokens);
+            if (!shimInclude) return undefined;
+            const resolvedPath = this.resolveFilePath(shimInclude.referencedFile!, fromDir, fromFile);
+            if (!resolvedPath) return undefined;
+            const key = resolvedPath.toLowerCase();
+            if (visited.has(key)) return undefined;
+            visited.add(key);
             const data = await this.loadDocument(resolvedPath);
-            if (!data) continue;
-            const nested = TokenHelper.findMemberHeaderToken(data.tokens);
-            if (nested) return nested;
+            if (!data) return undefined;
+            tokens = data.tokens;
+            fromDir = path.dirname(resolvedPath);
+            fromFile = resolvedPath;
         }
         return undefined;
     }
 
-    /**
-     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
-     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
-     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
-     * `resolveViaProjectRedirection`'s redirection lookup matches by extension mask (e.g. the `*.clw
-     * = ...` line in a .red file), so an extension-less name never matches any rule and silently
-     * fails to resolve: `resolveViaProjectRedirection('TargetProgram', ...)` -> null,
-     * `resolveViaProjectRedirection('TargetProgram.clw', ...)` -> the correct path.
-     */
+    /** See TokenHelper.normalizeMemberFilename — kept as a thin delegate for existing call sites. */
     private normalizeMemberFilename(name: string): string {
-        return path.extname(name) ? name : `${name}.clw`;
+        return TokenHelper.normalizeMemberFilename(name);
     }
 
     private resolveFilePath(filename: string, fromDir: string, fromFile?: string): string | null {

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -155,9 +155,9 @@ export class MemberLocatorService {
         // interface walk and #361's procedure walk).
         const timeSlice = makeTimeSlicer();
 
-        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
+            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -398,7 +398,7 @@ export class MemberLocatorService {
         }
 
         // 1.5 MEMBER parent file + its INCLUDE chain (common libsrc .clw layout)
-        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath), docPath);
         if (memberToken?.referencedFile) {
             const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
             if (parentPath) {
@@ -566,7 +566,7 @@ export class MemberLocatorService {
     public async warmMemberParent(document: TextDocument): Promise<boolean> {
         const tokens = this.tokenCache.getTokens(document);
         const docPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
-        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath), docPath);
         if (!memberToken?.referencedFile) return false;
 
         const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
@@ -643,9 +643,9 @@ export class MemberLocatorService {
         const currentDir = path.dirname(currentFilePath);
 
         // 2. MEMBER parent file (and its INCLUDE chain)
-        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
+            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -749,9 +749,9 @@ export class MemberLocatorService {
         if (found) return { token: found, tokens, doc: document };
 
         // 2. MEMBER parent + its include chain
-        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
+            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -1738,14 +1738,21 @@ export class MemberLocatorService {
      * Only looks one INCLUDE hop deep — matches the shim-file convention; a MEMBER statement
      * buried deeper than that would be unusual. Takes the first MEMBER token found across the
      * direct includes, in document order.
+     *
+     * `fromFile` (the CURRENT file's own path, not the include target) must be threaded through
+     * to resolveFilePath's owner-project-first redirection (#328) — some projects use a DIFFERENT
+     * same-named shim per project (e.g. many `member.clw` files, one per project, each redirecting
+     * to a different MEMBER target so the same shared source tree can belong to different PROGRAMs).
+     * Omitting it makes redirection fall back to an unscoped solution-wide walk that can resolve to
+     * the WRONG project's shim.
      */
-    private async resolveMemberHeaderToken(tokens: Token[], fromDir: string): Promise<Token | undefined> {
+    private async resolveMemberHeaderToken(tokens: Token[], fromDir: string, fromFile?: string): Promise<Token | undefined> {
         const direct = TokenHelper.findMemberHeaderToken(tokens);
         if (direct) return direct;
 
         const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
         for (const inc of includeTokens) {
-            const resolvedPath = this.resolveFilePath(inc.referencedFile!, fromDir);
+            const resolvedPath = this.resolveFilePath(inc.referencedFile!, fromDir, fromFile);
             if (!resolvedPath) continue;
             const data = await this.loadDocument(resolvedPath);
             if (!data) continue;

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -772,6 +772,30 @@ export class MemberLocatorService {
     private findPrefixFieldInTokens(prefix: string, fieldName: string, tokens: Token[]): Token | undefined {
         const prefixUpper = prefix.toUpperCase();
         const fieldUpper = fieldName.toUpperCase();
+
+        // Prefer an actual FIELD of the structure over the structure's own PRE()'d declaration
+        // token. A field can coincidentally share its name with the enclosing structure (e.g. a
+        // FILE named `Evl` containing a field also named `Evl` — real shape in this codebase's
+        // event-log dictionary entry) — StructureProcessor stamps `structurePrefix` on the
+        // declaring structure token ITSELF as well as on its fields, so without this the
+        // declaration token wins the search below simply by appearing first in document order.
+        //
+        // `t.line > t.structureParent.line` additionally excludes a DocumentStructure quirk: the
+        // structure is pushed onto its structure-stack the moment its own keyword token (FILE,
+        // QUEUE, ...) is seen, so any later Variable/StructurePrefix-type token on THAT SAME
+        // declaration line — e.g. the `GLOB:Owner` in `OWNER(GLOB:Owner)`, or the `Evl` argument
+        // inside `PRE(Evl)` on the FILE's own line — gets mistagged isStructureField=true with the
+        // structure's own prefix too, even though it's an attribute argument, not a real field.
+        // Real fields are always declared on later lines, so this line comparison cleanly excludes
+        // that noise without touching the tokenizer's core (widely-depended-on) structure walker.
+        const fieldMatch = tokens.find(t =>
+            t.isStructureField &&
+            t.structurePrefix?.toUpperCase() === prefixUpper &&
+            t.value.toUpperCase() === fieldUpper &&
+            t.structureParent !== undefined && t.line > t.structureParent.line
+        );
+        if (fieldMatch) return fieldMatch;
+
         return tokens.find(t =>
             t.structurePrefix?.toUpperCase() === prefixUpper &&
             // Label tokens: t.value is the name; Structure tokens (nested GROUP etc): t.label is the name

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -157,7 +157,7 @@ export class MemberLocatorService {
 
         const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
+            const parentPath = this.resolveFilePath(this.normalizeMemberFilename(memberToken.referencedFile), currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -400,7 +400,7 @@ export class MemberLocatorService {
         // 1.5 MEMBER parent file + its INCLUDE chain (common libsrc .clw layout)
         const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath), docPath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
+            const parentPath = this.resolveFilePath(this.normalizeMemberFilename(memberToken.referencedFile), path.dirname(docPath), docPath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -569,7 +569,7 @@ export class MemberLocatorService {
         const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath), docPath);
         if (!memberToken?.referencedFile) return false;
 
-        const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
+        const parentPath = this.resolveFilePath(this.normalizeMemberFilename(memberToken.referencedFile), path.dirname(docPath), docPath);
         if (!parentPath) return false;
 
         // Already tokenized (open in the editor, or warmed by another member sharing this
@@ -645,7 +645,7 @@ export class MemberLocatorService {
         // 2. MEMBER parent file (and its INCLUDE chain)
         const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
+            const parentPath = this.resolveFilePath(this.normalizeMemberFilename(memberToken.referencedFile), currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -751,7 +751,7 @@ export class MemberLocatorService {
         // 2. MEMBER parent + its include chain
         const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir, currentFilePath);
         if (memberToken?.referencedFile) {
-            const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir, currentFilePath);
+            const parentPath = this.resolveFilePath(this.normalizeMemberFilename(memberToken.referencedFile), currentDir, currentFilePath);
             if (parentPath) {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
@@ -1760,6 +1760,19 @@ export class MemberLocatorService {
             if (nested) return nested;
         }
         return undefined;
+    }
+
+    /**
+     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
+     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
+     * `resolveViaProjectRedirection`'s redirection lookup matches by extension mask (e.g. the `*.clw
+     * = ...` line in a .red file), so an extension-less name never matches any rule and silently
+     * fails to resolve: `resolveViaProjectRedirection('TargetProgram', ...)` -> null,
+     * `resolveViaProjectRedirection('TargetProgram.clw', ...)` -> the correct path.
+     */
+    private normalizeMemberFilename(name: string): string {
+        return path.extname(name) ? name : `${name}.clw`;
     }
 
     private resolveFilePath(filename: string, fromDir: string, fromFile?: string): string | null {

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -155,7 +155,7 @@ export class MemberLocatorService {
         // interface walk and #361's procedure walk).
         const timeSlice = makeTimeSlicer();
 
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
         if (memberToken?.referencedFile) {
             const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
             if (parentPath) {
@@ -398,7 +398,7 @@ export class MemberLocatorService {
         }
 
         // 1.5 MEMBER parent file + its INCLUDE chain (common libsrc .clw layout)
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath));
         if (memberToken?.referencedFile) {
             const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
             if (parentPath) {
@@ -565,10 +565,10 @@ export class MemberLocatorService {
      */
     public async warmMemberParent(document: TextDocument): Promise<boolean> {
         const tokens = this.tokenCache.getTokens(document);
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const docPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(docPath));
         if (!memberToken?.referencedFile) return false;
 
-        const docPath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
         const parentPath = this.resolveFilePath(memberToken.referencedFile, path.dirname(docPath), docPath);
         if (!parentPath) return false;
 
@@ -643,7 +643,7 @@ export class MemberLocatorService {
         const currentDir = path.dirname(currentFilePath);
 
         // 2. MEMBER parent file (and its INCLUDE chain)
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
         if (memberToken?.referencedFile) {
             const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
             if (parentPath) {
@@ -749,7 +749,7 @@ export class MemberLocatorService {
         if (found) return { token: found, tokens, doc: document };
 
         // 2. MEMBER parent + its include chain
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const memberToken = await this.resolveMemberHeaderToken(tokens, currentDir);
         if (memberToken?.referencedFile) {
             const parentPath = this.resolveFilePath(memberToken.referencedFile, currentDir);
             if (parentPath) {
@@ -1724,6 +1724,37 @@ export class MemberLocatorService {
      * ImplementationProvider / MethodHoverResolver already do via their
      * direct-fix-sites.
      */
+    /**
+     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
+     * targets when no literal MEMBER statement is present locally.
+     *
+     * Project convention seen across many member modules: the real MEMBER('program')
+     * statement lives in a small generated shim file reached via e.g. INCLUDE('member.clw')
+     * rather than being written directly in each member — this lets the same shared source
+     * files belong to different PROGRAMs across projects by swapping just that one shim.
+     * TokenHelper.findMemberHeaderToken() only sees literal tokens in the tokens it's given,
+     * so it can never find a MEMBER hidden behind that indirection on its own.
+     *
+     * Only looks one INCLUDE hop deep — matches the shim-file convention; a MEMBER statement
+     * buried deeper than that would be unusual. Takes the first MEMBER token found across the
+     * direct includes, in document order.
+     */
+    private async resolveMemberHeaderToken(tokens: Token[], fromDir: string): Promise<Token | undefined> {
+        const direct = TokenHelper.findMemberHeaderToken(tokens);
+        if (direct) return direct;
+
+        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
+        for (const inc of includeTokens) {
+            const resolvedPath = this.resolveFilePath(inc.referencedFile!, fromDir);
+            if (!resolvedPath) continue;
+            const data = await this.loadDocument(resolvedPath);
+            if (!data) continue;
+            const nested = TokenHelper.findMemberHeaderToken(data.tokens);
+            if (nested) return nested;
+        }
+        return undefined;
+    }
+
     private resolveFilePath(filename: string, fromDir: string, fromFile?: string): string | null {
         const sm = SolutionManager.getInstance();
         if (sm?.solution) {

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -920,23 +920,44 @@ export class SymbolFinderService {
     }
     
     /**
-     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
-     * targets when no literal MEMBER statement is present locally — mirrors
+     * Resolves the MEMBER token for a file, following its FIRST statement into an
+     * INCLUDE'd shim when no literal MEMBER statement is present locally — mirrors
      * MemberLocatorService.resolveMemberHeaderToken (same project convention: MEMBER('program')
      * often lives in a small generated shim reached via INCLUDE('member.clw') rather than being
      * written directly in each member module, so a shared source tree can belong to different
      * PROGRAMs across projects by swapping just that shim). TokenHelper.findMemberHeaderToken()
      * only sees literal tokens in the tokens it's given, so it can never find a MEMBER hidden
-     * behind that indirection on its own. Only looks one INCLUDE hop deep.
+     * behind that indirection on its own.
+     *
+     * Because MEMBER/PROGRAM must be the first statement of the compiled token stream (see
+     * TokenHelper.findShimIncludeToken), only the FIRST statement of each file is consulted:
+     * a non-INCLUDE first statement is an instant miss with zero file reads, each hop reads
+     * exactly one file, MAX_SHIM_HOPS bounds the rare chained-shim case, and a visited set
+     * stops include cycles.
+     *
+     * The shim include is resolved redirection-first (`resolveViaProjectRedirection`, threaded
+     * with `fromFile` for #328 owner-project-first) with a plain relative-path probe as the
+     * fallback — the same order MemberLocatorService.resolveFilePath uses — so a shim reachable
+     * only via a .red mapping resolves identically for hover (MemberLocatorService) and for the
+     * definition/global-variable paths that come through here.
      */
-    private async resolveMemberHeaderToken(tokens: Token[], currentDir: string): Promise<Token | undefined> {
-        const direct = TokenHelper.findMemberHeaderToken(tokens);
-        if (direct) return direct;
+    private static readonly MAX_SHIM_HOPS = 3;
+    private async resolveMemberHeaderToken(tokens: Token[], currentDir: string, fromFile?: string): Promise<Token | undefined> {
+        const visited = new Set<string>();
+        for (let hop = 0; hop <= SymbolFinderService.MAX_SHIM_HOPS; hop++) {
+            const direct = TokenHelper.findMemberHeaderToken(tokens);
+            if (direct) return direct;
 
-        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
-        for (const inc of includeTokens) {
-            const resolvedPath = path.resolve(currentDir, inc.referencedFile!);
-            if (!fs.existsSync(resolvedPath)) continue;
+            const shimInclude = TokenHelper.findShimIncludeToken(tokens);
+            if (!shimInclude) return undefined;
+            const viaRedirection = resolveViaProjectRedirection328(shimInclude.referencedFile!, fromFile ?? null);
+            const relative = path.resolve(currentDir, shimInclude.referencedFile!);
+            const resolvedPath = viaRedirection ?? (fs.existsSync(relative) ? relative : null);
+            if (!resolvedPath) return undefined;
+            const key = resolvedPath.toLowerCase();
+            if (visited.has(key)) return undefined;
+            visited.add(key);
+
             const incUri = pathToCanonicalUri(resolvedPath);
             let incTokens = this.tokenCache.getTokensByUriCaseInsensitive(incUri);
             if (!incTokens) {
@@ -944,25 +965,18 @@ export class SymbolFinderService {
                     const content = await fs.promises.readFile(resolvedPath, 'utf-8');
                     const incDoc = TextDocument.create(incUri, 'clarion', 1, content);
                     incTokens = this.tokenCache.getTokens(incDoc);
-                } catch { continue; }
+                } catch { return undefined; }
             }
-            const nested = TokenHelper.findMemberHeaderToken(incTokens);
-            if (nested) return nested;
+            tokens = incTokens;
+            currentDir = path.dirname(resolvedPath);
+            fromFile = resolvedPath;
         }
         return undefined;
     }
 
-    /**
-     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
-     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
-     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
-     * Both the redirection parser (matches by extension mask) and SolutionManager.findFileWithExtension
-     * (matches by exact source-file basename) silently fail to resolve an extension-less name:
-     * `resolveViaProjectRedirection('TargetProgram', ...)` -> null,
-     * `resolveViaProjectRedirection('TargetProgram.clw', ...)` -> the correct path.
-     */
+    /** See TokenHelper.normalizeMemberFilename — kept as a thin delegate for existing call sites. */
     private normalizeMemberFilename(name: string): string {
-        return path.extname(name) ? name : `${name}.clw`;
+        return TokenHelper.normalizeMemberFilename(name);
     }
 
     /**
@@ -984,7 +998,7 @@ export class SymbolFinderService {
 
         // If MEMBER file, search the parent PROGRAM file
         const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '').replace(/\//g, '\\'));
-        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePath));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePath), currentFilePath);
         if (memberToken?.referencedFile) {
             try {
                 const memberFile = this.normalizeMemberFilename(memberToken.referencedFile);
@@ -1181,7 +1195,7 @@ export class SymbolFinderService {
 
         // Step 2: If not found and current file has MEMBER token, search parent file
         const currentFilePathForMember = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '').replace(/\//g, '\\'));
-        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePathForMember));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePathForMember), currentFilePathForMember);
 
         if (memberToken && memberToken.referencedFile) {
             logger.info(`Found MEMBER reference to: ${memberToken.referencedFile}`);

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -920,6 +920,39 @@ export class SymbolFinderService {
     }
     
     /**
+     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
+     * targets when no literal MEMBER statement is present locally — mirrors
+     * MemberLocatorService.resolveMemberHeaderToken (same project convention: MEMBER('program')
+     * often lives in a small generated shim reached via INCLUDE('member.clw') rather than being
+     * written directly in each member module, so a shared source tree can belong to different
+     * PROGRAMs across projects by swapping just that shim). TokenHelper.findMemberHeaderToken()
+     * only sees literal tokens in the tokens it's given, so it can never find a MEMBER hidden
+     * behind that indirection on its own. Only looks one INCLUDE hop deep.
+     */
+    private async resolveMemberHeaderToken(tokens: Token[], currentDir: string): Promise<Token | undefined> {
+        const direct = TokenHelper.findMemberHeaderToken(tokens);
+        if (direct) return direct;
+
+        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
+        for (const inc of includeTokens) {
+            const resolvedPath = path.resolve(currentDir, inc.referencedFile!);
+            if (!fs.existsSync(resolvedPath)) continue;
+            const incUri = pathToCanonicalUri(resolvedPath);
+            let incTokens = this.tokenCache.getTokensByUriCaseInsensitive(incUri);
+            if (!incTokens) {
+                try {
+                    const content = await fs.promises.readFile(resolvedPath, 'utf-8');
+                    const incDoc = TextDocument.create(incUri, 'clarion', 1, content);
+                    incTokens = this.tokenCache.getTokens(incDoc);
+                } catch { continue; }
+            }
+            const nested = TokenHelper.findMemberHeaderToken(incTokens);
+            if (nested) return nested;
+        }
+        return undefined;
+    }
+
+    /**
      * Find a structure field or sub-structure accessed via PRE:Field notation.
      * e.g. "IBSDataSets:Record" → prefix="IBSDataSets", fieldName="Record"
      * Finds the structure with structurePrefix="IBSDataSets" and returns scope='field'
@@ -937,10 +970,10 @@ export class SymbolFinderService {
         if (result) return result;
 
         // If MEMBER file, search the parent PROGRAM file
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '').replace(/\//g, '\\'));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePath));
         if (memberToken?.referencedFile) {
             try {
-                const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '').replace(/\//g, '\\'));
                 let resolvedPath = path.resolve(path.dirname(currentFilePath), memberToken.referencedFile);
                 let parentUri = `file:///${resolvedPath.replace(/\\/g, '/')}`;
 
@@ -1133,7 +1166,8 @@ export class SymbolFinderService {
         }
 
         // Step 2: If not found and current file has MEMBER token, search parent file
-        const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+        const currentFilePathForMember = decodeURIComponent(document.uri.replace(/^file:\/\/\//i, '').replace(/\//g, '\\'));
+        const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePathForMember));
 
         if (memberToken && memberToken.referencedFile) {
             logger.info(`Found MEMBER reference to: ${memberToken.referencedFile}`);

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -953,6 +953,19 @@ export class SymbolFinderService {
     }
 
     /**
+     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
+     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
+     * Both the redirection parser (matches by extension mask) and SolutionManager.findFileWithExtension
+     * (matches by exact source-file basename) silently fail to resolve an extension-less name:
+     * `resolveViaProjectRedirection('TargetProgram', ...)` -> null,
+     * `resolveViaProjectRedirection('TargetProgram.clw', ...)` -> the correct path.
+     */
+    private normalizeMemberFilename(name: string): string {
+        return path.extname(name) ? name : `${name}.clw`;
+    }
+
+    /**
      * Find a structure field or sub-structure accessed via PRE:Field notation.
      * e.g. "IBSDataSets:Record" → prefix="IBSDataSets", fieldName="Record"
      * Finds the structure with structurePrefix="IBSDataSets" and returns scope='field'
@@ -974,7 +987,8 @@ export class SymbolFinderService {
         const memberToken = await this.resolveMemberHeaderToken(tokens, path.dirname(currentFilePath));
         if (memberToken?.referencedFile) {
             try {
-                let resolvedPath = path.resolve(path.dirname(currentFilePath), memberToken.referencedFile);
+                const memberFile = this.normalizeMemberFilename(memberToken.referencedFile);
+                let resolvedPath = path.resolve(path.dirname(currentFilePath), memberFile);
                 let parentUri = `file:///${resolvedPath.replace(/\\/g, '/')}`;
 
                 // #119 — cache-first parity with findGlobalVariableInParentFile (:816-838):
@@ -997,7 +1011,7 @@ export class SymbolFinderService {
                         // without it, prefixed fields of parent-inline FILEs dead-end here.
                         const solutionManager = SolutionManager.getInstance();
                         const viaRedirection = solutionManager
-                            ? await solutionManager.findFileWithExtension(memberToken.referencedFile, currentFilePath)
+                            ? await solutionManager.findFileWithExtension(memberFile, currentFilePath)
                             : null;
                         if (!viaRedirection?.path || !fs.existsSync(viaRedirection.path)) {
                             return null;
@@ -1171,7 +1185,9 @@ export class SymbolFinderService {
 
         if (memberToken && memberToken.referencedFile) {
             logger.info(`Found MEMBER reference to: ${memberToken.referencedFile}`);
-            const parentResult = await this.findGlobalVariableInParentFile(word, memberToken.referencedFile, document);
+            const parentResult = await this.findGlobalVariableInParentFile(
+                word, this.normalizeMemberFilename(memberToken.referencedFile), document
+            );
             if (parentResult) return parentResult;
             // Fall through to equates.clw check
         }

--- a/server/src/test/CrossFileMemberViaInclude.test.ts
+++ b/server/src/test/CrossFileMemberViaInclude.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Location, Position } from 'vscode-languageserver-protocol';
+import { DefinitionProvider } from '../providers/DefinitionProvider';
+import { HoverProvider } from '../providers/HoverProvider';
+
+/**
+ * MEMBER hidden behind an INCLUDE shim (real-world project convention: swap which
+ * PROGRAM a shared source tree belongs to by swapping one small generated file,
+ * e.g. `INCLUDE('member.clw')` where member.clw contains the actual
+ * `MEMBER('parent.clw')` statement, rather than writing MEMBER directly in every
+ * member module). TokenHelper.findMemberHeaderToken() only sees literal tokens in
+ * the file it's given, so both MemberLocatorService (hover) and SymbolFinderService
+ * (F12) need to fall through one INCLUDE hop to find it — this pins that fix for
+ * both surfaces, mirroring CrossFilePrefixField327's direct-MEMBER case.
+ */
+
+const PARENT_CONTENT =
+    "  PROGRAM\n" +
+    "GloQ     QUEUE,PRE(GLO)\n" +
+    "Amount     LONG\n" +
+    "         END\n" +
+    "  MAP\n" +
+    "  END\n" +
+    "  CODE\n" +
+    "  RETURN\n";
+
+const SHIM_CONTENT =
+    "  MEMBER('parent.clw')\n";
+
+const MEMBER_CONTENT =
+    "  INCLUDE('shim.clw')\n" +
+    "  MAP\n" +
+    "  END\n" +
+    "Child  PROCEDURE\n" +
+    "  CODE\n" +
+    "  GLO:Amount += 1\n" +
+    "  RETURN\n";
+
+function toUri(fsPath: string): string {
+    return 'file:///' + fsPath.replace(/\\/g, '/').replace(/^([a-zA-Z]):/, (_m, d) => d + '%3A');
+}
+
+function cursorOn(source: string, needle: string, offset = 0): Position {
+    const lines = source.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        const idx = lines[i].indexOf(needle);
+        if (idx !== -1) return { line: i, character: idx + offset };
+    }
+    throw new Error(`cursorOn: '${needle}' not found`);
+}
+
+suite('Cross-file MEMBER-via-INCLUDE resolution', () => {
+
+    let tmpRoot: string;
+    let memberUri: string;
+    let memberDocText: string;
+    const parentFieldLine = 2; // 0-based line of "Amount     LONG" in parent.clw
+
+    setup(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'xfile-member-include-'));
+        fs.writeFileSync(path.join(tmpRoot, 'parent.clw'), PARENT_CONTENT);
+        fs.writeFileSync(path.join(tmpRoot, 'shim.clw'), SHIM_CONTENT);
+        const memberFile = path.join(tmpRoot, 'child.clw');
+        fs.writeFileSync(memberFile, MEMBER_CONTENT);
+        memberUri = toUri(memberFile);
+        memberDocText = MEMBER_CONTENT;
+    });
+
+    teardown(() => {
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    test('F12 on GLO:Amount resolves the parent PROGRAM queue field through the INCLUDE shim', async () => {
+        const doc = TextDocument.create(memberUri, 'clarion', 1, memberDocText);
+        const provider = new DefinitionProvider();
+
+        const result = await provider.provideDefinition(doc, cursorOn(memberDocText, 'GLO:Amount', 5));
+        assert.ok(result, 'F12 must resolve the MEMBER hidden behind INCLUDE(\'shim.clw\')');
+        const loc = (Array.isArray(result) ? result[0] : result) as Location;
+
+        assert.ok(loc.uri.toLowerCase().endsWith('parent.clw'),
+            `F12 must land in parent.clw, got ${loc.uri}`);
+        assert.strictEqual(loc.range.start.line, parentFieldLine,
+            `F12 must land on the Amount field (line ${parentFieldLine}), got ${loc.range.start.line}`);
+    });
+
+    test('hover on GLO:Amount shows the parent PROGRAM queue field through the INCLUDE shim', async () => {
+        const doc = TextDocument.create(memberUri, 'clarion', 1, memberDocText);
+        const provider = new HoverProvider();
+
+        const hover = await provider.provideHover(doc, cursorOn(memberDocText, 'GLO:Amount', 5));
+        assert.ok(hover, 'hover must resolve the MEMBER hidden behind INCLUDE(\'shim.clw\')');
+        const contents = (hover as { contents: { value?: string } | string }).contents;
+        const text = typeof contents === 'string' ? contents : (contents.value ?? '');
+
+        assert.ok(text.includes(`parent.clw:${parentFieldLine + 1}`),
+            `hover must cite parent.clw:${parentFieldLine + 1} (the Amount field); got:\n${text}`);
+    });
+});

--- a/server/src/test/CrossFileMemberViaInclude.test.ts
+++ b/server/src/test/CrossFileMemberViaInclude.test.ts
@@ -13,9 +13,16 @@ import { HoverProvider } from '../providers/HoverProvider';
  * e.g. `INCLUDE('member.clw')` where member.clw contains the actual `MEMBER('parent')`
  * statement, rather than writing MEMBER directly in every member module).
  * TokenHelper.findMemberHeaderToken() only sees literal tokens in the file it's given,
- * so both MemberLocatorService (hover) and SymbolFinderService (F12) need to fall
- * through one INCLUDE hop to find it — this pins that fix for both surfaces, mirroring
+ * so both MemberLocatorService (hover) and SymbolFinderService (F12) need to follow the
+ * INCLUDE to find it — this pins that fix for both surfaces, mirroring
  * CrossFilePrefixField327's direct-MEMBER case.
+ *
+ * The walk is FIRST-STATEMENT-ONLY: MEMBER/PROGRAM must be the first statement of a
+ * compiled module (only comments may precede it), so a shim INCLUDE is only legal as the
+ * file's first statement, and the shim chain is followed one first-statement INCLUDE at a
+ * time (bounded hops + cycle guard). A MEMBER behind any LATER include would not compile —
+ * the 'does NOT resolve' test below pins that no all-includes sweep creeps back in (the
+ * sweep was both a perf hazard on the miss-path and a correctness hazard).
  *
  * `MEMBER('parent')` deliberately omits the `.clw` extension — idiomatic Clarion (the
  * compiler infers it), and the exact shape that exposed a second bug: resolveFilePath /
@@ -106,5 +113,60 @@ suite('Cross-file MEMBER-via-INCLUDE resolution', () => {
 
         assert.ok(text.includes(`parent.clw:${parentFieldLine + 1}`),
             `hover must cite parent.clw:${parentFieldLine + 1} (the Amount field); got:\n${text}`);
+    });
+
+    test('F12 resolves a CHAINED shim (first-statement INCLUDE -> INCLUDE -> MEMBER)', async () => {
+        // Legal-but-rare: the shim's own first statement is another INCLUDE that
+        // carries the MEMBER. Still one file read per hop, still first-statement-only.
+        fs.writeFileSync(path.join(tmpRoot, 'shim.clw'), "  INCLUDE('shim2.clw')\n");
+        fs.writeFileSync(path.join(tmpRoot, 'shim2.clw'), "  MEMBER('parent')\n");
+
+        const doc = TextDocument.create(memberUri, 'clarion', 1, memberDocText);
+        const provider = new DefinitionProvider();
+
+        const result = await provider.provideDefinition(doc, cursorOn(memberDocText, 'GLO:Amount', 5));
+        assert.ok(result, 'F12 must resolve MEMBER through a two-hop shim chain');
+        const loc = (Array.isArray(result) ? result[0] : result) as Location;
+        assert.ok(loc.uri.toLowerCase().endsWith('parent.clw'),
+            `F12 must land in parent.clw, got ${loc.uri}`);
+    });
+
+    test('a MEMBER behind a NON-first-statement INCLUDE does NOT resolve (no all-includes sweep)', async () => {
+        // The file's first statement is a data declaration, so it cannot be a member
+        // module — the compiler requires MEMBER (or the shim INCLUDE carrying it) to be
+        // the FIRST statement. The old sweep walked every INCLUDE token and would have
+        // "found" the MEMBER in shim.clw anyway: wrong (the compiler rejects this file)
+        // and the reason a miss used to cold-tokenize every include.
+        const notAMember =
+            "SomeVar  LONG\n" +
+            "  INCLUDE('shim.clw')\n" +
+            "Child  PROCEDURE\n" +
+            "  CODE\n" +
+            "  GLO:Amount += 1\n" +
+            "  RETURN\n";
+        const otherFile = path.join(tmpRoot, 'notmember.clw');
+        fs.writeFileSync(otherFile, notAMember);
+
+        const doc = TextDocument.create(toUri(otherFile), 'clarion', 1, notAMember);
+        const provider = new DefinitionProvider();
+
+        const result = await provider.provideDefinition(doc, cursorOn(notAMember, 'GLO:Amount', 5));
+        const locs = result ? (Array.isArray(result) ? result : [result]) as Location[] : [];
+        assert.ok(!locs.some(l => l.uri.toLowerCase().endsWith('parent.clw')),
+            'GLO:Amount must NOT resolve into parent.clw — the shim INCLUDE is not the first statement');
+    });
+
+    test('a self-including shim terminates without resolving (cycle guard)', async () => {
+        fs.writeFileSync(path.join(tmpRoot, 'shim.clw'), "  INCLUDE('shim.clw')\n");
+
+        const doc = TextDocument.create(memberUri, 'clarion', 1, memberDocText);
+        const provider = new DefinitionProvider();
+
+        // The assertion is twofold: it returns (no infinite include loop), and it
+        // finds nothing in parent.clw (the chain never reached a MEMBER).
+        const result = await provider.provideDefinition(doc, cursorOn(memberDocText, 'GLO:Amount', 5));
+        const locs = result ? (Array.isArray(result) ? result : [result]) as Location[] : [];
+        assert.ok(!locs.some(l => l.uri.toLowerCase().endsWith('parent.clw')),
+            'a cyclic shim chain must not resolve a MEMBER parent');
     });
 });

--- a/server/src/test/CrossFileMemberViaInclude.test.ts
+++ b/server/src/test/CrossFileMemberViaInclude.test.ts
@@ -10,12 +10,19 @@ import { HoverProvider } from '../providers/HoverProvider';
 /**
  * MEMBER hidden behind an INCLUDE shim (real-world project convention: swap which
  * PROGRAM a shared source tree belongs to by swapping one small generated file,
- * e.g. `INCLUDE('member.clw')` where member.clw contains the actual
- * `MEMBER('parent.clw')` statement, rather than writing MEMBER directly in every
- * member module). TokenHelper.findMemberHeaderToken() only sees literal tokens in
- * the file it's given, so both MemberLocatorService (hover) and SymbolFinderService
- * (F12) need to fall through one INCLUDE hop to find it — this pins that fix for
- * both surfaces, mirroring CrossFilePrefixField327's direct-MEMBER case.
+ * e.g. `INCLUDE('member.clw')` where member.clw contains the actual `MEMBER('parent')`
+ * statement, rather than writing MEMBER directly in every member module).
+ * TokenHelper.findMemberHeaderToken() only sees literal tokens in the file it's given,
+ * so both MemberLocatorService (hover) and SymbolFinderService (F12) need to fall
+ * through one INCLUDE hop to find it — this pins that fix for both surfaces, mirroring
+ * CrossFilePrefixField327's direct-MEMBER case.
+ *
+ * `MEMBER('parent')` deliberately omits the `.clw` extension — idiomatic Clarion (the
+ * compiler infers it), and the exact shape that exposed a second bug: resolveFilePath /
+ * resolveViaProjectRedirection's redirection lookup matches by extension mask, so an
+ * extension-less name never matched and silently failed. A fixture using the (less
+ * common in the wild, but what the earlier version of this test used)
+ * `MEMBER('parent.clw')` form would never have caught that.
  */
 
 const PARENT_CONTENT =
@@ -29,7 +36,7 @@ const PARENT_CONTENT =
     "  RETURN\n";
 
 const SHIM_CONTENT =
-    "  MEMBER('parent.clw')\n";
+    "  MEMBER('parent')\n";
 
 const MEMBER_CONTENT =
     "  INCLUDE('shim.clw')\n" +

--- a/server/src/test/PrefixFieldNameCollidesWithStructure.test.ts
+++ b/server/src/test/PrefixFieldNameCollidesWithStructure.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+/**
+ * A PRE()'d FILE/QUEUE/GROUP field can coincidentally share its name with the enclosing
+ * structure itself — a real shape in dictionary-generated code (e.g. a FILE `Evl` whose
+ * RECORD has a field also named `Evl`, "System Event ident"). `findPrefixFieldInTokens`
+ * matched by `structurePrefix` alone, and StructureProcessor stamps that same prefix on
+ * the declaring structure token too — so `EVL:Evl` resolved to the FILE's own declaration
+ * line instead of the field, with type "UNKNOWN" instead of the field's real type.
+ *
+ * A second, independent bug in the same area: DocumentStructure pushes a structure onto
+ * its stack the moment the structure's own keyword token (FILE/QUEUE/...) is seen, so any
+ * later Variable/StructurePrefix-type token on THAT SAME declaration line — e.g. the
+ * `GLOB:Owner` argument of `OWNER(GLOB:Owner)`, or a `PRE(Evl)` argument — gets mistagged
+ * isStructureField=true with the structure's own prefix too, even though it's an
+ * attribute argument, not a real field. This fixture's OWNER(...) attribute reproduces
+ * that noise directly so the fix's line-based exclusion is pinned, not just the
+ * name-collision fix.
+ */
+
+const CONTENT =
+    "  PROGRAM\n" +
+    "Evl   FILE,PRE(Evl),OWNER(GLOB:Owner)\n" +
+    "Key1                KEY(+Evl:Lic),DUP\n" +
+    "Record                RECORD,PRE()\n" +
+    "Lic                     LONG\n" +
+    "Evl                     LONG\n" +
+    "                      END\n" +
+    "                    END\n" +
+    "  MAP\n" +
+    "  END\n" +
+    "DoStuff PROCEDURE\n" +
+    "  CODE\n" +
+    "  EVL:Evl = 1\n" +
+    "  EVL:Lic = 2\n" +
+    "  RETURN\n";
+
+const evlFieldLine = 5; // 0-based line of "Evl   LONG" (the field, not the FILE)
+const licFieldLine = 4; // 0-based line of "Lic   LONG"
+
+function cursorOn(source: string, needle: string, offset = 0): Position {
+    const lines = source.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        const idx = lines[i].indexOf(needle);
+        if (idx !== -1) return { line: i, character: idx + offset };
+    }
+    throw new Error(`cursorOn: '${needle}' not found`);
+}
+
+suite('PRE:Field resolution when the field shares its structure\'s own name', () => {
+
+    teardown(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    test('EVL:Evl resolves to the FIELD declaration, not the FILE\'s own declaration line', async () => {
+        const doc = TextDocument.create('file:///c%3A/test/collide.clw', 'clarion', 1, CONTENT);
+        const provider = new HoverProvider();
+
+        // Cursor on the "Evl" in "EVL:Evl = 1" (the reference, in CODE)
+        const pos = cursorOn(CONTENT, 'EVL:Evl', 4);
+        const hover = await provider.provideHover(doc, pos);
+        assert.ok(hover, 'hover must resolve EVL:Evl');
+        const contents = (hover as { contents: { value?: string } | string }).contents;
+        const text = typeof contents === 'string' ? contents : (contents.value ?? '');
+
+        assert.ok(text.includes('LONG'), `must show the field's real type LONG, not UNKNOWN; got:\n${text}`);
+        assert.ok(text.includes(`collide.clw:${evlFieldLine + 1}`),
+            `must cite the field's own line (${evlFieldLine + 1}), not the FILE's declaration line; got:\n${text}`);
+        assert.ok(!text.includes('DRIVER'),
+            `must NOT show the FILE's own attribute list (proves it didn't match the FILE declaration token); got:\n${text}`);
+    });
+
+    test('EVL:Lic still resolves correctly alongside the name-colliding EVL:Evl field', async () => {
+        const doc = TextDocument.create('file:///c%3A/test/collide.clw', 'clarion', 1, CONTENT);
+        const provider = new HoverProvider();
+
+        const pos = cursorOn(CONTENT, 'EVL:Lic', 4);
+        const hover = await provider.provideHover(doc, pos);
+        assert.ok(hover, 'hover must resolve EVL:Lic even with the name-colliding Evl field present');
+        const contents = (hover as { contents: { value?: string } | string }).contents;
+        const text = typeof contents === 'string' ? contents : (contents.value ?? '');
+
+        assert.ok(text.includes(`collide.clw:${licFieldLine + 1}`),
+            `must cite the Lic field's own line (${licFieldLine + 1}); got:\n${text}`);
+    });
+});

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -25,6 +25,45 @@ export class TokenHelper {
             t.referencedFile !== undefined);
     }
 
+    /**
+     * The first non-comment token of a compiled module, if it is an INCLUDE
+     * carrying a file reference — i.e. the only place a MEMBER-via-INCLUDE shim
+     * can legally live.
+     *
+     * Language rule: MEMBER (or PROGRAM) must be the FIRST statement in the
+     * compiled token stream — only comments and blank lines may precede it. So
+     * when a file has no literal MEMBER header, the sole legal way for it to be
+     * a MEMBER module is that its first statement is an INCLUDE whose target
+     * (or, transitively, the target's own first-statement INCLUDE) starts with
+     * MEMBER. A MEMBER found in any LATER include would not compile — sweeping
+     * all INCLUDE tokens is therefore not just wasted I/O on the miss-path, it
+     * can invent a parent the compiler would reject.
+     *
+     * Returns undefined when the first statement is anything else (MEMBER and
+     * PROGRAM included — callers already handled the literal-header case via
+     * findMemberHeaderToken / findProgramHeaderToken).
+     */
+    public static findShimIncludeToken(tokens: Token[]): Token | undefined {
+        const first = tokens.find(t =>
+            t.type !== TokenType.Comment &&
+            t.type !== TokenType.LineContinuation);
+        if (first?.value?.toUpperCase() === 'INCLUDE' && first.referencedFile) return first;
+        return undefined;
+    }
+
+    /**
+     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`.
+     * INCLUDE/LINK/MODULE targets always carry an explicit extension, so this is
+     * deliberately only applied to MEMBER targets. Both the redirection parser
+     * (matches by extension mask, e.g. the `*.clw = ...` line in a .red file) and
+     * SolutionManager.findFileWithExtension (matches by exact source-file
+     * basename) silently fail to resolve an extension-less name.
+     */
+    public static normalizeMemberFilename(name: string): string {
+        return /\.[^\\/.]+$/.test(name) ? name : `${name}.clw`;
+    }
+
     /** #337 — PROGRAM header lookup (ClarionDocument-typed, no line cap). */
     public static findProgramHeaderToken(tokens: Token[]): Token | undefined {
         return tokens.find(t =>


### PR DESCRIPTION
# fix(hover,definition): resolve MEMBER through one INCLUDE hop for hover and F12

**Status**: this took three passes to get right. Each earlier commit fixed a real bug, but none of
them alone fixed the reported symptom (`EVL:Lic` giving no hover) — see the two "Follow-up" sections
below for what each subsequent test run still got wrong, and the final one for what actually closed it.

## What happened

Hovering (or F12-ing) a cross-file reference — a plain global variable, or a `PRE:Field`-style
reference — returns **nothing at all** in member modules that use a common project convention:
putting the actual `MEMBER('program')` statement inside a small generated shim file, reached via
`INCLUDE('member.clw')`, instead of writing `MEMBER(...)` directly in every member.

Reproduced with `EVL:Lic` in a member file whose own `INCLUDE('member.clw')` contains:

```clarion
MEMBER('TargetProgram')
```

Both `lsp_hover` and `lsp_definition` return nothing for this reference.

## Root cause

`TokenHelper.findMemberHeaderToken(tokens)` looks for a literal `MEMBER` token with a
`referencedFile` **in the tokens it's given** — i.e. only the current file's own tokens. When the
real `MEMBER(...)` statement lives in a separately-INCLUDEd shim file instead, this returns
`undefined`, and every caller's "check the MEMBER parent" step is silently skipped.

Six call sites depend on this, across two services:
- `MemberLocatorService.ts` (hover path): global-variable cross-file lookup, `PRE:field` lookup, class
  member lookup, `warmMemberParent`.
- `SymbolFinderService.ts` (F12/definition path): `findPrefixedField`, `findGlobalVariable`.

## Fix

Both services gained a `resolveMemberHeaderToken(tokens, dir, fromFile)` helper: try
`TokenHelper.findMemberHeaderToken` on the file's own tokens first (unchanged, fast path); if that
finds nothing, follow the file's **first statement** — and only its first statement — into an
INCLUDE'd shim.

This shape comes from a language rule, not a heuristic: `MEMBER` (or `PROGRAM`) must be the first
statement of a compiled module — only comments may precede it. So when a file has no literal
`MEMBER`, the only legal shim form is that the file's first statement is the INCLUDE carrying it
(or, transitively, the shim's own first statement is another INCLUDE — legal but rare). A `MEMBER`
behind any *later* include would not compile. Consequences:

- a non-INCLUDE first statement is an instant miss with **zero file reads** — the common miss-path
  (the freeze class from #358/#366/#367) now costs nothing;
- each hop reads exactly **one** file; `MAX_SHIM_HOPS` (3) bounds the chained-shim case and a
  visited set stops include cycles;
- no sweep over all INCLUDE tokens — which was also a correctness hazard, since it could infer a
  parent the compiler rejects.

`SymbolFinderService`'s copy resolves the shim include redirection-first
(`resolveViaProjectRedirection`, threaded with the current file for the #328 owner-project-first
behavior) with the relative-path probe as fallback — the same order
`MemberLocatorService.resolveFilePath` uses — so a shim reachable only via a `.red` mapping resolves
identically for hover and F12.

The convention logic itself lives as `TokenHelper` statics (`findShimIncludeToken`,
`normalizeMemberFilename`) shared by both services.

All 6 call sites (`MemberLocatorService.ts` x4, `SymbolFinderService.ts` x2) go through this instead
of calling `TokenHelper.findMemberHeaderToken` directly.

## Testing

New test file `CrossFileMemberViaInclude.test.ts`, mirroring the existing direct-MEMBER pin in
`CrossFilePrefixField327.test.ts`: a member file `INCLUDE`s a `shim.clw` containing
`MEMBER('parent')`, and both F12 and hover on a `PRE:Field` reference must resolve to the parent
PROGRAM's field through that indirection. Plus three first-statement-rule pins, each verified red
against the sweep implementation by reverting just the source fix:

- a chained shim (first-statement `INCLUDE` → `INCLUDE` → `MEMBER`) resolves;
- a `MEMBER` behind a **non**-first-statement INCLUDE does **not** resolve — pins that no
  all-includes sweep creeps back in;
- a self-including shim terminates without resolving (cycle guard).

`npm run test:server`: 2390 passing / 0 failing / 4 pending, rebased onto `origin/version-1.0.2`
(the merged #391 three-arg `isVariableLookupCandidate` signature re-applied throughout).

## Scope

Four files: `server/src/services/MemberLocatorService.ts`, `server/src/services/SymbolFinderService.ts`,
`server/src/utils/TokenHelper.ts` (shared shim-convention statics),
`server/src/test/CrossFileMemberViaInclude.test.ts` (new). 
Found while investigating a hover-links bug report, but this is a plain cross-file symbol-resolution bug unrelated to that feature, so it goes out as its own PR.

## Follow-up #1: `fromFile` omission in redirection (real bug, but NOT what was blocking `EVL:Lic`)

Testing the fix above with a `SolutionManager` loaded surfaced a second issue:
`resolveMemberHeaderToken`'s call to `resolveFilePath(inc.referencedFile!, fromDir)` (and several
pre-existing parent-path resolutions in the same file) omitted the third `fromFile` argument. Per the
`#328` "owner-project-first" contract on `resolveFilePath`/`resolveViaProjectRedirection`: without
`fromFile`, redirection can't identify which project is asking and falls back to an unscoped walk
across every project's redirection parser, returning the first match in solution order rather than the
one actually owned by the file being hovered — a real correctness gap in a multi-project solution.

Fixed by threading the current file's path through as `fromFile` everywhere it was missing. This is a
legitimate, worth-keeping fix, but **turned out not to be what was blocking the `EVL:Lic` repro** — the
test solution used here has only one project, so there was no cross-project collision actually
happening. Diagnosed with a standalone test that initially bypassed the resolver's redirection path
entirely — it had no `SolutionManager` loaded, so it never even exercised the code path it was meant to
test. Lesson for follow-up #2.

## Follow-up #2: extension-less MEMBER targets (this is what was actually blocking `EVL:Lic`)

`EVL:Lic` still gave no hover after follow-up #1. Rewriting the test to actually load a
`SolutionManager` (`SolutionManager.create('...TargetProgram.sln')`) before calling the resolver —
matching the production code path instead of accidentally exercising the no-solution fallback —
surfaced the answer directly:

```
resolveViaProjectRedirection('TargetProgram', ...)      => null
resolveViaProjectRedirection('TargetProgram.clw', ...)  => <project dir>\TargetProgram.clw
```

Clarion `MEMBER('TargetProgram')` conventionally omits the `.clw` extension (the compiler infers
it) — completely idiomatic, not an edge case. `referencedFile` is stored exactly as written by the
tokenizer. `resolveViaProjectRedirection`'s lookup matches by extension mask (a `.red` file's `*.clw =
...` line), so an extension-less name never matches any rule; `SolutionManager.findFileWithExtension`
matches by exact source-file basename, which also misses. Both silently return nothing for the
idiomatic, extension-less form — which is presumably the common case in most Clarion codebases, not a
corner case.

**This is also why the tokenizer's `structurePrefix` propagation for nested `FILE,PRE(x)` →
`RECORD,PRE()` → field was never actually the problem** (a concern raised earlier in this
investigation) — the chain never got far enough to exercise it; it was dying one step earlier, on the
MEMBER→PROGRAM hop itself.

Fixed with a `normalizeMemberFilename()` helper in both services (append `.clw` only when there's no
extension already — deliberately scoped to MEMBER targets only, since INCLUDE/LINK/MODULE targets
always carry an explicit extension already) applied at every MEMBER-target resolution call site.
Updated `CrossFileMemberViaInclude.test.ts`'s shim fixture from `MEMBER('parent.clw')` to
`MEMBER('parent')` — the explicit-extension form the original fixture used would never have caught
either of these bugs.

Verified end-to-end with a `SolutionManager` loaded:
`findPrefixFieldTokenInChain('Evl', 'Lic', ...)` now resolves to the dictionary include file, matching
the expected hover output. `npm run test:server`: all passing, 0 failing, verified again in the isolated
worktree.

## Follow-up #3: field name collides with its own enclosing structure's name

`EVL:Lic` and `EVL:Txt` now resolved correctly, but `EVL:Evl` (a field named the same as its enclosing
FILE) showed `Evl — UNKNOWN` pointing at the FILE's own declaration line instead of the field. Two
independent bugs, both in the same small area:

1. `findPrefixFieldInTokens` matched by `structurePrefix` alone. `StructureProcessor` stamps
   `structurePrefix` on the declaring structure token itself, not just its fields, so a field that
   happens to share its structure's name matches the structure's own declaration token first (it
   appears earlier in document order).
2. A second, independent tokenizer quirk feeds the same symptom class: `DocumentStructure` pushes a
   structure onto its stack the moment the structure's own keyword token is seen, so a *later*
   Variable/StructurePrefix-type token on that **same declaration line** — e.g. the `GLOB:Owner`
   argument of `OWNER(GLOB:Owner)`, or the `Evl` argument inside `PRE(Evl)` itself — gets mistagged
   `isStructureField=true` with the structure's own prefix too, even though it's an attribute
   argument, not a real field.

Fixed both with a targeted selector in `findPrefixFieldInTokens` — prefer a field match that is
`isStructureField` AND declared on a line strictly after its `structureParent`'s own line — rather
than touching `DocumentStructure`'s core structure-stack walker, which many other features
(completion, diagnostics, F12) depend on.

Also addressed the original ergonomic question that started this whole thread: a `PRE:Field` hover
(e.g. `EVL:Lic`) resolves through the same code path as a true global variable and showed a generic
"🌍 Global variable" label — losing exactly the context needed to tell a real global apart from a
structure field reached via its PRE prefix. Now labeled "🔷 `Evl` field", matching the "`X` Field:"
wording `StructureFieldResolver` already uses for dot-notation access (`Evl.Lic`) to the same field.

New test: `PrefixFieldNameCollidesWithStructure.test.ts`, reproducing both the name-collision and the
same-line-attribute-argument shapes directly. `npm run test:server`: all passing (2344 in the isolated
worktree's older base + the 2 new tests), 0 failing.

**Confirmed via the test suite**: `EVL:Lic`, `EVL:Txt`, and `EVL:Evl` all hover correctly now, each
showing exactly one result — `EVL:Lic` is a single lexical token (Clarion colon-prefix notation), so
there is exactly one thing to hover, unlike `Evl.Lic` (two separate dot-joined tokens, each
independently hoverable, which is why that form can show two different results depending on which half
the cursor is on). That's expected, not a gap — noted here so a future pass doesn't try to "fix" it.

