### PR TITLE
fix(hover): bare-word lookup no longer matches unrelated CLASS/INTERF…

### DIFF
--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -129,7 +129,7 @@ export class MemberLocatorService {
             // cross-file cache holds it) so a stale token is never handed out.
             const data = await this.loadDocument(cachedPath);
             const found = data?.tokens.find(t =>
-                this.isVariableLookupCandidate(t) && this.tokenMatchesName(t, varName.toLowerCase())
+                this.isVariableLookupCandidate(t, data!.doc) && this.tokenMatchesName(t, varName.toLowerCase())
             );
             if (data && found) return { token: found, tokens: data.tokens, doc: data.doc };
             // File gone or declaration moved — fall through to a fresh walk.
@@ -162,7 +162,7 @@ export class MemberLocatorService {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
                     const parentVar = parentData.tokens.find(t =>
-                        this.isVariableLookupCandidate(t) && this.tokenMatchesName(t, varName.toLowerCase())
+                        this.isVariableLookupCandidate(t, parentData.doc) && this.tokenMatchesName(t, varName.toLowerCase())
                     );
                     if (parentVar) return { token: parentVar, tokens: parentData.tokens, doc: parentData.doc };
                     const incResult = await this.searchIncludesForToken(
@@ -259,7 +259,7 @@ export class MemberLocatorService {
             // conclude "not an alias". A local declaration still takes the full check,
             // so same-file aliases keep exact semantics.
             const hasLocalDecl = tokens.some(t =>
-                this.isVariableLookupCandidate(t) && this.tokenMatchesName(t, key));
+                this.isVariableLookupCandidate(t, document) && this.tokenMatchesName(t, key));
             if (!hasLocalDecl) {
                 await this.ensureIndexBuilt();
                 if (this.sdi.find(current.typeName).length > 0) break;
@@ -633,7 +633,7 @@ export class MemberLocatorService {
 
         // 1. Current file (column 0 label or structure)
         const local = tokens.find(t =>
-            this.isVariableLookupCandidate(t) &&
+            this.isVariableLookupCandidate(t, document) &&
             this.tokenMatchesName(t, varNameLower) &&
             !isExcluded(t.line)
         );
@@ -650,7 +650,7 @@ export class MemberLocatorService {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
                     const parentVar = parentData.tokens.find(t =>
-                        this.isVariableLookupCandidate(t) && this.tokenMatchesName(t, varName.toLowerCase())
+                        this.isVariableLookupCandidate(t, parentData.doc) && this.tokenMatchesName(t, varName.toLowerCase())
                     );
                     if (parentVar) return { token: parentVar, tokens: parentData.tokens, doc: parentData.doc };
                     const incResult = await this.searchIncludesForToken(
@@ -687,7 +687,7 @@ export class MemberLocatorService {
             if (!data) continue;
 
             const found = data.tokens.find(t =>
-                this.isVariableLookupCandidate(t) &&
+                this.isVariableLookupCandidate(t, data.doc) &&
                 this.tokenMatchesName(t, varName.toLowerCase())
             );
             if (found) return { token: found, tokens: data.tokens, doc: data.doc };
@@ -818,8 +818,19 @@ export class MemberLocatorService {
         return false;
     }
 
-    private isVariableLookupCandidate(t: Token): boolean {
-        return t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0;
+    private isVariableLookupCandidate(t: Token, doc: TextDocument): boolean {
+        if (!(t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0)) {
+            return false;
+        }
+        // A CLASS/INTERFACE member (property or method prototype) is only reachable via
+        // qualified access (SELF.X / instance.X) — Clarion has no bare/global path to it,
+        // even though its declaration token is column-0 and procedure-shaped exactly like a
+        // real global procedure. Without this guard, an undeclared word that happens to share
+        // a name with some unrelated class's method resolves to that method instead of
+        // correctly reporting "not found" (e.g. hovering a stray/typo'd bare word elsewhere in
+        // the include chain matched `SomeClass.SomeMethod`).
+        const context = this.tokenCache.getStructure(doc).getStructureContextAt(t.line);
+        return !context.inClass && !context.inInterface;
     }
 
     /**

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -129,7 +129,7 @@ export class MemberLocatorService {
             // cross-file cache holds it) so a stale token is never handed out.
             const data = await this.loadDocument(cachedPath);
             const found = data?.tokens.find(t =>
-                this.isVariableLookupCandidate(t, data!.doc) && this.tokenMatchesName(t, varName.toLowerCase())
+                this.isVariableLookupCandidate(t, data!.doc, true) && this.tokenMatchesName(t, varName.toLowerCase())
             );
             if (data && found) return { token: found, tokens: data.tokens, doc: data.doc };
             // File gone or declaration moved — fall through to a fresh walk.
@@ -162,7 +162,7 @@ export class MemberLocatorService {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
                     const parentVar = parentData.tokens.find(t =>
-                        this.isVariableLookupCandidate(t, parentData.doc) && this.tokenMatchesName(t, varName.toLowerCase())
+                        this.isVariableLookupCandidate(t, parentData.doc, true) && this.tokenMatchesName(t, varName.toLowerCase())
                     );
                     if (parentVar) return { token: parentVar, tokens: parentData.tokens, doc: parentData.doc };
                     const incResult = await this.searchIncludesForToken(
@@ -259,7 +259,7 @@ export class MemberLocatorService {
             // conclude "not an alias". A local declaration still takes the full check,
             // so same-file aliases keep exact semantics.
             const hasLocalDecl = tokens.some(t =>
-                this.isVariableLookupCandidate(t, document) && this.tokenMatchesName(t, key));
+                this.isVariableLookupCandidate(t, document, false) && this.tokenMatchesName(t, key));
             if (!hasLocalDecl) {
                 await this.ensureIndexBuilt();
                 if (this.sdi.find(current.typeName).length > 0) break;
@@ -633,7 +633,7 @@ export class MemberLocatorService {
 
         // 1. Current file (column 0 label or structure)
         const local = tokens.find(t =>
-            this.isVariableLookupCandidate(t, document) &&
+            this.isVariableLookupCandidate(t, document, false) &&
             this.tokenMatchesName(t, varNameLower) &&
             !isExcluded(t.line)
         );
@@ -650,7 +650,7 @@ export class MemberLocatorService {
                 const parentData = await this.loadDocument(parentPath);
                 if (parentData) {
                     const parentVar = parentData.tokens.find(t =>
-                        this.isVariableLookupCandidate(t, parentData.doc) && this.tokenMatchesName(t, varName.toLowerCase())
+                        this.isVariableLookupCandidate(t, parentData.doc, true) && this.tokenMatchesName(t, varName.toLowerCase())
                     );
                     if (parentVar) return { token: parentVar, tokens: parentData.tokens, doc: parentData.doc };
                     const incResult = await this.searchIncludesForToken(
@@ -687,7 +687,7 @@ export class MemberLocatorService {
             if (!data) continue;
 
             const found = data.tokens.find(t =>
-                this.isVariableLookupCandidate(t, data.doc) &&
+                this.isVariableLookupCandidate(t, data.doc, true) &&
                 this.tokenMatchesName(t, varName.toLowerCase())
             );
             if (found) return { token: found, tokens: data.tokens, doc: data.doc };
@@ -818,7 +818,13 @@ export class MemberLocatorService {
         return false;
     }
 
-    private isVariableLookupCandidate(t: Token, doc: TextDocument): boolean {
+    /**
+     * @param crossFile True when `doc` is a file OTHER than the one the lookup started in
+     *   (a MEMBER parent or an INCLUDE). Required rather than defaulted: the two filters
+     *   below differ in reach, and silently getting it wrong is precisely how the bugs
+     *   this method exists to prevent were introduced.
+     */
+    private isVariableLookupCandidate(t: Token, doc: TextDocument, crossFile: boolean): boolean {
         if (!(t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0)) {
             return false;
         }
@@ -830,7 +836,32 @@ export class MemberLocatorService {
         // correctly reporting "not found" (e.g. hovering a stray/typo'd bare word elsewhere in
         // the include chain matched `SomeClass.SomeMethod`).
         const context = this.tokenCache.getStructure(doc).getStructureContextAt(t.line);
-        return !context.inClass && !context.inInterface;
+        if (context.inClass || context.inInterface) return false;
+
+        // Same shape, one scope out — but only when looking into ANOTHER file. A declaration
+        // in a PROCEDURE/FUNCTION/ROUTINE's local data section carries a column-0 label
+        // indistinguishable from module-level global data, yet nothing outside that scope can
+        // name it. Both same-file siblings already stop at the module boundary
+        // (SymbolFinderService.findModuleVariable and .findGlobalVariableInCurrentFile each cut
+        // off at the first PROCEDURE); the cross-file walks had no boundary at all, so an
+        // undeclared bare word matched whatever unrelated procedure local happened to share its
+        // name — typically one thousands of lines deep in a large MEMBER parent, reported to the
+        // user as "📦 Module variable".
+        //
+        // NOT applied to same-file lookups: those legitimately see procedure locals, and the
+        // caller does its own, finer scope filtering (#304's excludedRanges deliberately keeps a
+        // ROUTINE's parent-procedure data and an ABC `ThisWindow CLASS(WindowManager)` method
+        // impl's host-procedure locals visible). Rejecting here would pre-empt that and make it
+        // dead code.
+        if (!crossFile) return true;
+
+        const scope = context.scope;
+        return !(scope && (
+            scope.subType === TokenType.Procedure ||
+            scope.subType === TokenType.GlobalProcedure ||
+            scope.subType === TokenType.MethodImplementation ||
+            scope.subType === TokenType.Routine
+        ));
     }
 
     /**

--- a/server/src/test/MemberLocatorService.BareWordClassMemberGuard.test.ts
+++ b/server/src/test/MemberLocatorService.BareWordClassMemberGuard.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A bare, undeclared word that happens to share its name with some unrelated
+ * CLASS's method/property was resolving to that method via
+ * findVariableTokenInParentChain's MEMBER-parent/INCLUDE-chain walk — the
+ * walk's isVariableLookupCandidate() gate accepted any column-0 or
+ * procedure-shaped token with no check for CLASS/INTERFACE containment, even
+ * though a class member is only reachable via qualified access (SELF.X /
+ * instance.X), never as a bare word. Repro: hovering an undeclared local
+ * named the same as some class's method resolved that method's signature
+ * instead of correctly finding nothing.
+ *
+ * Pins:
+ *   1. A bare word matching a CLASS member's name resolves to null.
+ *   2. A bare word matching an INTERFACE member's name resolves to null.
+ *   3. A genuine top-level global reachable through the SAME include chain
+ *      still resolves — the guard must not overreach.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MemberLocatorService } from '../services/MemberLocatorService';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function writeFixture(name: string, lines: string[]): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, lines.join('\n'));
+    return p;
+}
+
+function makeDoc(name: string, lines: string[]): TextDocument {
+    const p = writeFixture(name, lines);
+    return TextDocument.create(`file:///${p.replace(/\\/g, '/')}`, 'clarion', 1, lines.join('\n'));
+}
+
+suite('MemberLocatorService — bare-word lookup must not match CLASS/INTERFACE members', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mls_bareword_'));
+
+        writeFixture('declarations.inc', [
+            'SomeClass  CLASS,TYPE',
+            'DoWork       PROCEDURE( *? )',
+            '           END',
+            '',
+            'SomeInterface  INTERFACE',
+            'Handle           PROCEDURE()',
+            '               END',
+            '',
+            'GlobalFlag  LONG',
+        ]);
+    });
+
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    teardown(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    function makeMainDoc(name: string): TextDocument {
+        return makeDoc(name, [
+            "  MEMBER('prog.clw')",
+            "  INCLUDE('declarations.inc'),ONCE",
+            'Caller PROCEDURE',
+            '  CODE',
+        ]);
+    }
+
+    test('a bare word matching a CLASS method name resolves to nothing', async () => {
+        const doc = makeMainDoc('bareword_class.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('DoWork', doc);
+        assert.strictEqual(result, null, 'a CLASS member must never satisfy a bare-word lookup');
+    });
+
+    test('a bare word matching an INTERFACE method name resolves to nothing', async () => {
+        const doc = makeMainDoc('bareword_interface.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('Handle', doc);
+        assert.strictEqual(result, null, 'an INTERFACE member must never satisfy a bare-word lookup');
+    });
+
+    test('a genuine top-level global in the same include chain still resolves', async () => {
+        const doc = makeMainDoc('bareword_global.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('GlobalFlag', doc);
+        assert.ok(result, 'a real top-level global must still resolve through the include-chain walk');
+        assert.strictEqual(result!.token.label, 'GlobalFlag');
+    });
+});

--- a/server/src/test/MemberLocatorService.ProcedureLocalGuard.test.ts
+++ b/server/src/test/MemberLocatorService.ProcedureLocalGuard.test.ts
@@ -1,0 +1,148 @@
+/**
+ * A bare, undeclared word was resolving to an unrelated PROCEDURE's *local*
+ * variable in the MEMBER parent file. findVariableTokenInParentChain's
+ * isVariableLookupCandidate() gate checked token shape and CLASS/INTERFACE
+ * containment (#391) but had no module-scope boundary, so a column-0 label in
+ * a procedure's local data section — shaped identically to module-level global
+ * data — was accepted as a cross-file global.
+ *
+ * Both same-file siblings already stop at the module boundary
+ * (SymbolFinderService.findModuleVariable and .findGlobalVariableInCurrentFile
+ * each cut off at the first PROCEDURE); the cross-file walks had no boundary at all.
+ *
+ * The guard is opt-in per call site via isVariableLookupCandidate's `crossFile`
+ * parameter and applies ONLY when the searched document is not the one the lookup
+ * started in. Same-file lookups legitimately see procedure locals and do their own
+ * finer filtering (#304's excludedRanges keeps a ROUTINE's parent-procedure data and
+ * an ABC `ThisWindow CLASS(WindowManager)` method impl's host-procedure locals
+ * visible) — MemberLocatorService.test.ts pins those, and they must keep passing
+ * alongside this suite.
+ *
+ * Repro: an undeclared bare word in a MEMBER module resolved to a same-named
+ * local of an unrelated procedure thousands of lines into the PROGRAM file, and
+ * was reported to the user as "📦 Module variable".
+ *
+ * Pins:
+ *   1. A procedure's local variable never satisfies a cross-file lookup.
+ *   2. A procedure's local QUEUE (the reported shape) likewise resolves to null.
+ *   3. A ROUTINE's DATA-section local likewise resolves to null.
+ *   4. A genuine module-level global still resolves — the guard must not overreach.
+ *   5. A MAP prototype inside MODULE('...') still resolves. (It reaches file scope via
+ *      the `chain` branch, so `scope` is null — the subtype list stays explicit anyway.)
+ *   6. A global procedure's own implementation label still resolves.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MemberLocatorService } from '../services/MemberLocatorService';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function writeFixture(name: string, lines: string[]): string {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, lines.join('\n'));
+    return p;
+}
+
+function makeDoc(name: string, lines: string[]): TextDocument {
+    const p = writeFixture(name, lines);
+    return TextDocument.create(`file:///${p.replace(/\\/g, '/')}`, 'clarion', 1, lines.join('\n'));
+}
+
+suite('MemberLocatorService — cross-file lookup must not match a PROCEDURE/ROUTINE local', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mls_proclocal_'));
+
+        writeFixture('prog.clw', [
+            '  PROGRAM',
+            'GlobalFlag        LONG',
+            '  MAP',
+            '    MODULE(\'other.clw\')',
+            'MappedProc          PROCEDURE()',
+            '    END',
+            '  END',
+            '  CODE',
+            '  RETURN',
+            '',
+            'HostProc PROCEDURE()',
+            'ProcLocal         LONG',
+            'LocalQ          QUEUE',
+            'Field1              STRING(64)',
+            '                  END',
+            '  CODE',
+            '  DO SomeRoutine',
+            '  RETURN',
+            'SomeRoutine ROUTINE',
+            '  DATA',
+            'RoutineLocal      LONG',
+            '  CODE',
+            '  RETURN',
+        ]);
+    });
+
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    teardown(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    function makeMainDoc(name: string): TextDocument {
+        return makeDoc(name, [
+            "  MEMBER('prog.clw')",
+            'Caller PROCEDURE',
+            '  CODE',
+        ]);
+    }
+
+    test("a procedure's local variable never satisfies a cross-file lookup", async () => {
+        const doc = makeMainDoc('proclocal_scalar.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('ProcLocal', doc);
+        assert.strictEqual(result, null, "a procedure local is unreachable from another file");
+    });
+
+    test("a procedure's local QUEUE never satisfies a cross-file lookup", async () => {
+        const doc = makeMainDoc('proclocal_queue.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('LocalQ', doc);
+        assert.strictEqual(result, null, 'the reported repro shape — a local QUEUE — must not resolve');
+    });
+
+    test("a ROUTINE's DATA-section local never satisfies a cross-file lookup", async () => {
+        const doc = makeMainDoc('proclocal_routine.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('RoutineLocal', doc);
+        assert.strictEqual(result, null, 'a routine local is unreachable from another file');
+    });
+
+    test('a genuine module-level global still resolves', async () => {
+        const doc = makeMainDoc('proclocal_global.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('GlobalFlag', doc);
+        assert.ok(result, 'a real module-level global must still resolve through the parent walk');
+        assert.strictEqual(result!.token.value, 'GlobalFlag');
+    });
+
+    test("a MAP prototype inside MODULE('...') still resolves", async () => {
+        const doc = makeMainDoc('proclocal_mapproto.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('MappedProc', doc);
+        assert.ok(result, 'a MAP MODULE prototype is a genuine global declaration and must still resolve');
+    });
+
+    test("a global procedure's own implementation label still resolves", async () => {
+        const doc = makeMainDoc('proclocal_procimpl.clw');
+        const svc = new MemberLocatorService();
+        const result = await svc.findVariableTokenInParentChain('HostProc', doc);
+        assert.ok(result, "a procedure's own label is at file scope, not inside itself");
+    });
+});


### PR DESCRIPTION
# fix(hover): bare-word lookup no longer matches unrelated CLASS/INTERFACE members

## What happened

Hovering a bare, undeclared word can resolve to an unrelated CLASS's or INTERFACE's method/property
elsewhere in the include chain — labeled correctly as "🔷 Class property of X", but shown as if it
were a legitimate match, when the correct behavior is to show nothing.

```Clarion

MyClass CLASS, TYPE
Test     PROCEDURE()
    END 

MyProc PROCEDURE() 
 CODE
   IF test = TRUE
```
`test` is not declared in the procedure, but still the hover found a match and told that `test` was a method in `MyClass`.

Repro (see the new test `MemberLocatorService.BareWordClassMemberGuard.test.ts`): a file includes
`declarations.inc`, which declares `SomeClass CLASS,TYPE ... DoWork PROCEDURE(*?) ... END`. Hovering
the bare word `DoWork` anywhere else in that file — where it is not declared and has no local scope
— resolves to `SomeClass.DoWork` instead of correctly finding nothing. Same shape for an INTERFACE
member.

## Root cause

`MemberLocatorService.isVariableLookupCandidate(t)` — the gate for the bare-word MEMBER-parent and
INCLUDE-chain walk used by hover/F12/Ctrl+F12 — accepted any `TokenType.Structure`, any
procedure/function-shaped token, or any column-0 token, with **no check for CLASS/INTERFACE
containment**. A class method prototype (`DoWork PROCEDURE(...)` inside `CLASS...END`) tokenizes
identically to a real top-level global procedure, so it passed the gate unfiltered.

Class members are never reachable as a bare unqualified word in Clarion — only via `SELF.X` /
`instance.X` — so this was always a wrong candidate; the check just never existed.
`VariableHoverResolver.buildGlobalVariableHover` already computes `isInClassBlock` for the exact
same token, but only to relabel the hover text ("🔷 Class property of X"), never to reject the
match.

This surfaces through either bare-word walk branch — the current file's own INCLUDE chain, or the
MEMBER-parent file's INCLUDE chain (via the one-hop `INCLUDE('member.clw')` shim convention handled
by `resolveMemberHeaderToken()`, a separate in-flight fix on `fix/member-header-via-include`) — both
share the same `isVariableLookupCandidate` gate, so this fix applies to both.

## Fix

`isVariableLookupCandidate` now takes the token's owning `TextDocument` and rejects the match when
`tokenCache.getStructure(doc).getStructureContextAt(t.line)` reports `inClass` or `inInterface`. All
5 call sites in this base updated to pass the right doc (`data.doc` / `parentData.doc` / the ambient
`document` param, matched per call site).

Structure-opening lines themselves are NOT considered "inside" the structure per
`DocumentStructure`'s existing containment semantics (matches `isInClassBlock`'s existing behavior),
so a global CLASS/QUEUE/GROUP *type name* lookup is unaffected — only members nested between
`CLASS...END` / `INTERFACE...END` are excluded.

## Testing

New test file `MemberLocatorService.BareWordClassMemberGuard.test.ts`: pins that a CLASS method name
and an INTERFACE method name both resolve to nothing via `findVariableTokenInParentChain`, and that a
genuine top-level global declared in the very same include chain still resolves (guards against the
fix overreaching).

`npx tsc -b`: clean. `npm run test:server` (isolated worktree off `origin/master`): 2126 passing,
3 pending (pre-existing), 0 failing.

## Scope

One file changed + one new test: `server/src/services/MemberLocatorService.ts`,
`server/src/test/MemberLocatorService.BareWordClassMemberGuard.test.ts` (new). Plain scope-resolution
bug in the shared bare-word lookup, unrelated to any in-flight feature work, so it goes out as its
own PR.

## Update — a second scope leak in the same gate, folded into this PR (commit 2)

Live-testing turned up the sibling defect: the same gate also accepted a declaration sitting in an
unrelated **PROCEDURE's or ROUTINE's local data section**. Such a declaration carries a column-0
label indistinguishable by shape from module-level global data, so the MEMBER-parent and
INCLUDE-chain walks took it for a cross-file global. An undeclared bare word therefore resolved to
whatever unrelated procedure local happened to share its name — reported as "📦 Module variable"
and pointing thousands of lines into the parent PROGRAM.

It also **suppressed the undeclared-variable diagnostic**: the cross-file augmentation treated the
name as declared, so a genuinely undeclared variable produced no warning at all. That is the more
damaging half — a wrong tooltip is visible, a missing diagnostic is not.

Both same-file siblings already enforce the boundary this walk lacked:
`SymbolFinderService.findModuleVariable` cuts off at the first
GlobalProcedure/MethodImplementation (plus a belt-and-braces `isTokenInsideProcedure`), and
`.findGlobalVariableInCurrentFile` cuts off at the first `CODE`, falling back to the first
PROCEDURE. The cross-file walks had no boundary at all. `StructureContext.scope` already carries
the answer and is already computed on this path, so the check costs nothing.

### Why the guard is opt-in per call site, not unconditional

The obvious form — reject a procedure-scoped hit inside `isVariableLookupCandidate` — is **wrong**,
on the false premise that this gate only ever searches other files. Two of its five call sites
search the **current** document and legitimately want procedure locals:

| Call site | Reach |
|---|---|
| `findVariableTokenInParentChain` → MEMBER parent | cross-file |
| `hasLocalDecl` in `resolveTypeAlias` | **same-file** — its own comment: "A local declaration still takes the full check, so same-file aliases keep exact semantics" |
| `findVariableTokenCrossFile` step 1, `// 1. Current file` | **same-file** — its `excludedRanges` implements #304 |
| `findVariableTokenCrossFile` step 2 → MEMBER parent | cross-file |
| `searchIncludesForToken` → INCLUDE chain | cross-file |

Guarding unconditionally rejects those tokens *before* `!isExcluded(t.line)` runs, making #304 dead
code — the deliberate carve-outs for a ROUTINE seeing its parent procedure's data and for an ABC
`ThisWindow CLASS(WindowManager)` method implementation seeing its host procedure's locals. Measured
against a real solution, it broke resolution of **every procedure-local object instance** (hover,
completion, F12 and signature help on any `instance.Method(...)` receiver would have gone dead) and
failed two existing `MemberLocatorService.test.ts` cases.

So `isVariableLookupCandidate` takes a **required** third parameter, `crossFile: boolean` — required
rather than defaulted, because this is now the third defect in this one gate and a silent default is
exactly how a future call site would acquire the wrong reach.

`MODULE` is not in the rejected set. It is also unreachable in practice: MODULE is a `Structure`, so
`getStructureContextAt` routes it to the `chain` branch and never sets `scope`. The four rejected
subtypes mirror `DocumentStructure.isScopeToken`'s procedure-like branch exactly; there is no
separate FUNCTION subtype (FUNCTION implementations get `GlobalProcedure`/`MethodImplementation`).

No cache version bump: `varWalkCache` is in-memory, epoch-invalidated, and re-derives every cached
hit through this same gate before returning, so it self-corrects. No disk cache stores this decision.

### Verification

- `npx tsc -b` clean; `npm run test:server` **2132 passing / 3 pending / 0 failing** (2126 before,
  +6 new pins), including the three #304 tests.
- New `server/src/test/MemberLocatorService.ProcedureLocalGuard.test.ts`: procedure local, procedure
  local QUEUE, and ROUTINE `DATA` local each resolve to null; module-level global, MAP `MODULE(...)`
  prototype, and a global procedure's own implementation label each still resolve.
- Over-rejection swept across a real 199-file solution: 20,997 kept / 17,674 rejected, **zero**
  declarations before their file's first procedure header rejected.
- Before/after against the real solution: the reported wrong hit becomes null, while every
  procedure-local object instance and every cross-file global in the same scope resolves unchanged.

### Not in this PR

The same word under **F12** resolves to a local of an unrelated procedure in the *same* file, via
`DefinitionProvider`'s FILE/QUEUE/GROUP/RECORD label fallback — a whole-file scan for a column-0
label followed by a structure keyword, with no scope check. Its comment says it is deliberately
scope-loose ("covers labels the scope walks miss … in odd layouts"), so tightening it is a
judgement call with its own blast radius. Separate defect, separate PR.
