### PR TITLE
Fix/diagnostics scanprocedures class member leak

### DIFF
--- a/server/src/test/ScanSourceForProcedures362.test.ts
+++ b/server/src/test/ScanSourceForProcedures362.test.ts
@@ -87,6 +87,67 @@ suite('scanSourceForProcedures (#362)', () => {
         assert.strictEqual(procs.length, 0, `no false positives; got ${JSON.stringify(procs.map(p => p.name))}`);
     });
 
+    test('does not index CLASS/INTERFACE member prototypes as bare global procedures', () => {
+        // Real-world class bodies are often written unindented — member labels at
+        // column 0, the same shape as a real top-level declaration. Before the
+        // structureStack fix, a method like `DoWork` indexed identically to a
+        // global procedure — the bare name then resolved via
+        // SymbolFinderService.findProcedureViaIndex (and so the undeclared-variable
+        // diagnostic's cross-file augmentation) to this unrelated class member,
+        // matching the defect class PR #391 fixed for hover.
+        const src = [
+            'SomeClass CLASS,TYPE, MODULE(\'SomeClass.clw\')',
+            '',
+            'SomeField      &SomeFieldType',
+            'Construct      PROCEDURE()',
+            'Destruct       PROCEDURE()',
+            'DoWork         PROCEDURE( *? )',
+            '',
+            '             END',
+            '',
+            'SomeInterface  INTERFACE',
+            'Method1        PROCEDURE()',
+            '             END',
+            '',
+            'GlobalAfter    PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\SomeClass.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(!byName.has('Construct'), 'CLASS member not indexed as bare global procedure');
+        assert.ok(!byName.has('Destruct'), 'CLASS member not indexed as bare global procedure');
+        assert.ok(!byName.has('DoWork'), 'CLASS member "DoWork" not indexed as bare global procedure (the real repro shape)');
+        assert.ok(!byName.has('Method1'), 'INTERFACE member not indexed as bare global procedure');
+
+        assert.ok(byName.has('GlobalAfter'), 'a real global procedure after the CLASS/INTERFACE close is still indexed');
+    });
+
+    test('CLASS/INTERFACE tracking survives an inline nested structure (e.g. a GROUP data member)', () => {
+        // A GROUP declared inline inside a CLASS needs its own END — that inner END
+        // must pop only the GROUP, not prematurely close the enclosing CLASS.
+        const src = [
+            'SomeClass2  CLASS,TYPE',
+            'Rec           GROUP',
+            'Field1           STRING(10)',
+            '              END',
+            'Method1       PROCEDURE()',
+            '            END',
+            '',
+            'GlobalAfter2  PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\y.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(!byName.has('Method1'), 'CLASS member after an inline nested GROUP is still correctly excluded');
+        assert.ok(byName.has('GlobalAfter2'), 'a real global procedure after the CLASS close is still indexed');
+    });
+
     test('finds real procedures in IBSCommon.clw when present', function () {
         const real = 'F:\\TestApps\\Direct10Source\\IBSCommon.clw';
         if (!fs.existsSync(real)) { this.skip(); return; }

--- a/server/src/test/ScanSourceForProcedures362.test.ts
+++ b/server/src/test/ScanSourceForProcedures362.test.ts
@@ -148,6 +148,86 @@ suite('scanSourceForProcedures (#362)', () => {
         assert.ok(byName.has('GlobalAfter2'), 'a real global procedure after the CLASS close is still indexed');
     });
 
+    test('a trailing `.` on the last member line closes the structure (period-terminated CLASS)', () => {
+        // Clarion closes a structure with a `.` terminator as often as with END —
+        // commonly as a TRAILING terminator on the last member line. If that form
+        // doesn't pop the stack, the CLASS stays "open" to EOF and every genuine
+        // global procedure declared later in the same file is dropped from the
+        // proc index (F12/hover fast-path regression).
+        const src = [
+            'PClass      CLASS,TYPE',
+            'Method1       PROCEDURE()',
+            'LastField       STRING(10).',
+            '',
+            'GlobalAfter3 PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\p1.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(!byName.has('Method1'), 'CLASS member still excluded in a period-terminated class');
+        assert.ok(byName.has('GlobalAfter3'), 'a global procedure after a period-terminated CLASS must be indexed');
+    });
+
+    test('a trailing `.` on a member PROCEDURE line closes the structure', () => {
+        // The terminator can sit on a member *prototype* line too. That line is
+        // still INSIDE the class it terminates (must be excluded from the bare-name
+        // index) — the close takes effect for the lines after it.
+        const src = [
+            'PClass2     CLASS,TYPE',
+            'Done          PROCEDURE().',
+            '',
+            'GlobalAfter4 PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\p2.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(!byName.has('Done'), 'the period-terminated member prototype itself is still a member, not a global');
+        assert.ok(byName.has('GlobalAfter4'), 'a global procedure after the close must be indexed');
+    });
+
+    test('collapsed `. .` closes multiple structures (nested GROUP + CLASS on one line)', () => {
+        const src = [
+            'PClass3     CLASS,TYPE',
+            'Rec           GROUP',
+            'Field1          STRING(10)',
+            '. .',
+            '',
+            'GlobalAfter5 PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\p3.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(byName.has('GlobalAfter5'), 'a `. .` line must pop BOTH the GROUP and the CLASS');
+    });
+
+    test('a one-line `Rec GROUP,PRE(R1).` inside a CLASS opens and closes on the same line', () => {
+        const src = [
+            'PClass4     CLASS,TYPE',
+            'Rec           GROUP,PRE(R1).',
+            'Method1       PROCEDURE()',
+            '            END',
+            '',
+            'GlobalAfter6 PROCEDURE()',
+            '  CODE',
+            '  RETURN'
+        ].join('\n');
+
+        const procs = scanSourceForProcedures(src, 'C:\\x\\p4.inc');
+        const byName = new Map(procs.map(p => [p.name, p]));
+
+        assert.ok(!byName.has('Method1'), 'member after the self-closing GROUP is still inside the CLASS — excluded');
+        assert.ok(byName.has('GlobalAfter6'), 'the CLASS END must not have been consumed by the self-closing GROUP');
+    });
+
     test('finds real procedures in IBSCommon.clw when present', function () {
         const real = 'F:\\TestApps\\Direct10Source\\IBSCommon.clw';
         if (!fs.existsSync(real)) { this.skip(); return; }

--- a/server/src/utils/StructureDeclarationIndexer.ts
+++ b/server/src/utils/StructureDeclarationIndexer.ts
@@ -24,7 +24,10 @@ const perfLogger = LoggerManager.getLogger('StructureDeclarationIndexer.Perf', '
  * Bump DISK_CACHE_VERSION whenever StructureDeclarationInfo or the scanner semantics change.
  */
 // v2 (#362): entries now also carry procedure declarations (`procs`).
-const DISK_CACHE_VERSION = 3;
+// v3: scanSourceForProcedures now excludes CLASS/INTERFACE member prototypes
+// from the bare-name procedure index (previously indexed identically to a
+// global procedure — see the structureStack tracking in that function).
+const DISK_CACHE_VERSION = 4;
 
 interface SdiDiskCacheEntry {
     mtimeMs: number;
@@ -321,6 +324,21 @@ export function scanSourceForProcedures(
     // without this the library MODULE prototypes (NetTalk et al.) never index, so
     // the hover/definition fast-paths can never fire for them.
     let mapDepth = 0;
+    // Tracks currently-open TYPE_PATTERN structures (CLASS/INTERFACE/QUEUE/GROUP/
+    // RECORD/FILE/VIEW) so a column-0 `Name PROCEDURE/FUNCTION` line found while a
+    // CLASS or INTERFACE is open is recognised as a member prototype, not a global
+    // procedure. Clarion class bodies are often written unindented (member labels
+    // at column 0, same shape as a real top-level declaration) — without this, a
+    // line like `Test PROCEDURE(...)` inside `SomeClass CLASS,TYPE...END` indexes
+    // identically to a real global procedure, and the bare name then resolves via
+    // SymbolFinderService.findProcedureViaIndex (and so the undeclared-variable
+    // diagnostic's cross-file augmentation) to an unrelated class's member. Same
+    // defect class fixed for hover in PR #391 (MemberLocatorService
+    // .isVariableLookupCandidate) — a separate, tokenizer-free code path that fix
+    // never touched. Non-CLASS/INTERFACE kinds are tracked too, purely so their own
+    // END pops correctly instead of prematurely closing an outer CLASS/INTERFACE
+    // (e.g. an inline GROUP field declared inside a class).
+    const structureStack: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
         const rawLine = lines[i];
@@ -351,9 +369,27 @@ export function scanSourceForProcedures(
             continue;
         }
 
+        // --- CLASS/INTERFACE/QUEUE/GROUP/... structure tracking -----------------
+        // Innermost-first: a nested structure's own END pops it before any
+        // enclosing CLASS/INTERFACE is affected.
+        if (structureStack.length > 0 && (END_PATTERN.test(t) || t === '.')) {
+            structureStack.pop();
+            continue;
+        }
+        const typeMatch = TYPE_PATTERN.exec(t);
+        if (typeMatch) {
+            structureStack.push(typeMatch[2].toUpperCase());
+            continue;
+        }
+        const inClassOrInterface = structureStack.some(
+            k => k === 'CLASS' || k === 'INTERFACE'
+        );
+
         // --- Column-0 explicit form: `Name PROCEDURE/FUNCTION ...` --------------
-        // Global implementations and `Class.Method` bodies live at column 0.
-        if (atColumnZero) {
+        // Global implementations and `Class.Method` bodies live at column 0 — but
+        // so do class/interface MEMBER prototypes in many real codebases
+        // (unindented style), which must NOT be indexed as bare global names.
+        if (atColumnZero && !inClassOrInterface) {
             const m = PROCEDURE_PATTERN.exec(t);
             if (m) {
                 const name = m[1];

--- a/server/src/utils/StructureDeclarationIndexer.ts
+++ b/server/src/utils/StructureDeclarationIndexer.ts
@@ -145,6 +145,17 @@ const EQUATE_PATTERN =
     /^([A-Za-z_][\w:]*)\s+EQUATE\b/i;
 const END_PATTERN =
     /^END\b/i;
+// A structure closes with a `.` terminator as often as with END — including a
+// TRAILING terminator on the last member line (`Field1 STRING(10).`) and
+// collapsed multi-closes (`. .` or `..` = two ENDs). One close per period.
+// Safe on comment-stripped lines: a period inside a string literal is always
+// followed by at least the closing quote, so it can never be line-trailing.
+const PERIODS_ONLY_PATTERN = /^\.[.\s]*$/;
+const TRAILING_TERMINATORS_PATTERN = /(?:\s*\.)+\s*$/;
+function countTrailingTerminators(t: string): number {
+    const m = TRAILING_TERMINATORS_PATTERN.exec(t);
+    return m ? (m[0].match(/\./g) as RegExpMatchArray).length : 0;
+}
 // #362 — a column-0 label followed by PROCEDURE or FUNCTION. Captures the label
 // (bare or dotted `Class.Method`), the keyword, and the trailing signature.
 // PROCEDURE and FUNCTION are equivalent in modern Clarion (both return values),
@@ -370,20 +381,42 @@ export function scanSourceForProcedures(
         }
 
         // --- CLASS/INTERFACE/QUEUE/GROUP/... structure tracking -----------------
-        // Innermost-first: a nested structure's own END pops it before any
-        // enclosing CLASS/INTERFACE is affected.
-        if (structureStack.length > 0 && (END_PATTERN.test(t) || t === '.')) {
+        // Innermost-first: a nested structure's own close pops it before any
+        // enclosing CLASS/INTERFACE is affected. A structure closes with a `.`
+        // terminator as often as with END — including a TRAILING terminator on
+        // the last member line (`Field1 STRING(10).`) and collapsed multi-closes
+        // (`. .` = two ENDs). Every form must pop: a period-closed CLASS that
+        // stays on the stack keeps `inClassOrInterface` true to EOF, silently
+        // dropping every later genuine global procedure in the file from the
+        // index (F12/hover fast-path regression).
+        if (structureStack.length > 0 && END_PATTERN.test(t)) {
             structureStack.pop();
+            continue;
+        }
+        if (structureStack.length > 0 && PERIODS_ONLY_PATTERN.test(t)) {
+            let closes = (t.match(/\./g) as RegExpMatchArray).length;
+            while (closes-- > 0 && structureStack.length > 0) structureStack.pop();
             continue;
         }
         const typeMatch = TYPE_PATTERN.exec(t);
         if (typeMatch) {
             structureStack.push(typeMatch[2].toUpperCase());
+            // `Rec GROUP,PRE(R1).` — opens and closes on the same line.
+            let closes = countTrailingTerminators(t);
+            while (closes-- > 0 && structureStack.length > 0) structureStack.pop();
             continue;
         }
         const inClassOrInterface = structureStack.some(
             k => k === 'CLASS' || k === 'INTERFACE'
         );
+        // A trailing `.` on a member line closes its structure AFTER the line
+        // itself — a `LastField LONG.` or `Done PROCEDURE().` line is still
+        // INSIDE the class it terminates, so `inClassOrInterface` above is
+        // deliberately the pre-pop snapshot used to classify THIS line.
+        if (structureStack.length > 0) {
+            let closes = countTrailingTerminators(t);
+            while (closes-- > 0 && structureStack.length > 0) structureStack.pop();
+        }
 
         // --- Column-0 explicit form: `Name PROCEDURE/FUNCTION ...` --------------
         // Global implementations and `Class.Method` bodies live at column 0 — but


### PR DESCRIPTION
# fix(diagnostics): scanSourceForProcedures excludes CLASS/INTERFACE members from the bare-name procedure index

## What happened

The undeclared-variable diagnostic can silently fail to fire on a genuinely undeclared bare word, when an unrelated CLASS or INTERFACE elsewhere in the solution happens to declare a member with the same name.

Repro (see the new tests in `ScanSourceForProcedures362.test.ts`): a `.inc` file declares `SomeClass CLASS,TYPE ... DoWork PROCEDURE(*?) ... END`, written unindented (member labels at column 0 — a common, legal Clarion style). A bare, genuinely undeclared `DoWork` anywhere else in the solution resolves via `SymbolFinderService.findProcedureViaIndex` to this class member, so the undeclared-variable diagnostic's cross-file augmentation treats it as declared and never warns.

## Root cause

`StructureDeclarationIndexer.scanSourceForProcedures` — the lightweight regex scanner that builds the "which file declares procedure X" index consumed by `SymbolFinderService.findProcedureViaIndex` (and so by hover/F12's fast path too) — indexes **any** column-0 `Name PROCEDURE/FUNCTION` line as a global procedure, with no CLASS/INTERFACE containment awareness. It already tracks MAP/MODULE nesting (`mapDepth`) so shorthand prototypes inside those contexts aren't double-counted, but has no equivalent for CLASS/INTERFACE.

Same defect *class* as #391 (`MemberLocatorService.isVariableLookupCandidate`, fixed for hover) — a bare word resolving to an unrelated class member — but a separate, tokenizer-free scanning code path that fix never touched.

## Fix

Tracks currently-open TYPE_PATTERN structures (CLASS/INTERFACE/QUEUE/GROUP/RECORD/FILE/VIEW) as a stack, mirroring the existing `mapDepth` pattern. Skips indexing a column-0 PROCEDURE/FUNCTION line while a CLASS or INTERFACE is anywhere on the stack. Non-CLASS/INTERFACE kinds are tracked too, purely so an inline nested structure's own `END` (e.g. a GROUP data member declared inside a class) pops correctly instead of prematurely closing the enclosing CLASS.

Bumps `DISK_CACHE_VERSION` 3→4 — the on-disk SDI cache is keyed on file mtime, not scanner semantics, so a code-only fix would leave stale bad entries served indefinitely after an upgrade.

The stack pops on every close form Clarion allows, not just an `END` line: a **trailing** `.`
terminator on the last member line (`Field1 STRING(10).`) — counted after the line itself is
classified, so a period-terminated member prototype (`Done PROCEDURE().`) is still treated as
*inside* the class it terminates; collapsed multi-closes (`. .` = two ENDs, one pop per period);
and a one-line self-closing structure (`Rec GROUP,PRE(R1).`), which must not consume the enclosing
CLASS's END. This is safe on the comment-stripped lines the scanner works with: a period inside a
string literal is always followed by at least the closing quote, so it can never be line-trailing.

## Testing

New tests in `ScanSourceForProcedures362.test.ts`: the triggering shape (unindented CLASS +
INTERFACE member prototypes, confirming they're excluded while a genuine global procedure declared
after the closing `END` is still indexed), a nested-GROUP-inside-CLASS case confirming the stack
pop is innermost-first, and four period-terminator cases — period-terminated CLASS via the last
member line, period-terminated member PROCEDURE line, collapsed `. .` popping GROUP+CLASS on one
line, and a one-line self-closing GROUP inside a CLASS. The four period cases all fail against an
END/standalone-`.`-only pop (verified by reverting just the indexer).

`npx tsc -b`: clean. Full suite: 2389 passing, 0 failing, 4 pending (pre-existing), rebased onto
`origin/version-1.0.2`.
## Scope

Two files changed, both in this PR: `server/src/utils/StructureDeclarationIndexer.ts`, `server/src/test/ScanSourceForProcedures362.test.ts`. Plain scope-resolution bug in a shared cross-file index, unrelated to any in-flight feature work, so it goes out as its own PR.
