### PR TITLE
feat(hover): render footer file:line locations as clickable links

### DIFF
--- a/server/src/providers/hover/HoverFormatter.ts
+++ b/server/src/providers/hover/HoverFormatter.ts
@@ -3,7 +3,6 @@ import { Token, TokenType } from '../../ClarionTokenizer';
 import { ScopeAnalyzer } from '../../utils/ScopeAnalyzer';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TokenCache } from '../../TokenCache';
-import * as path from 'path';
 import * as fs from 'fs';
 
 /**
@@ -124,9 +123,6 @@ export class HoverFormatter {
         }
         
         if (document) {
-            const fileName = path.basename(document.uri.replace('file:///', ''));
-            const lineNumber = info.line + 1;
-            
             // Add the actual source code line
             const content = document.getText();
             const lines = content.split(/\r?\n/);
@@ -141,7 +137,7 @@ export class HoverFormatter {
             }
 
             // Location at bottom, after code block
-            markdown.push(`${fileName}:${lineNumber}`);
+            markdown.push(this.locationLink(document.uri, info.line));
 
             // Append doc comment if present
             const docComment = DocCommentReader.read(lines, info.line);
@@ -186,8 +182,7 @@ export class HoverFormatter {
             markdown.push('```');
         }
 
-        const fileName = info.file.split(/[\/\\]/).pop() || info.file;
-        markdown.push(`${fileName}:${info.line + 1}`);
+        markdown.push(this.locationLink(info.file, info.line));
 
         return { contents: { kind: 'markdown', value: markdown.join('\n') } };
     }
@@ -202,7 +197,9 @@ export class HoverFormatter {
 
         let docComment: DocComment | null = null;
         let declSnippet: string | null = null;
-        let declLocationStr = '';
+        // Derived from the URI alone, so it survives an unreadable file — hence built up-front
+        // instead of separately in the try and the catch.
+        const declLocationStr = this.locationLink(declarationInfo.file, declarationInfo.line);
 
         try {
             const declUri = decodeURIComponent(declarationInfo.file.replace('file:///', ''));
@@ -211,11 +208,7 @@ export class HoverFormatter {
             const declLine = declLines[declarationInfo.line];
             docComment = DocCommentReader.read(declLines, declarationInfo.line);
             if (declLine) declSnippet = declLine.trim();
-            declLocationStr = `${path.basename(declUri)}:${declarationInfo.line + 1}`;
-        } catch {
-            const fileName = declarationInfo.file.split(/[\/\\]/).pop() || declarationInfo.file;
-            declLocationStr = `${fileName}:${declarationInfo.line + 1}`;
-        }
+        } catch { }
 
         if (declSnippet) {
             markdown.push('```clarion');
@@ -226,10 +219,11 @@ export class HoverFormatter {
         let implLocationStr = '';
         try {
             const lastColonIndex = implementationLocation.lastIndexOf(':');
-            const implFilePath = implementationLocation.substring(0, lastColonIndex).replace('file:///', '');
+            const implLocationUri = implementationLocation.substring(0, lastColonIndex);   // scheme kept, for the link
+            const implFilePath = implLocationUri.replace('file:///', '');
             const implLine = parseInt(implementationLocation.substring(lastColonIndex + 1));
             const implUri = decodeURIComponent(implFilePath);
-            implLocationStr = `${path.basename(implUri)}:${implLine + 1}`;
+            implLocationStr = this.locationLink(implLocationUri, implLine);
             if (!implUri.startsWith('test://')) {
                 try {
                     const implLines = fs.readFileSync(implUri, 'utf-8').split('\n');
@@ -278,8 +272,7 @@ export class HoverFormatter {
         markdown.push(declInfo.signature.trim());
         markdown.push('```');
 
-        const fileName = declInfo.file.split(/[\/\\]/).pop() || declInfo.file;
-        markdown.push(`${fileName}:${declInfo.line + 1}`);
+        markdown.push(this.locationLink(declInfo.file, declInfo.line));
 
         let docComment: DocComment | null = null;
         try {
@@ -557,11 +550,9 @@ export class HoverFormatter {
 
                 const mapLines = mapContent.split('\n');
                 const mapLine = mapLines[mapDecl.range.start.line];
-                const fileName = mapUri.includes('://')
-                    ? mapUri.split('/').pop() || 'unknown'
-                    : path.basename(mapUri);
-                const lineNumber = mapDecl.range.start.line + 1;
-                declLocationStr = `${fileName}:${lineNumber}`;
+                // Link from mapDecl.uri, NOT the decoded mapUri used for the fs read above — the
+                // original URI is what the opener needs, and it is already percent-encoded.
+                declLocationStr = this.locationLink(mapDecl.uri, mapDecl.range.start.line);
 
                 if (mapLine && !isAtMapDeclaration) {
                     parts.push(`\`\`\`clarion\n${mapLine.trim()}\n\`\`\``);
@@ -576,13 +567,7 @@ export class HoverFormatter {
         let implLocationStr = '';
         if (procImpl) {
             try {
-                const implUri = procImpl.uri.startsWith('test://')
-                    ? procImpl.uri
-                    : decodeURIComponent(procImpl.uri.replace('file:///', ''));
-                const fileName = implUri.includes('://')
-                    ? implUri.split('/').pop() || 'unknown'
-                    : path.basename(implUri);
-                implLocationStr = `${fileName}:${procImpl.range.start.line + 1}`;
+                implLocationStr = this.locationLink(procImpl.uri, procImpl.range.start.line);
             } catch (error) {
                 logger.error(`Error reading PROCEDURE implementation: ${error}`);
             }
@@ -859,6 +844,54 @@ export class HoverFormatter {
         return {
             contents: { kind: 'markdown', value: content.trim() }
         };
+    }
+
+    /**
+     * Renders a hover footer location as a CLICKABLE markdown link — `[Foo.clw:12](file:///…/Foo.clw#L12)`.
+     *
+     * The `#L<line>` fragment is the editor-core convention for "open this file at that line": VS Code's
+     * opener service parses it out of the target URI before opening (`extractSelection`), so the link
+     * navigates with no client-side command, no `isTrusted` markdown, and no new LSP request. Hosts that
+     * embed Monaco get the same behaviour by registering a link opener.
+     *
+     * Each location is linked SEPARATELY — a "declaration → implementation" footer (`Foo.inc:12 →
+     * Foo.clw:340`) yields two independent links, since jumping to the prototype and jumping to the body
+     * are different intents.
+     *
+     * Falls back to the previous plain text when the location isn't openable (a `test://` fixture URI, or
+     * any other non-file scheme), so hover output is unchanged wherever a link would be dead.
+     */
+    locationLink(fileOrUri: string, line0: number): string {
+        const lineNo = line0 + 1;
+        const label = `${this.locationBaseName(fileOrUri)}:${lineNo}`;
+        const uri = this.toFileUri(fileOrUri);
+        return uri ? `[${label}](${uri}#L${lineNo})` : label;
+    }
+
+    /** File name for a footer label, from either a `file:///` URI or a plain path (percent-decoded). */
+    private locationBaseName(fileOrUri: string): string {
+        const last = (fileOrUri || '').split(/[\/\\]/).pop() || fileOrUri || '';
+        try { return decodeURIComponent(last); } catch { return last; }
+    }
+
+    /**
+     * Normalises a location to a `file:` URI for linking, or null when it can't be one.
+     * Already-URI inputs are passed through untouched (they are already percent-encoded); a plain
+     * path is converted segment-wise so spaces survive. The drive-letter segment (`d:`) is left
+     * UNESCAPED — that's the canonical `file:///d:/...` form vscode-uri/Node's pathToFileURL both
+     * produce (and what the OTHER half of a decl→impl footer already uses, since that one comes
+     * from an already-formed `file://` Location.uri). Percent-encoding it as `d%3A` — this
+     * function's first cut — was inconsistent with that and, being non-canonical, an avoidable
+     * risk for any URI consumer that special-cases the raw two-char drive-letter pattern.
+     */
+    private toFileUri(fileOrUri: string): string | null {
+        if (!fileOrUri) return null;
+        if (fileOrUri.startsWith('file://')) return fileOrUri;
+        if (fileOrUri.includes('://')) return null;   // test:// and friends — not openable
+        const segments = fileOrUri.replace(/\\/g, '/').split('/');
+        const encoded = segments.map((seg, i) =>
+            i === 0 && /^[a-zA-Z]:$/.test(seg) ? seg : encodeURIComponent(seg));
+        return 'file:///' + encoded.join('/');
     }
 
     /**

--- a/server/src/providers/hover/MethodHoverResolver.ts
+++ b/server/src/providers/hover/MethodHoverResolver.ts
@@ -90,8 +90,6 @@ export class MethodHoverResolver {
             );
             if (classToken) {
                 const typeStr = SymbolFinderService.extractTypeInfo(classToken, tokens);
-                const fileName = path.basename(document.uri.replace(/file:\/\/\//i, '').replace(/\//g, '\\'));
-                const lineNumber = classToken.line + 1;
                 const lineTokens = tokens.filter(t => t.line === classToken.line);
                 const declaration = lineTokens.map(t => t.value).join(' ');
                 const markdown = [
@@ -102,7 +100,7 @@ export class MethodHoverResolver {
                     '```clarion',
                     declaration,
                     '```',
-                    `${fileName}:${lineNumber}`
+                    this.formatter.locationLink(document.uri, classToken.line)
                 ];
                 return { contents: { kind: 'markdown', value: markdown.join('\n') } };
             }

--- a/server/src/providers/hover/StructureFieldResolver.ts
+++ b/server/src/providers/hover/StructureFieldResolver.ts
@@ -320,14 +320,13 @@ export class StructureFieldResolver {
         const declaration = lineTokens.map(t => t.value).join('  ').trim();
         const typeToken = lineTokens.find(t => t.start > fieldToken.start);
         const fieldType = typeToken?.value ?? 'UNKNOWN';
-        const fileName = path.basename(decodeURIComponent(sourceUri.replace(/^file:\/\/\//, '')).replace(/\//g, path.sep));
         const markdown = [
             `**${typeName} Field:** \`${fieldName}\` — \`${fieldType}\``,
             ``,
             `\`\`\`clarion`,
             declaration,
             `\`\`\``,
-            `${fileName}:${fieldToken.line + 1}`
+            this.formatter.locationLink(sourceUri, fieldToken.line)
         ].join('\n');
         return { contents: { kind: 'markdown', value: markdown } };
     }
@@ -372,7 +371,6 @@ export class StructureFieldResolver {
                     const structToken = lineTokens.find(t => t.type === TokenType.Structure);
                     const structKind = structToken?.value.toUpperCase() ?? 'TYPE';
                     const declaration = lineTokens.map(t => t.value).join('  ').trim();
-                    const incFileName = path.basename(equatesPath);
                     let structureEndLine = Number.MAX_VALUE;
                     if (structToken?.finishesAt !== undefined) structureEndLine = structToken.finishesAt;
                     const fieldCount = equatesTokens.filter(t =>
@@ -389,7 +387,7 @@ export class StructureFieldResolver {
                         `\`\`\`clarion`,
                         declaration,
                         `\`\`\``,
-                        `${incFileName}:${labelToken.line + 1}`
+                        this.formatter.locationLink(equatesPath, labelToken.line)
                     ].join('\n');
                     return { contents: { kind: 'markdown', value: markdown } };
                 }
@@ -452,7 +450,6 @@ export class StructureFieldResolver {
                     const structToken = lineTokens.find(t => t.type === TokenType.Structure);
                     const structKind = structToken?.value.toUpperCase() ?? 'TYPE';
                     const declaration = lineTokens.map(t => t.value).join('  ').trim();
-                    const incFileName = path.basename(resolvedPath);
 
                     // Count fields in the structure
                     let structureEndLine = Number.MAX_VALUE;
@@ -473,7 +470,7 @@ export class StructureFieldResolver {
                         `\`\`\`clarion`,
                         declaration,
                         `\`\`\``,
-                        `${incFileName}:${labelToken.line + 1}`
+                        this.formatter.locationLink(resolvedPath, labelToken.line)
                     ].join('\n');
                     return { contents: { kind: 'markdown', value: markdown } };
                 }
@@ -561,14 +558,13 @@ export class StructureFieldResolver {
                         const declaration = lineTokens.map(t => t.value).join('  ').trim();
                         const typeToken = lineTokens.find(t => t.start > fieldToken.start);
                         const fieldType = typeToken?.value ?? 'UNKNOWN';
-                        const incFileName = path.basename(resolvedPath);
                         const markdown = [
                             `**${typeName} Field:** \`${fieldName}\` — \`${fieldType}\``,
                             ``,
                             `\`\`\`clarion`,
                             declaration,
                             `\`\`\``,
-                            `${incFileName}:${fieldToken.line + 1}`
+                            this.formatter.locationLink(resolvedPath, fieldToken.line)
                         ].join('\n');
                         return { contents: { kind: 'markdown', value: markdown } };
                     }

--- a/server/src/providers/hover/VariableHoverResolver.ts
+++ b/server/src/providers/hover/VariableHoverResolver.ts
@@ -104,9 +104,6 @@ export class VariableHoverResolver {
             markdown.push(`${scopeIcon} Module variable`);
         }
         
-        const fileName = path.basename(document.uri.replace('file:///', ''));
-        const lineNumber = symbolInfo.location.line + 1;
-        
         // Add the actual source code line
         if (symbolInfo.declaration) {
             markdown.push(``);
@@ -116,7 +113,7 @@ export class VariableHoverResolver {
         }
 
         // Location at bottom, after code block
-        markdown.push(`${fileName}:${lineNumber}`);
+        markdown.push(this.formatter.locationLink(document.uri, symbolInfo.location.line));
         
         markdown.push(``);
         
@@ -302,9 +299,6 @@ export class VariableHoverResolver {
             }
         }
         
-        const fileName = path.basename(document.uri.replace('file:///', ''));
-        const lineNumber = globalVar.line + 1;
-        
         // Add the actual source code line
         const content = document.getText();
         const lines = content.split(/\r?\n/);
@@ -319,7 +313,7 @@ export class VariableHoverResolver {
         }
 
         // Location at bottom, after code block
-        markdown.push(`${fileName}:${lineNumber}`);
+        markdown.push(this.formatter.locationLink(document.uri, globalVar.line));
         
         return {
             contents: {

--- a/server/src/test/HoverFormatter.LocationLink.test.ts
+++ b/server/src/test/HoverFormatter.LocationLink.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import { HoverFormatter } from '../providers/hover/HoverFormatter';
+import { ScopeAnalyzer } from '../utils/ScopeAnalyzer';
+import { TokenCache } from '../TokenCache';
+
+/**
+ * `locationLink` renders a hover footer location as a clickable markdown link
+ * (`[name:line](file:///...#Lline)`) instead of plain text. Pins the link shape across the
+ * input forms callers actually pass it: a plain OS path, a path containing a space, an
+ * already-formed `file://` URI, and a non-file scheme (which must fall back to plain text
+ * unchanged, since `test://` fixture URIs and similar aren't openable).
+ */
+suite('HoverFormatter.locationLink', () => {
+    const formatter = new HoverFormatter(new ScopeAnalyzer(TokenCache.getInstance(), undefined as never));
+
+    test('plain Windows path with a drive letter renders as a clickable link, drive letter unescaped', () => {
+        const link = formatter.locationLink('d:\\proj\\demo.clw', 2);
+        assert.strictEqual(link, '[demo.clw:3](file:///d:/proj/demo.clw#L3)');
+    });
+
+    test('path containing a space is percent-encoded in the URI but not in the label', () => {
+        const link = formatter.locationLink('d:\\src dir\\demo.clw', 0);
+        assert.strictEqual(link, '[demo.clw:1](file:///d:/src%20dir/demo.clw#L1)');
+    });
+
+    test('an already-formed file:// URI is passed through untouched', () => {
+        const link = formatter.locationLink('file:///D:/proj/Foo.clw', 4);
+        assert.strictEqual(link, '[Foo.clw:5](file:///D:/proj/Foo.clw#L5)');
+    });
+
+    test('a non-file scheme (e.g. test:// fixtures) falls back to plain text, unchanged', () => {
+        const link = formatter.locationLink('test://fixture/demo.clw', 6);
+        assert.strictEqual(link, 'demo.clw:7');
+    });
+
+    test('two locations in a decl -> impl footer link independently', () => {
+        const declLink = formatter.locationLink('d:\\proj\\demo.inc', 1);
+        const implLink = formatter.locationLink('d:\\proj\\demo.clw', 39);
+        const footer = `${declLink} → ${implLink}`;
+        assert.strictEqual(
+            footer,
+            '[demo.inc:2](file:///d:/proj/demo.inc#L2) → [demo.clw:40](file:///d:/proj/demo.clw#L40)'
+        );
+    });
+});


### PR DESCRIPTION
# Hover: make the `file:line` footer locations clickable

**Companion PR**: `geircodes/ClarionAssistant#feat/hover-position-font-links` (Monaco-side: hover
reposition/font sync + a `registerLinkOpener` that makes the links this PR produces actually navigate
in the Monaco-embedding host). This PR's links work fine in VS Code on their own; the companion PR is
what makes them clickable in a host that embeds Monaco instead. Originally scoped as a look-and-feel
Issue+patch; re-scoped to a PR given the combined size of the two changes.

Here is what it looks like after:

&emsp;&emsp;<img width="535" height="130" alt="image" src="https://github.com/user-attachments/assets/fc673125-5838-4dc5-8cfe-58560c16894e" />


## What happens today

Every hover footer that cites a location renders as plain text:

`````
**LocVar** — `LONG`
🔧 Local procedure variable
```clarion
LocVar  LONG
```
demo.clw:2
`````

…and for a procedure, the declaration/implementation pair:

```
demo.inc:2 → demo.clw:3
```

The hover has just told you exactly where the symbol lives, but getting there means F12 (which
re-resolves from scratch and picks *one* target) or reading the line number and navigating by hand.
The `decl → impl` footer is the case that stings most: it names two different places and neither is
reachable from the tooltip.

## Proposal

Render each location as a markdown link to the file with an `#L<line>` fragment:

```
[demo.inc:2](file:///c%3A/proj/demo.inc#L2) → [demo.clw:3](file:///c%3A/proj/demo.clw#L3)
```

`#L<line>` is editor-core's own convention: VS Code's opener service strips the fragment into a
selection before opening (`extractSelection`, which accepts `#L12`, `#12` and `#L12,5`). So the link
navigates with:

- no new client-side command, and no `isTrusted` markdown (only `command:` links need that — `file:`
  links are opened by the standard opener),
- no extra LSP round-trip on click,
- nothing to register in the client at all for VS Code.

Hosts that embed Monaco rather than VS Code can honor the identical link by registering a
`monaco.editor.registerLinkOpener` that routes `file:` URIs to their own navigation (verified working
against Monaco 0.52.2 — same `extractSelection` code path, so the same link form serves both; this is
what the companion PR adds).

**Each location is linked separately**, since jumping to a prototype and jumping to a body are
different intents.

## Behaviour when a location isn't openable

`toFileUri()` returns null for `test://` fixture URIs and any other non-file scheme, and the footer
falls back to today's exact plain text. So hover output is unchanged wherever a link would be dead —
including the whole test fixture suite.

## Scope

A helper trio (`locationLink` / `locationBaseName` / `toFileUri`) on `HoverFormatter`, used across four
files and thirteen footer sites in total:

**`HoverFormatter.ts`** (six sites):

| Method | Footer |
|---|---|
| `formatVariable` | declaring file:line |
| `formatClassMember` | declaring file:line |
| `formatMethodCall` | declaration **and** implementation (two links) |
| `formatMethodImplementation` | declaration file:line |
| `formatProcedure` | MAP declaration **and** implementation (two links) |

`formatParameter` is left alone — `ParameterInfo` carries no file, only a line, so there is nothing to
link to.

**Three other resolver files** (seven more sites) that built their footer as a raw
`${fileName}:${lineNumber}` template string and never called `HoverFormatter.locationLink` at all, so
they rendered as plain, non-clickable text even after the `HoverFormatter` sites above were fixed:

| File | Method | Cross-file? |
|---|---|---|
| `VariableHoverResolver.ts` | `findModuleVariableHover` | same-file only |
| `VariableHoverResolver.ts` | `buildGlobalVariableHover` (reached via `searchEquatesFile`, `findInIncludesAndEquates`) | **yes** — equates/INCLUDE search |
| `MethodHoverResolver.ts` | class-prefix declaration footer (hovering the class name in `Class.Method PROCEDURE`) | same-file only |
| `StructureFieldResolver.ts` | `findFieldInTokens` | same-file only |
| `StructureFieldResolver.ts` | `resolveTypeNameHover`'s equates.clw fallback | **yes** — equates.clw |
| `StructureFieldResolver.ts` | `findTypeDeclarationInIncludes` | **yes** — INCLUDE chain |
| `StructureFieldResolver.ts` | `findFieldInTypeIncludes` | **yes** — INCLUDE chain |

Fixed by promoting `HoverFormatter.locationLink` from `private` to a plain method (all three resolvers
already hold a `formatter: HoverFormatter` instance via constructor injection, so no new wiring was
needed) and replacing each raw footer string with a call to it.

One false alarm ruled out during the audit: `MethodHoverResolver.resolveChainedMethodCall`'s
`implLocationStr` looks unlinked (it's a raw `${uri}:${line}` string) but is passed into
`HoverFormatter.formatMethodCall`, which re-parses it and does call `locationLink` — that path already
worked, no change needed.

Two incidental cleanups fall out of the `HoverFormatter` change:

- `formatMethodCall` built `declLocationStr` separately in the `try` and the `catch`; the label
  derives from the URI alone, so it moves above the `try` and the duplicate goes away.
- `formatProcedure` built its labels from the *decoded* path used for the `fs` read. The link needs
  the original (already percent-encoded) `Location.uri`, which is also the more correct source for
  the label, so both footers now read from `mapDecl.uri` / `procImpl.uri`.
- The `path` import is no longer used in `HoverFormatter.ts` and is removed.

## A real cross-file bug this surfaces well

Hovering a `PRE:Field`-style reference (e.g. `FILE_LABEL:FieldName`) that resolves into a different,
already-open-elsewhere file previously showed the correct location as inert text — the footer named
the right file and line, but there was no way to jump there short of reading it and navigating by hand.
That's exactly the `buildGlobalVariableHover`/equates-and-INCLUDE-search row in the table above.

## Verification

- `npm run test:server`: all passing, 0 failing. Existing assertions such as
  `hoverText.includes('utils.clw:57')` and `content.includes('.clw:')` keep passing unchanged, because
  the link **label** preserves the exact `name.ext:line` text — no test asserts whole-footer equality.
- `tsc --noEmit` clean.
- New test file `HoverFormatter.LocationLink.test.ts`, pinning the link shape directly: a plain Windows
  path with a drive letter (unescaped, matching `pathToFileURL`'s canonical form), a path containing a
  space (percent-encoded in the URI, not the label), an already-formed `file://` URI passed through
  untouched, a non-file scheme falling back to plain text, and two locations in a `decl → impl` footer
  linking independently.
- Live-tested by the developer across several rounds on a real deployment (with the companion PR
  deployed too): single- and multi-location links, drive-letter/space encoding, and cross-file
  resolution through equates/INCLUDE chains all confirmed working correctly.

## Known gap, deliberately not chased here

`HoverRouter.ts`'s `handleImplementsHover` (hovering an interface name in `IMPLEMENTS(...)`) pushes a
bare filename string straight into the markdown, bypassing `HoverFormatter` entirely — not touched by
this PR, flagged for separate follow-up. A related but likely-unrelated case (a plain procedure-call
hover showing a wrong, non-clickable filename because the correct target is gated behind a
`COMPILE`/`OMIT` section the resolver doesn't evaluate) was also observed but not chased down here —
out of scope for this link-rendering change.
