### PR TITLE
Fix/missing include member via include shim

### DIFF
--- a/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
+++ b/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { IncludeVerifier } from '../utils/IncludeVerifier';
+import { SolutionManager } from '../solution/solutionManager';
+
+/**
+ * Project convention: the real MEMBER('program') statement is not written directly in
+ * every member module — it lives in a small shared shim file reached via
+ * INCLUDE('member.clw'). MemberLocatorService.resolveMemberHeaderToken() already follows
+ * that one INCLUDE hop for hover/F12/completion; IncludeVerifier.computeMemberParentDocument()
+ * did not, so isClassIncluded() could never see the MEMBER parent's include chain for any
+ * file using the shim — a class only reachable through the real PROGRAM file's includes was
+ * reported as a missing-include false positive even though it compiles fine.
+ */
+suite('IncludeVerifier — MEMBER resolved via INCLUDE shim (member.clw convention)', () => {
+    let tmpRoot = '';
+    let savedSm: SolutionManager | null = null;
+
+    const fileUri = (p: string) => `file:///${p.replace(/\\/g, '/')}`;
+
+    setup(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'member-shim-'));
+        // No-solution mode forces local-directory resolution.
+        savedSm = (SolutionManager as unknown as { instance: SolutionManager | null }).instance;
+        (SolutionManager as unknown as { instance: SolutionManager | null }).instance = null;
+        IncludeVerifier.getInstance().clearCache();
+        clearReachableSetBucket();
+
+        // The shim: no CODE of its own, just the real MEMBER() statement.
+        fs.writeFileSync(path.join(tmpRoot, 'member.clw'), [
+            "  MEMBER('parent.clw')",
+            '',
+        ].join('\r\n'));
+
+        // The real PROGRAM file — includes the class several hops down its own chain.
+        fs.writeFileSync(path.join(tmpRoot, 'parent.clw'), [
+            '  PROGRAM',
+            "  INCLUDE('level1.inc'),ONCE",
+            '  MAP',
+            '  END',
+            '  CODE',
+            '  RETURN',
+            '',
+        ].join('\r\n'));
+        fs.writeFileSync(path.join(tmpRoot, 'level1.inc'), [
+            "  INCLUDE('SharedThings.inc'),ONCE",
+            '',
+        ].join('\r\n'));
+        fs.writeFileSync(path.join(tmpRoot, 'SharedThings.inc'), [
+            'SomeClass   CLASS,TYPE',
+            'DoIt          PROCEDURE(),LONG',
+            '            END',
+            '',
+        ].join('\r\n'));
+
+        // The member module under test: reaches its MEMBER only through the shim,
+        // matching the real-world convention: SomeMember.clw -> INCLUDE('member.clw') -> MEMBER('...').
+        fs.writeFileSync(path.join(tmpRoot, 'child.clw'), [
+            "  INCLUDE('member.clw')",
+            '  MAP',
+            '  END',
+            'MyProc PROCEDURE',
+            '  CODE',
+            '  RETURN',
+            '',
+        ].join('\r\n'));
+    });
+
+    teardown(() => {
+        (SolutionManager as unknown as { instance: SolutionManager | null }).instance = savedSm;
+        savedSm = null;
+        IncludeVerifier.getInstance().clearCache();
+        clearReachableSetBucket();
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    const clearReachableSetBucket = () => {
+        try { fs.rmSync(path.join(os.tmpdir(), 'clarion-extension-reachableset'), { recursive: true, force: true }); }
+        catch { /* best-effort */ }
+    };
+
+    const childDoc = () => {
+        const p = path.join(tmpRoot, 'child.clw');
+        return TextDocument.create(fileUri(p), 'clarion', 1, fs.readFileSync(p, 'utf-8'));
+    };
+
+    test('a class reachable only through the shim-resolved MEMBER parent is found', async () => {
+        const iv = IncludeVerifier.getInstance();
+        assert.strictEqual(await iv.isClassIncluded('SharedThings.inc', childDoc()), true,
+            "SharedThings.inc is only reachable via child.clw -> INCLUDE('member.clw') -> MEMBER('parent.clw') -> level1.inc; must resolve as included");
+    });
+
+    test('a class not reachable anywhere in the shim-resolved chain is still reported missing', async () => {
+        const iv = IncludeVerifier.getInstance();
+        assert.strictEqual(await iv.isClassIncluded('NotAnywhere.inc', childDoc()), false,
+            'a genuinely unreachable class must still be reported as not included');
+    });
+});

--- a/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
+++ b/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
@@ -10,10 +10,11 @@ import { SolutionManager } from '../solution/solutionManager';
  * Project convention: the real MEMBER('program') statement is not written directly in
  * every member module — it lives in a small shared shim file reached via
  * INCLUDE('member.clw'). MemberLocatorService.resolveMemberHeaderToken() already follows
- * that one INCLUDE hop for hover/F12/completion; IncludeVerifier.computeMemberParentDocument()
- * did not, so isClassIncluded() could never see the MEMBER parent's include chain for any
- * file using the shim — a class only reachable through the real PROGRAM file's includes was
- * reported as a missing-include false positive even though it compiles fine.
+ * that one INCLUDE hop (plus normalizeMemberFilename's extension-less MEMBER target fix) for
+ * hover/F12/completion; IncludeVerifier.computeMemberParentDocument() had neither, so
+ * isClassIncluded() could never see the MEMBER parent's include chain for any file using the
+ * shim — a class only reachable through the real PROGRAM file's includes was reported as a
+ * missing-include false positive even though it compiles fine.
  */
 suite('IncludeVerifier — MEMBER resolved via INCLUDE shim (member.clw convention)', () => {
     let tmpRoot = '';
@@ -29,9 +30,11 @@ suite('IncludeVerifier — MEMBER resolved via INCLUDE shim (member.clw conventi
         IncludeVerifier.getInstance().clearCache();
         clearReachableSetBucket();
 
-        // The shim: no CODE of its own, just the real MEMBER() statement.
+        // The shim: no CODE of its own, just the real MEMBER() statement — extension-less,
+        // the idiomatic Clarion form (MEMBER('TargetProgram') style), which exercises the
+        // normalizeMemberFilename fallback alongside the INCLUDE-hop fallback.
         fs.writeFileSync(path.join(tmpRoot, 'member.clw'), [
-            "  MEMBER('parent.clw')",
+            "  MEMBER('parent')",
             '',
         ].join('\r\n'));
 

--- a/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
+++ b/server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts
@@ -101,4 +101,56 @@ suite('IncludeVerifier — MEMBER resolved via INCLUDE shim (member.clw conventi
         assert.strictEqual(await iv.isClassIncluded('NotAnywhere.inc', childDoc()), false,
             'a genuinely unreachable class must still be reported as not included');
     });
+
+    test('a CHAINED shim (first-statement INCLUDE -> INCLUDE -> MEMBER) resolves', async () => {
+        // Legal-but-rare: the shim's own first statement is another INCLUDE carrying the
+        // MEMBER. Still one file read per hop, still first-statement-only.
+        fs.writeFileSync(path.join(tmpRoot, 'member1.clw'), "  INCLUDE('member2.clw')\r\n");
+        fs.writeFileSync(path.join(tmpRoot, 'member2.clw'), "  MEMBER('parent')\r\n");
+        const p = path.join(tmpRoot, 'chained.clw');
+        fs.writeFileSync(p, [
+            "  INCLUDE('member1.clw')",
+            'MyProc PROCEDURE',
+            '  CODE',
+            '  RETURN',
+            '',
+        ].join('\r\n'));
+        const doc = TextDocument.create(fileUri(p), 'clarion', 1, fs.readFileSync(p, 'utf-8'));
+
+        const iv = IncludeVerifier.getInstance();
+        assert.strictEqual(await iv.isClassIncluded('SharedThings.inc', doc), true,
+            'the MEMBER parent must resolve through a two-hop shim chain');
+    });
+
+    test('a MEMBER behind a NON-first-statement INCLUDE does NOT resolve (no all-includes sweep)', async () => {
+        // The file's first statement is a data declaration, so it cannot be a member
+        // module — MEMBER (or the shim INCLUDE carrying it) must be the FIRST statement
+        // of the compiled token stream. An all-includes sweep would tokenize member.clw
+        // and "find" the MEMBER anyway: wrong (the compiler rejects this file), and the
+        // reason a plain definition include used to cost a cold tokenize of every
+        // direct include instead of returning null instantly.
+        const p = path.join(tmpRoot, 'notmember.clw');
+        fs.writeFileSync(p, [
+            'SomeVar  LONG',
+            "  INCLUDE('member.clw')",
+            'MyProc PROCEDURE',
+            '  CODE',
+            '  RETURN',
+            '',
+        ].join('\r\n'));
+        const doc = TextDocument.create(fileUri(p), 'clarion', 1, fs.readFileSync(p, 'utf-8'));
+
+        const iv = IncludeVerifier.getInstance();
+        assert.strictEqual(await iv.isClassIncluded('SharedThings.inc', doc), false,
+            'the shim INCLUDE is not the first statement — no MEMBER parent may be inferred');
+    });
+
+    test('a self-including shim terminates without resolving (cycle guard)', async () => {
+        fs.writeFileSync(path.join(tmpRoot, 'member.clw'), "  INCLUDE('member.clw')\r\n");
+
+        const iv = IncludeVerifier.getInstance();
+        // Twofold: it returns at all (no infinite include loop), and finds nothing.
+        assert.strictEqual(await iv.isClassIncluded('SharedThings.inc', childDoc()), false,
+            'a cyclic shim chain must not resolve a MEMBER parent');
+    });
 });

--- a/server/src/utils/IncludeVerifier.ts
+++ b/server/src/utils/IncludeVerifier.ts
@@ -711,15 +711,23 @@ export class IncludeVerifier {
                 return null;
             }
 
-            logger.debug(`⏱️ [IV] getMemberParentDocument: resolving "${memberToken.referencedFile}"`);
+            // MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+            // MEMBER('TargetProgram')) — the Clarion compiler infers .clw. resolveViaProjectRedirection's
+            // redirection lookup matches by extension mask (e.g. the `*.clw = ...` line in a .red
+            // file), so an extension-less name never matches any rule and silently fails to resolve;
+            // the local-directory fallback below fails the same way (fs.existsSync on a path with no
+            // extension never finds the real "Name.clw" file). Same fix already applied in
+            // MemberLocatorService.normalizeMemberFilename() for hover/F12/completion.
+            const memberFileName = this.normalizeMemberFilename(memberToken.referencedFile);
+            logger.debug(`⏱️ [IV] getMemberParentDocument: resolving "${memberFileName}"`);
 
             // Resolve path: try redirection parser first, then local directory fallback
             let resolvedPath: string | null = null;
 
             // #328: owner-project-first redirection
-            resolvedPath = resolveViaProjectRedirection(memberToken.referencedFile, currentFilePath);
+            resolvedPath = resolveViaProjectRedirection(memberFileName, currentFilePath);
             if (!resolvedPath) {
-                const candidate = path.resolve(currentFileDir, memberToken.referencedFile);
+                const candidate = path.resolve(currentFileDir, memberFileName);
                 if (fs.existsSync(candidate)) resolvedPath = candidate;
             }
 
@@ -811,6 +819,18 @@ export class IncludeVerifier {
             }
         }
         return undefined;
+    }
+
+    /**
+     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
+     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
+     * `resolveViaProjectRedirection`'s redirection lookup matches by extension mask (e.g. the `*.clw
+     * = ...` line in a .red file), so an extension-less name never matches any rule and silently
+     * fails to resolve. Mirrors MemberLocatorService.normalizeMemberFilename().
+     */
+    private normalizeMemberFilename(name: string): string {
+        return path.extname(name) ? name : `${name}.clw`;
     }
 
     /**

--- a/server/src/utils/IncludeVerifier.ts
+++ b/server/src/utils/IncludeVerifier.ts
@@ -698,9 +698,13 @@ export class IncludeVerifier {
     private async computeMemberParentDocument(document: TextDocument): Promise<TextDocument | null> {
         try {
             const tokens = this.tokenCache.getTokens(document);
-            
-            // #337: module header lookup — no line cap (comment banners are legal)
-            const memberToken = TokenHelper.findMemberHeaderToken(tokens);
+            const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
+            const currentFileDir = path.dirname(currentFilePath);
+
+            // #337: module header lookup — no line cap (comment banners are legal).
+            // Falls through to a one-INCLUDE-hop scan (e.g. INCLUDE('member.clw')) when this
+            // file has no literal MEMBER(...) of its own — see findMemberHeaderTokenWithFallback.
+            const memberToken = await this.findMemberHeaderTokenWithFallback(tokens, currentFileDir, currentFilePath);
 
             if (!memberToken || !memberToken.referencedFile) {
                 logger.debug(`⏱️ [IV] getMemberParentDocument: no MEMBER token in ${document.uri.split('/').pop()}`);
@@ -710,8 +714,6 @@ export class IncludeVerifier {
             logger.debug(`⏱️ [IV] getMemberParentDocument: resolving "${memberToken.referencedFile}"`);
 
             // Resolve path: try redirection parser first, then local directory fallback
-            const currentFilePath = decodeURIComponent(document.uri.replace(/^file:\/\/\//, '')).replace(/\//g, '\\');
-            const currentFileDir = path.dirname(currentFilePath);
             let resolvedPath: string | null = null;
 
             // #328: owner-project-first redirection
@@ -758,6 +760,57 @@ export class IncludeVerifier {
             logger.error(`Error getting MEMBER parent: ${error instanceof Error ? error.message : String(error)}`);
             return null;
         }
+    }
+
+    /**
+     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
+     * targets when no literal MEMBER statement is present locally.
+     *
+     * Project convention seen across many member modules: the real MEMBER('program')
+     * statement lives in a small shared shim file reached via e.g. INCLUDE('member.clw')
+     * rather than being written directly in each member — this lets the same shared source
+     * files belong to different PROGRAMs across projects by swapping just that one shim.
+     * TokenHelper.findMemberHeaderToken() only sees literal tokens in the tokens it's given,
+     * so it can never find a MEMBER hidden behind that indirection on its own — without this
+     * fallback, isClassIncluded()'s "MEMBER parent" check silently never fires for any file
+     * using the shim, so an include that's only reachable through the real PROGRAM/MEMBER
+     * file's chain is reported as missing even though it compiles fine.
+     *
+     * Same one-hop convention MemberLocatorService.resolveMemberHeaderToken() already
+     * applies for hover/F12/completion — mirrored here for the diagnostic path.
+     *
+     * Only looks one INCLUDE hop deep — matches the shim-file convention; a MEMBER
+     * statement buried deeper than that would be unusual. Takes the first MEMBER token
+     * found across the direct includes, in document order.
+     */
+    private async findMemberHeaderTokenWithFallback(
+        tokens: Token[],
+        fromDir: string,
+        fromFile: string
+    ): Promise<Token | undefined> {
+        const direct = TokenHelper.findMemberHeaderToken(tokens);
+        if (direct) return direct;
+
+        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
+        for (const inc of includeTokens) {
+            let resolvedPath: string | null = resolveViaProjectRedirection(inc.referencedFile!, fromFile);
+            if (!resolvedPath) {
+                const candidate = path.resolve(fromDir, inc.referencedFile!);
+                if (fs.existsSync(candidate)) resolvedPath = candidate;
+            }
+            if (!resolvedPath) continue;
+
+            try {
+                const contents = await fs.promises.readFile(resolvedPath, 'utf-8');
+                const doc = TextDocument.create(pathToCanonicalUri(resolvedPath), 'clarion', 1, contents);
+                const nestedTokens = this.tokenCache.getTokens(doc);
+                const nested = TokenHelper.findMemberHeaderToken(nestedTokens);
+                if (nested) return nested;
+            } catch {
+                // Unreadable — skip
+            }
+        }
+        return undefined;
     }
 
     /**

--- a/server/src/utils/IncludeVerifier.ts
+++ b/server/src/utils/IncludeVerifier.ts
@@ -771,8 +771,8 @@ export class IncludeVerifier {
     }
 
     /**
-     * Resolves the MEMBER token for a file, falling through into its own direct INCLUDE
-     * targets when no literal MEMBER statement is present locally.
+     * Resolves the MEMBER token for a file, following its FIRST statement into an
+     * INCLUDE'd shim when no literal MEMBER statement is present locally.
      *
      * Project convention seen across many member modules: the real MEMBER('program')
      * statement lives in a small shared shim file reached via e.g. INCLUDE('member.clw')
@@ -784,53 +784,57 @@ export class IncludeVerifier {
      * using the shim, so an include that's only reachable through the real PROGRAM/MEMBER
      * file's chain is reported as missing even though it compiles fine.
      *
-     * Same one-hop convention MemberLocatorService.resolveMemberHeaderToken() already
-     * applies for hover/F12/completion — mirrored here for the diagnostic path.
+     * Because MEMBER/PROGRAM must be the first statement of the compiled token stream (see
+     * TokenHelper.findShimIncludeToken), only the FIRST statement of each file is consulted.
+     * This is what keeps the common cases free: a definition .inc (first statement is a
+     * data/CLASS declaration) or a PROGRAM file is an instant miss with ZERO file reads —
+     * the pre-fallback behavior of returning null immediately is preserved exactly. Each
+     * hop reads exactly one file, MAX_SHIM_HOPS bounds the legal-but-rare chained-shim
+     * case, and a visited set stops include cycles.
      *
-     * Only looks one INCLUDE hop deep — matches the shim-file convention; a MEMBER
-     * statement buried deeper than that would be unusual. Takes the first MEMBER token
-     * found across the direct includes, in document order.
+     * Same first-statement walk MemberLocatorService.resolveMemberHeaderToken() applies for
+     * hover/F12/completion — mirrored here for the diagnostic path, sharing the convention
+     * logic via TokenHelper.findShimIncludeToken / TokenHelper.normalizeMemberFilename.
      */
+    private static readonly MAX_SHIM_HOPS = 3;
     private async findMemberHeaderTokenWithFallback(
         tokens: Token[],
         fromDir: string,
         fromFile: string
     ): Promise<Token | undefined> {
-        const direct = TokenHelper.findMemberHeaderToken(tokens);
-        if (direct) return direct;
+        const visited = new Set<string>();
+        for (let hop = 0; hop <= IncludeVerifier.MAX_SHIM_HOPS; hop++) {
+            const direct = TokenHelper.findMemberHeaderToken(tokens);
+            if (direct) return direct;
 
-        const includeTokens = tokens.filter(t => t.value?.toUpperCase() === 'INCLUDE' && t.referencedFile);
-        for (const inc of includeTokens) {
-            let resolvedPath: string | null = resolveViaProjectRedirection(inc.referencedFile!, fromFile);
+            const shimInclude = TokenHelper.findShimIncludeToken(tokens);
+            if (!shimInclude) return undefined;
+            let resolvedPath: string | null = resolveViaProjectRedirection(shimInclude.referencedFile!, fromFile);
             if (!resolvedPath) {
-                const candidate = path.resolve(fromDir, inc.referencedFile!);
+                const candidate = path.resolve(fromDir, shimInclude.referencedFile!);
                 if (fs.existsSync(candidate)) resolvedPath = candidate;
             }
-            if (!resolvedPath) continue;
+            if (!resolvedPath) return undefined;
+            const key = resolvedPath.toLowerCase();
+            if (visited.has(key)) return undefined;
+            visited.add(key);
 
             try {
                 const contents = await fs.promises.readFile(resolvedPath, 'utf-8');
                 const doc = TextDocument.create(pathToCanonicalUri(resolvedPath), 'clarion', 1, contents);
-                const nestedTokens = this.tokenCache.getTokens(doc);
-                const nested = TokenHelper.findMemberHeaderToken(nestedTokens);
-                if (nested) return nested;
+                tokens = this.tokenCache.getTokens(doc);
             } catch {
-                // Unreadable — skip
+                return undefined; // Unreadable — the chain is broken, nothing further can be legal
             }
+            fromDir = path.dirname(resolvedPath);
+            fromFile = resolvedPath;
         }
         return undefined;
     }
 
-    /**
-     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
-     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`. INCLUDE/LINK/MODULE targets
-     * always carry an explicit extension, so this is deliberately only applied to MEMBER targets.
-     * `resolveViaProjectRedirection`'s redirection lookup matches by extension mask (e.g. the `*.clw
-     * = ...` line in a .red file), so an extension-less name never matches any rule and silently
-     * fails to resolve. Mirrors MemberLocatorService.normalizeMemberFilename().
-     */
+    /** See TokenHelper.normalizeMemberFilename — kept as a thin delegate for existing call sites. */
     private normalizeMemberFilename(name: string): string {
-        return path.extname(name) ? name : `${name}.clw`;
+        return TokenHelper.normalizeMemberFilename(name);
     }
 
     /**

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -25,6 +25,45 @@ export class TokenHelper {
             t.referencedFile !== undefined);
     }
 
+    /**
+     * The first non-comment token of a compiled module, if it is an INCLUDE
+     * carrying a file reference — i.e. the only place a MEMBER-via-INCLUDE shim
+     * can legally live.
+     *
+     * Language rule: MEMBER (or PROGRAM) must be the FIRST statement in the
+     * compiled token stream — only comments and blank lines may precede it. So
+     * when a file has no literal MEMBER header, the sole legal way for it to be
+     * a MEMBER module is that its first statement is an INCLUDE whose target
+     * (or, transitively, the target's own first-statement INCLUDE) starts with
+     * MEMBER. A MEMBER found in any LATER include would not compile — sweeping
+     * all INCLUDE tokens is therefore not just wasted I/O on the miss-path, it
+     * can invent a parent the compiler would reject.
+     *
+     * Returns undefined when the first statement is anything else (MEMBER and
+     * PROGRAM included — callers already handled the literal-header case via
+     * findMemberHeaderToken / findProgramHeaderToken).
+     */
+    public static findShimIncludeToken(tokens: Token[]): Token | undefined {
+        const first = tokens.find(t =>
+            t.type !== TokenType.Comment &&
+            t.type !== TokenType.LineContinuation);
+        if (first?.value?.toUpperCase() === 'INCLUDE' && first.referencedFile) return first;
+        return undefined;
+    }
+
+    /**
+     * MEMBER/PROGRAM references conventionally omit the file extension (e.g.
+     * `MEMBER('TargetProgram')`) — the Clarion compiler infers `.clw`.
+     * INCLUDE/LINK/MODULE targets always carry an explicit extension, so this is
+     * deliberately only applied to MEMBER targets. Both the redirection parser
+     * (matches by extension mask, e.g. the `*.clw = ...` line in a .red file) and
+     * SolutionManager.findFileWithExtension (matches by exact source-file
+     * basename) silently fail to resolve an extension-less name.
+     */
+    public static normalizeMemberFilename(name: string): string {
+        return /\.[^\\/.]+$/.test(name) ? name : `${name}.clw`;
+    }
+
     /** #337 — PROGRAM header lookup (ClarionDocument-typed, no line cap). */
     public static findProgramHeaderToken(tokens: Token[]): Token | undefined {
         return tokens.find(t =>


### PR DESCRIPTION
# fix(diagnostics): resolve MEMBER through one INCLUDE hop for the missing-include check

## What happened

The missing-include diagnostic (`MissingIncludeDiagnostics.ts` → `IncludeVerifier.isClassIncluded`)
can false-positive on a class that is genuinely reachable, several INCLUDE hops deep, through a
PROGRAM file's transitive include chain — reporting it as missing even though it compiles fine —
whenever the member module reaches its `MEMBER('program')` statement through the common shim
convention described below.

## Root cause — two stacked bugs in `IncludeVerifier.computeMemberParentDocument()`

1. **Shim-blind.** It called `TokenHelper.findMemberHeaderToken(tokens)` directly on the current
   file's own tokens. A common project convention (the same one already fixed for hover/F12 in
   `fix/member-header-via-include`) puts the real `MEMBER('program')` statement in a small shared shim
   reached via `INCLUDE('member.clw')`, rather than writing it directly in every member. A member file
   using that shim has no literal `MEMBER(...)` token of its own, so the "check the MEMBER parent's
   includes" branch of `isClassIncluded` silently never ran.

2. **Extension-blind** (only surfaced once #1 was fixed and the MEMBER token was actually found).
   `MEMBER('SomeProgram')`-style targets omit the `.clw` extension — the idiomatic form; Clarion infers
   it for MEMBER, unlike INCLUDE/LINK/MODULE, which always carry one. `resolveViaProjectRedirection`
   matches by extension mask, so the extension-less name matches nothing; the local-dir fallback does a
   literal `fs.existsSync` on the extension-less path, which also can't find `SomeProgram.clw`. Path
   resolution failed a second, independent way even after the token was found.

Both bugs already had proven fixes for a **different resolver in the same repo** —
`MemberLocatorService.resolveMemberHeaderToken()` (one-INCLUDE-hop fallback) and
`MemberLocatorService.normalizeMemberFilename()` (append `.clw` when extension-less), both from
`fix/member-header-via-include` (commits `da0778a`, `21814a5`) for hover/F12/completion. Neither fix
had been ported to `IncludeVerifier.ts`, despite it hitting the identical shape of problem.

## Fix

Mirrored both `MemberLocatorService` patterns into `IncludeVerifier.ts`, in their revised
first-statement form (same revision as #388):

- `findMemberHeaderTokenWithFallback(tokens, fromDir, fromFile)` — tries the direct token lookup
  first, then follows the file's **first statement** — and only its first statement — into an
  INCLUDE'd shim. This shape comes from a language rule, not a heuristic: `MEMBER` (or `PROGRAM`)
  must be the first statement of a compiled module, so a MEMBER-carrying shim INCLUDE is only legal
  as the first statement, and a `MEMBER` behind any later include would not compile. A definition
  `.inc` (first statement is a data/CLASS declaration) or a PROGRAM file is therefore an instant
  miss with **zero file reads** — the pre-fallback instant-`null` behavior is preserved exactly.
  Each hop reads exactly one file; `MAX_SHIM_HOPS` (3) bounds the legal-but-rare chained-shim case
  and a visited set stops include cycles.
- `normalizeMemberFilename(name)` — appends `.clw` only when the MEMBER target has no extension
  already (deliberately scoped to MEMBER targets; INCLUDE/LINK/MODULE targets always carry one).

Both wired into `computeMemberParentDocument()`, replacing the bare `TokenHelper.findMemberHeaderToken`
call and the un-normalized `memberToken.referencedFile` passed to path resolution.

The convention logic lives as `TokenHelper` statics (`findShimIncludeToken`,
`normalizeMemberFilename`) shared with `MemberLocatorService`/`SymbolFinderService` (#388 carries the
identical `TokenHelper` hunk, so the two PRs merge cleanly in either order) — no parallel private
copies to diverge. The remaining ~20-line per-service walk loop around those statics can be
consolidated onto a single callback-parameterized helper in a small follow-up PR once both PRs land.

## Testing

New test file `IncludeVerifier.MemberViaIncludeShim.test.ts`: a member file `INCLUDE`s a `member.clw`
shim containing the extension-less `MEMBER('TargetProgram')`, and a class reachable only through the
target PROGRAM's transitive include chain must resolve as included; a genuinely unreachable class must
still be reported missing. Plus three first-statement-rule pins, each verified red against the
all-includes loop by reverting just the source fix:

- a chained shim (first-statement `INCLUDE` → `INCLUDE` → `MEMBER`) resolves;
- a `MEMBER` behind a **non**-first-statement INCLUDE does **not** resolve — pins both the compiler
  rule and the zero-file-reads miss-path;
- a self-including shim terminates without resolving (cycle guard).

`npm run test:server`: 2388 passing / 0 failing / 4 pending, rebased onto `origin/version-1.0.2`.

## Scope

Three files: `server/src/utils/IncludeVerifier.ts`, `server/src/utils/TokenHelper.ts` (shared
shim-convention statics, identical hunk carried by #388), and
`server/src/test/IncludeVerifier.MemberViaIncludeShim.test.ts` (new). No changes to
`MemberLocatorService.ts`/`SymbolFinderService.ts` — this PR only ports the already-proven pattern to
the diagnostics path; the hover/F12 fix is its own separate PR (#388).
