### PR TITLE
fix(tokenizer): PRAGMA(...) mistyped as Function, corrupting completion scope 

### DIFF
--- a/server/src/test/WordCompletionProvider.test.ts
+++ b/server/src/test/WordCompletionProvider.test.ts
@@ -518,4 +518,36 @@ suite('WordCompletionProvider', () => {
             await assert.doesNotReject(async () => { await p.provide(doc, { line: 0, character: 5 }, 'n'); });
         });
     });
+
+    suite('PRAGMA does not leak as a false procedure boundary (#tokenizer-directive-fix)', () => {
+        test('a PRAGMA line before any procedure does not vacuum in later procedures\' locals', async () => {
+            // PRAGMA(...) at global scope, before any real procedure — previously
+            // mistokenized as TokenType.Function (indistinguishable from a real
+            // procedure/function declaration to isProcedureOrFunction()), so the
+            // scope-analyzer fallback treated it as an "open" enclosing procedure
+            // with no end, vacuuming every later procedure's locals into this
+            // position's completion list.
+            const doc = makeDoc([
+                'MyProg PROGRAM',
+                '  PRAGMA(\'define(profile=>off)\')',
+                '',
+                'FirstProc PROCEDURE()',
+                'SomeLocalVar LONG',
+                'CODE',
+                'END',
+                '',
+                'SecondProc PROCEDURE()',
+                'IncludeAddress LONG(TRUE)',
+                'CODE',
+                'END',
+            ].join('\n'));
+            const p = makeProvider(doc);
+            const items = await p.provide(doc, { line: 1, character: 2 }, '');
+            const variableLabels = items.filter(i => i.kind === CompletionItemKind.Variable).map(i => i.label);
+            assert.ok(!variableLabels.includes('IncludeAddress'),
+                `PRAGMA line must not see later procedures' locals, got: ${variableLabels.join(', ')}`);
+            assert.ok(!variableLabels.includes('SomeLocalVar'),
+                `PRAGMA line must not see later procedures' locals, got: ${variableLabels.join(', ')}`);
+        });
+    });
 });

--- a/server/src/tokenizer/TokenPatterns.ts
+++ b/server/src/tokenizer/TokenPatterns.ts
@@ -74,7 +74,7 @@ export const tokenPatterns: Partial<Record<TokenType, RegExp>> = {
     [TokenType.ExecutionMarker]: /\b(?:CODE|DATA)\b/i,
     [TokenType.Type]: /\b(?:BYTE|SHORT|USHORT|LONG|ULONG|REAL|SREAL|DECIMAL|PDECIMAL|STRING|CSTRING|PSTRING|DATE|TIME|ASTRING|ANY|BSTRING|MEMO|SIGNED|UNSIGNED)(?=\(|\s|,|$)/i,
     [TokenType.TypeAnnotation]: /:\s*(?:byte|short|ushort|long|ulong|real|sreal|decimal|pdecimal|string|cstring|pstring|date|time)\b/i,
-    [TokenType.Directive]: /\b(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE)\b/i,
+    [TokenType.Directive]: /\b(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE|PRAGMA)\b/i,
     // ✅ Structure is handled specially in PatternMatcher - see STRUCTURE_PATTERNS
     // DO NOT combine patterns here as it breaks negative lookbehinds!
     [TokenType.WindowElement]: /\b(?:BUTTON|ENTRY|TEXT|LIST|COMBO|CHECK|RADIO|IMAGE|LINE|BOX|ELLIPSE|PANEL|PROGRESS|REGION|PROMPT|SPIN|ITEM)\b|STRING\s*\(@[^)]*\)/i,
@@ -91,7 +91,7 @@ export const tokenPatterns: Partial<Record<TokenType, RegExp>> = {
     [TokenType.Number]: /\b(?:[0-9][0-9A-Fa-f]*[hH]|[0-7]+[oO]|[01]+[bB]|[0-9]+(?:\.[0-9]+)?)\b/i,
     [TokenType.Operator]: /[\+\-\*\/\=\>\<\&\|\~]/,
     [TokenType.Delimiter]: /[\(\)\[\]\{\}\,\:\;]/,
-    [TokenType.Label]: /^(?!(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE|PROGRAM|MEMBER|END|CODE|DATA)(?![:\w]))[A-Za-z_][A-Za-z0-9_:]*/i,  // Starts at column 0, can include colons. Excludes truly reserved words. CODE/DATA are execution markers, never labels.
+    [TokenType.Label]: /^(?!(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE|PRAGMA|PROGRAM|MEMBER|END|CODE|DATA)(?![:\w]))[A-Za-z_][A-Za-z0-9_:]*/i,  // Starts at column 0, can include colons. Excludes truly reserved words. CODE/DATA are execution markers, never labels.
     [TokenType.Variable]: /\b(?!(?:IF|LOOP|CASE|ACCEPT|EXECUTE|BEGIN|FILE|QUEUE|GROUP|RECORD|CLASS|WINDOW|REPORT|MODULE|MAP|VIEW|INTERFACE|END)\b)[A-Za-z_][A-Za-z0-9_]*\b/i,  // Exclude structure keywords to allow them to match Structure type first
     [TokenType.ImplicitVariable]: /\b[A-Za-z_][A-Za-z0-9_]*[$#"]/i,  // ✅ Variables ending with implicit type suffixes
     [TokenType.Function]: /\b[A-Za-z_][A-Za-z0-9_]*(?=\()/i,


### PR DESCRIPTION
# fix(tokenizer): PRAGMA(...) mistyped as Function, corrupting completion scope

## What happened

Reported while investigating a different bug (missing `INCLUDE` keyword completion, see the
companion PR `fix/word-completion-missing-directives`): typing a few letters at the top of a real
member file (before any procedure) surfaced dozens of unrelated local variables belonging to
*other, later* procedures in that same file — not just the expected keyword/global noise.

Reproduced directly against a real ~1900-line member file: unfiltered word completion right after
a `PRAGMA(...)` line, before any real procedure, returned **132 variable-kind items** pulled from
the local DATA sections of many unrelated procedures later in the file.

## Root cause

`server/src/tokenizer/TokenPatterns.ts`'s `Directive` token pattern recognized
`COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE` — but not `PRAGMA`. Since `PRAGMA(...)` doesn't
match any higher-priority pattern in `orderedTokenTypes`, it fell through to the generic catch-all:

```ts
[TokenType.Function]: /\b[A-Za-z_][A-Za-z0-9_]*(?=\()/i,
```

So every `PRAGMA(...)` line was tokenized as `TokenType.Function` — indistinguishable from a real
procedure/function declaration to `TokenHelper.isProcedureOrFunction()`
(`type === Procedure || type === Function`).

`WordCompletionProvider`'s scope-analyzer fallback (`findEnclosingToken`, used when there is no
real containing procedure — e.g. global scope near the top of a file) picks the nearest
"procedure-like" token by type. A mistokenized `PRAGMA` token has no real end marker
(`finishesAt`/`executionMarker` both `undefined`, defaulting to `Number.MAX_SAFE_INTEGER`), so once
picked as the "containing procedure", `collectProcLocals` walks from that line all the way to
end-of-file — vacuuming in every top-level local variable declared in every procedure that
follows.

## Fix

Add `PRAGMA` to the `Directive` pattern, and to its `Label`-exclusion list (for the same reason
`COMPILE`/`OMIT`/`INCLUDE`/etc. are already excluded there — defense in depth, since `Directive` is
checked before `Label` in `orderedTokenTypes` and would already win, but keeps the exclusion list
internally consistent).

Two-line diff:

```ts
[TokenType.Directive]: /\b(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE|PRAGMA)\b/i,
...
[TokenType.Label]: /^(?!(?:COMPILE|OMIT|EMBED|SECTION|ENDSECTION|INCLUDE|PRAGMA|PROGRAM|MEMBER|END|CODE|DATA)(?![:\w]))[A-Za-z_][A-Za-z0-9_:]*/i,
```

## Testing

New test in `WordCompletionProvider.test.ts`: a `PRAGMA(...)` line before any real procedure, with
two procedures declared after it (each with a local variable) — asserts neither later procedure's
locals appear in completion at the `PRAGMA` line.

Harness against the real repro file: leaked variable count went from 132 to 0 after the fix, with
no change to any other token's classification (only the 2 `PRAGMA` tokens in that file were
reclassified, from `Function` to `Directive`). Full suite in an isolated worktree off
`origin/version-1.0.1`: 2341 passing, 0 failing, 4 pending (pre-existing, unrelated).

Deployed and confirmed working live.

## Scope

Two files: `server/src/tokenizer/TokenPatterns.ts`, `server/src/test/WordCompletionProvider.test.ts`
(new test only — no other test files touched). Independent of the companion
`fix/word-completion-missing-directives` PR — different files, different bug, safe to merge in
either order.
