### PR TITLE
fix(deps): pin protocol 3.17.5 + @types/vscode 1.97 (unbreak the #413 group on master)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,9 @@ updates:
       # Majors are deliberate, tested migrations — never an auto-PR.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Pinned to 3.17.x: 3.18+ is exports-only and needs tsconfig
+      # moduleResolution node16/bundler — deferred to the LSP migration (#405).
+      - dependency-name: "vscode-languageserver-protocol"
+      # Must track engines.vscode (the declared minimum VS Code) — bumping it
+      # ahead of engines fails `vsce package`. Move it only when raising engines.
+      - dependency-name: "@types/vscode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,14 @@
         "mkdirp": "^3.0.1",
         "vscode-languageclient": "^8.1.0",
         "vscode-languageserver": "^8.1.0",
-        "vscode-languageserver-protocol": "^3.18.2",
+        "vscode-languageserver-protocol": "3.17.5",
         "vscode-languageserver-textdocument": "^1.0.12",
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@types/mocha": "^8.2.2",
         "@types/node": "^22.20.1",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "~1.97.0",
         "@types/xml2js": "^0.4.14",
         "@typescript-eslint/parser": "^8.66.0",
         "@vscode/test-electron": "^2.5.2",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.97.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.97.0.tgz",
+      "integrity": "sha512-ueE73loeOTe7olaVyqP9mrRI54kVPJifUPjblZo9fYcv1CuVLPOEKEkqW0GkqPC454+nCEoigLWnC2Pp7prZ9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3114,9 +3114,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
-      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3186,13 +3186,13 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
-      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "9.0.1",
-        "vscode-languageserver-types": "3.18.0"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -3202,9 +3202,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
-      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -1357,7 +1357,7 @@
   "devDependencies": {
     "@types/mocha": "^8.2.2",
     "@types/node": "^22.20.1",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "~1.97.0",
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/parser": "^8.66.0",
     "@vscode/test-electron": "^2.5.2",
@@ -1377,7 +1377,7 @@
     "mkdirp": "^3.0.1",
     "vscode-languageclient": "^8.1.0",
     "vscode-languageserver": "^8.1.0",
-    "vscode-languageserver-protocol": "^3.18.2",
+    "vscode-languageserver-protocol": "3.17.5",
     "vscode-languageserver-textdocument": "^1.0.12",
     "xml2js": "^0.6.2"
   },


### PR DESCRIPTION
Follow-up to the #413 merge on master. Two of the grouped updates break the build/package, so this pins them back (the other 7 are kept) and adds them to the Dependabot ignore list:

- **vscode-languageserver-protocol 3.18.2 → pin `3.17.5`**: 3.18 is `exports`-only; the repo's classic module resolution (`module: commonjs`, no `moduleResolution`) can't find its types → `TS2307` across 80 test files. Deferred to the LSP migration (#405), which will move tsconfig to node16/bundler.
- **@types/vscode 1.125.0 → pin `~1.97.0`**: 1.125 exceeds `engines.vscode ^1.97.0`, so `vsce package` refuses to build. Must track the declared VS Code floor.

Verified: `npm ci` clean, protocol resolves 3.17.5, @types/vscode 1.97.0. The same fix is already on `version-1.0.2` (3f89a533), so the two stay in sync. This unbreaks master's build and stops Dependabot re-proposing these until #405.