### PR TITLE
fix(completion): surface INCLUDE/MEMBER/OMIT/COMPILE/PRAGMA as keyword completions

### DIFF
--- a/server/src/providers/WordCompletionProvider.ts
+++ b/server/src/providers/WordCompletionProvider.ts
@@ -13,6 +13,7 @@ import { BuiltinFunctionService } from '../utils/BuiltinFunctionService';
 import { DataTypeService } from '../utils/DataTypeService';
 import { ControlService } from '../utils/ControlService';
 import { AttributeService } from '../utils/AttributeService';
+import { DirectiveService } from '../utils/DirectiveService';
 import LoggerManager from '../logger';
 
 const logger = LoggerManager.getLogger("WordCompletionProvider");
@@ -38,6 +39,7 @@ export class WordCompletionProvider {
     private dataTypeService = DataTypeService.getInstance();
     private controlService = ControlService.getInstance();
     private attributeService = AttributeService.getInstance();
+    private directiveService = DirectiveService.getInstance();
 
     constructor(tokenCache: TokenCache, scopeAnalyzer: ScopeAnalyzer) {
         this.tokenCache = tokenCache;
@@ -134,6 +136,12 @@ export class WordCompletionProvider {
             // E2. Attributes — context-aware: filter by control/structure type
             // ----------------------------------------------------------------
             this.collectAttributes(document, position, seen);
+
+            // ----------------------------------------------------------------
+            // E3. Compiler directives (INCLUDE, MEMBER, OMIT, etc.) — collected
+            // before keywords so directive descriptions take priority
+            // ----------------------------------------------------------------
+            this.collectDirectives(seen);
 
             // ----------------------------------------------------------------
             // F. Language keywords (skipped if already in seen from JSON)
@@ -654,6 +662,24 @@ export class WordCompletionProvider {
                     kind: CompletionItemKind.Property,
                     detail: this.attributeService.getAttributeSignature(attr.name),
                     documentation: attr.description,
+                });
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // E3. Compiler directives
+    // -------------------------------------------------------------------------
+
+    private collectDirectives(seen: Map<string, CompletionItem>): void {
+        for (const d of this.directiveService.getAllByPrefix('')) {
+            const key = d.name.toUpperCase();
+            if (!seen.has(key)) {
+                seen.set(key, {
+                    label: d.name,
+                    kind: CompletionItemKind.Keyword,
+                    detail: d.syntax,
+                    documentation: d.description,
                 });
             }
         }

--- a/server/src/test/WordCompletionProvider.test.ts
+++ b/server/src/test/WordCompletionProvider.test.ts
@@ -518,4 +518,21 @@ suite('WordCompletionProvider', () => {
             await assert.doesNotReject(async () => { await p.provide(doc, { line: 0, character: 5 }, 'n'); });
         });
     });
+
+    suite('Compiler directives', () => {
+        test('surfaces INCLUDE (and other directives) as keyword completions', async () => {
+            const doc = makeDoc([
+                'MyProg PROGRAM',
+                '  INCLUDE(\'somefile.inc\'), ONCE',
+                '',
+                'MyGlobalProc PROCEDURE()',
+                'CODE',
+                'END',
+            ].join('\n'));
+            const p = makeProvider(doc);
+            const items = await p.provide(doc, { line: 1, character: 2 }, 'INCL');
+            const labels = items.map(i => i.label);
+            assert.ok(labels.includes('INCLUDE'), `Expected INCLUDE keyword in: ${labels.join(', ')}`);
+        });
+    });
 });


### PR DESCRIPTION
# fix(completion): surface INCLUDE/MEMBER/OMIT/COMPILE/PRAGMA as keyword completions

## What happened

Reported live: typing `INCL` at column 2, near the top of a real PROGRAM file (before any procedure), never offered the `INCLUDE` keyword — only unrelated variables from elsewhere in the project that happened to share the `Incl` prefix (e.g. `IncludeAddress`, `IncludeCriteria`, `IncludeIncomplete` ), with nothing named `INCLUDE` itself to compete
against.

## Root cause

`INCLUDE` is modeled in this codebase as a "Compiler Directive" — it's defined in `server/src/data/clarion-directives.json` (alongside `MEMBER`, `OMIT`, `COMPILE`, `PRAGMA`, `EQUATE`, `ITEMIZE`, `SECTION`) and served by `DirectiveService`, which is already wired into hover (`HoverRouter.ts:37`, alongside `BuiltinFunctionService`/`AttributeService`/`PropertyService`/
`EventService`/`KeywordService`).

`WordCompletionProvider.ts`, however, never queries `DirectiveService` at all. Its keyword completion only comes from two hardcoded local collections:

```ts
private static readonly BLOCK_STRUCTURES = new Set([
    'ACCEPT', 'APPLICATION', 'BEGIN', 'CASE', 'CLASS', 'DETAIL', ...
]);
private static readonly PLAIN_KEYWORDS = [
    'BREAK', 'CYCLE', 'EXIT', 'RETURN', ...
];
```

Neither list contains `INCLUDE` (or `MEMBER`/`OMIT`/`COMPILE`/`PRAGMA`), so none of them could ever appear in word completion — a gap unrelated to any scoping/parsing logic, just a missing data source.

## Fix

Wire `DirectiveService` into `WordCompletionProvider`, following the exact same pattern already used for `AttributeService`/`BuiltinFunctionService`/`DataTypeService`/`ControlService` in this same file — a `collectDirectives()` step added to the `seen`-map pipeline, run before `collectKeywords()` so directive descriptions take priority over the bare keyword fallback for anything they overlap with (e.g. `SECTION`/`ITEMIZE`, which are also in `BLOCK_STRUCTURES`):

```ts
private collectDirectives(seen: Map<string, CompletionItem>): void {
    for (const d of this.directiveService.getAllByPrefix('')) {
        const key = d.name.toUpperCase();
        if (!seen.has(key)) {
            seen.set(key, {
                label: d.name,
                kind: CompletionItemKind.Keyword,
                detail: d.syntax,
                documentation: d.description,
            });
        }
    }
}
```

This also fixes the identical missing-completion gap for `MEMBER`, `OMIT`, `COMPILE`, and `PRAGMA`
— same root cause, same file, same fix.

## Testing

New test in `WordCompletionProvider.test.ts`: a document with an `INCLUDE(...)` line before any procedure — asserts `INCLUDE` appears in the completion list for prefix `INCL`.

Harness against the real repro file: completion for `INCL`/`incl` (case-insensitively) at the top of the file now returns `INCLUDE` — previously returned nothing at all for that keyword. Full suite in an isolated worktree off `origin/version-1.0.1`: 2341 passing, 0 failing, 4 pending (pre-existing, unrelated).

Deployed and confirmed working live.

## Scope

Two files: `server/src/providers/WordCompletionProvider.ts`,
`server/src/test/WordCompletionProvider.test.ts` (new test only). Independent of the companion `fix/pragma-directive-misclassified-as-function` PR — different files, different bug, safe to merge in either order.

## Known follow-up (not part of this PR)

The `IncludeAddress`/`IncludeCriteria`/etc. noise reported alongside this bug turned out to be two separate issues, not fixed here:
- A tokenizer bug (`PRAGMA` mistyped as `Function`) — see the companion PR above.
- A client-side bug in `ClarionAssistant`'s `SharedLspBridge.cs` (`MergeDbBarePrefix`): its
  solution-wide CodeGraph bare-prefix merge never filters out `local`-scoped symbols, so a
  procedure-private variable in one file gets merged into completion anywhere in the solution. Not
  a Clarion-Extension bug — tracked separately in the `ClarionAssistant` repo.
