### PR TITLE
fix(hover): GROUP/QUEUE field declarations resolve to the wrong or no local variable

### DIFF
--- a/server/src/providers/hover/HoverFormatter.ts
+++ b/server/src/providers/hover/HoverFormatter.ts
@@ -31,6 +31,11 @@ logger.setLevel("error");
 export interface VariableInfo {
     type: string;
     line: number;
+    /** Set when this variable is a field directly inside a GROUP/QUEUE/FILE/
+     * RECORD/VIEW/REPORT — lets formatVariable note the containing structure
+     * instead of showing a bare local-variable card indistinguishable from a
+     * genuinely standalone variable. */
+    parentStructure?: { label: string; type: string };
 }
 
 export interface ParameterInfo {
@@ -97,31 +102,48 @@ export class HoverFormatter {
         if (document) {
             const position = { line: info.line, character: 0 };
             const detailedScope = this.scopeAnalyzer.getTokenScope(document, position);
-            
+
             if (detailedScope) {
-                const scopeIcon = detailedScope.type === 'routine' ? '🔐' : 
-                                  detailedScope.type === 'procedure' ? '🔧' : 
+                const scopeIcon = detailedScope.type === 'routine' ? '🔐' :
+                                  detailedScope.type === 'procedure' ? '🔧' :
                                   detailedScope.type === 'module' ? '📦' : '🌍';
-                
+
                 // Check if this is a method
                 const procedureName = detailedScope.containingProcedure?.label || detailedScope.containingProcedure?.value;
                 const isMethod = procedureName?.includes('.');
-                
-                let scopeLabel = '';
-                if (detailedScope.type === 'routine') {
-                    scopeLabel = `${scopeIcon} Local routine ${typeNoun}`;
-                } else if (detailedScope.type === 'procedure') {
-                    scopeLabel = isMethod ? `${scopeIcon} Local method ${typeNoun}` : `${scopeIcon} Local procedure ${typeNoun}`;
-                } else if (detailedScope.type === 'module') {
-                    scopeLabel = `${scopeIcon} Module ${typeNoun}`;
+
+                if (info.parentStructure) {
+                    // The procedure/routine/module-local-ness belongs to the
+                    // CONTAINING structure, not to this field — `Flag` isn't
+                    // itself "a local procedure variable", `Filter` is; `Flag`
+                    // is merely an offset into `Filter`'s storage. State that as
+                    // ONE accurate line rather than two adjacent, partially-wrong
+                    // claims ("local procedure variable" + "field of GROUP Filter").
+                    const scopeDescriptor =
+                        detailedScope.type === 'routine' ? 'local routine' :
+                        detailedScope.type === 'procedure' ? (isMethod ? 'local method' : 'local procedure') :
+                        detailedScope.type === 'module' ? 'module' : 'global';
+                    markdown.push(`${scopeIcon} Field of ${scopeDescriptor} ${info.parentStructure.type} \`${info.parentStructure.label}\``);
                 } else {
-                    scopeLabel = `${scopeIcon} Global ${typeNoun}`;
+                    let scopeLabel = '';
+                    if (detailedScope.type === 'routine') {
+                        scopeLabel = `${scopeIcon} Local routine ${typeNoun}`;
+                    } else if (detailedScope.type === 'procedure') {
+                        scopeLabel = isMethod ? `${scopeIcon} Local method ${typeNoun}` : `${scopeIcon} Local procedure ${typeNoun}`;
+                    } else if (detailedScope.type === 'module') {
+                        scopeLabel = `${scopeIcon} Module ${typeNoun}`;
+                    } else {
+                        scopeLabel = `${scopeIcon} Global ${typeNoun}`;
+                    }
+                    markdown.push(scopeLabel);
                 }
-                
-                markdown.push(scopeLabel);
+            } else if (info.parentStructure) {
+                // No detailedScope resolved, but the containing structure is
+                // still known — better than nothing.
+                markdown.push(`📦 Field of ${info.parentStructure.type} \`${info.parentStructure.label}\``);
             }
         }
-        
+
         if (document) {
             // Add the actual source code line
             const content = document.getText();

--- a/server/src/providers/hover/VariableHoverResolver.ts
+++ b/server/src/providers/hover/VariableHoverResolver.ts
@@ -59,13 +59,14 @@ export class VariableHoverResolver {
      * Find and format hover for a local variable
      */
     async findLocalVariableHover(word: string, tokens: Token[], currentScope: Token, document: TextDocument, originalWord?: string, hoverLine?: number): Promise<Hover | null> {
-        const symbolInfo = this.symbolFinder.findLocalVariable(word, tokens, currentScope, document, originalWord);
+        const symbolInfo = this.symbolFinder.findLocalVariable(word, tokens, currentScope, document, originalWord, hoverLine);
         
         if (symbolInfo) {
             logger.info(`✅ Found variable info for ${word}: type=${symbolInfo.type}, line=${symbolInfo.location.line}`);
             const variableInfo: VariableInfo = {
                 type: symbolInfo.type,
-                line: symbolInfo.location.line
+                line: symbolInfo.location.line,
+                parentStructure: symbolInfo.parentStructure
             };
             // #302 follow-up (Mark): no class-definition appendix — the declaration line and
             // location already carry everything the hover needs; F12 on the type covers "where

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -390,7 +390,9 @@ export class SymbolFinderService {
                     location: { uri: document.uri, line: declToken.line, character: declToken.start },
                     originalWord: originalWord || word,
                     searchWord: word,
-                    parentStructure: TokenHelper.getEnclosingDataStructure(declToken)
+                    // Pass the structure so a CLASS property (never `.parent`-linked, see
+                    // getEnclosingDataStructure) still gets its "field of CLASS `X`" note.
+                    parentStructure: TokenHelper.getEnclosingDataStructure(declToken, this.tokenCache.getStructure(document))
                 };
             }
         }

--- a/server/src/services/SymbolFinderService.ts
+++ b/server/src/services/SymbolFinderService.ts
@@ -119,12 +119,20 @@ export interface SymbolInfo {
     
     /** Full declaration if available (e.g., "Counter LONG,AUTO") */
     declaration?: string;
-    
+
     /** Original search word (before any prefix stripping) */
     originalWord: string;
-    
+
     /** Search word used to find this symbol (may be stripped) */
     searchWord: string;
+
+    /**
+     * Set when this symbol is a field directly inside a GROUP/QUEUE/FILE/RECORD/
+     * VIEW/REPORT (see TokenHelper.getEnclosingDataStructure) — lets the hover
+     * formatter note "field of GROUP `Filter`" instead of showing a bare local
+     * variable card indistinguishable from a genuinely standalone variable.
+     */
+    parentStructure?: { label: string; type: string };
 }
 
 /**
@@ -334,21 +342,69 @@ export class SymbolFinderService {
         tokens: Token[],
         scopeToken: Token,
         document: TextDocument,
-        originalWord?: string
+        originalWord?: string,
+        hoverLine?: number
     ): SymbolInfo | null {
         logger.info(`Finding local variable: "${word}" in scope: ${scopeToken.value} at line ${scopeToken.line}`);
-        
+
+        const searchText = originalWord || word;
+
+        // Fast path: the cursor is literally ON a declaration token for this name
+        // (column 0, Label/Variable, this exact line) — that IS the answer, with
+        // no ambiguity left to resolve. Without this, two things go wrong for a
+        // field of a PRE()-less GROUP/QUEUE:
+        //   1. The name-based symbol-tree search below has no line awareness, so
+        //      a DIFFERENT same-named symbol elsewhere (e.g. a top-level `Name`
+        //      variable) wins over the GROUP field the cursor is actually on.
+        //   2. Even when the token-fallback further down IS reached, the #350
+        //      "PRE-less fields are dot-only" rule — correct for a bare
+        //      REFERENCE elsewhere in code — wrongly excludes the DECLARATION
+        //      token itself; you were never doing a bare-name lookup, you're
+        //      already looking straight at it.
+        // Real repro: `Filter GROUP` with sibling fields `Name`/`Type`/`Flag` and
+        // no PRE() — hovering the GROUP's own `Name` field showed the unrelated
+        // top-level `Name` variable's declaration instead, and `Type`/`Flag`
+        // (no name collision to mask the miss) got no hover at all.
+        if (hoverLine !== undefined) {
+            const wordLower = searchText.toLowerCase();
+            const declToken = tokens.find(t =>
+                t.line === hoverLine &&
+                t.start === 0 &&
+                (t.type === TokenType.Label || t.type === TokenType.Variable) &&
+                t.value.toLowerCase() === wordLower);
+            // Same exclusion the token-fallback further down applies: a MAP/global
+            // procedure or method declaration sharing this line is handled by
+            // findProcedureDeclaration with the correct scope/type, not here.
+            const isProcDecl = declToken !== undefined && tokens.some(t =>
+                t.line === declToken.line &&
+                (t.type === TokenType.Procedure || t.type === TokenType.Function) &&
+                (t.subType === TokenType.MapProcedure ||
+                 t.subType === TokenType.GlobalProcedure ||
+                 t.subType === TokenType.MethodDeclaration));
+            if (declToken && !isProcDecl) {
+                logger.info(`✅ Found "${searchText}" via direct declaration-line match at line ${declToken.line}`);
+                return {
+                    token: declToken,
+                    type: SymbolFinderService.extractTypeInfo(declToken, tokens),
+                    scope: { token: scopeToken, type: 'local' },
+                    location: { uri: document.uri, line: declToken.line, character: declToken.start },
+                    originalWord: originalWord || word,
+                    searchWord: word,
+                    parentStructure: TokenHelper.getEnclosingDataStructure(declToken)
+                };
+            }
+        }
+
         // Get the symbol tree (pass document for better results)
         const symbols = this.symbolProvider.provideDocumentSymbols(tokens, document.uri, document);
-        
+
         // Find the procedure/method symbol containing this scope
         const procedureSymbol = this.findProcedureContainingLine(symbols, scopeToken.line);
         if (!procedureSymbol) {
             logger.info(`❌ No procedure symbol found for scope at line ${scopeToken.line} — falling back to token scan`);
         }
-        
+
         // Search for the variable in the symbol tree (if we have a procedure symbol)
-        const searchText = originalWord || word;
         // #265: a bare search word must never bind to a field of a PRE()'d
         // structure — those are only addressable as Pre:Field or Structure.Field
         // (Language Reference, PRE attribute). Qualified searches resolve via
@@ -1789,7 +1845,7 @@ export class SymbolFinderService {
         }
         
         // 2. Try as local variable
-        result = this.findLocalVariable(word, tokens, currentScope, document);
+        result = this.findLocalVariable(word, tokens, currentScope, document, undefined, position.line);
         if (result) {
             logger.info(`✅ Found as local variable: ${word}`);
             return result;
@@ -1889,7 +1945,7 @@ export class SymbolFinderService {
             }
             
             // Try local variable with stripped word
-            result = this.findLocalVariable(searchWord, tokens, currentScope, document, word);
+            result = this.findLocalVariable(searchWord, tokens, currentScope, document, word, position.line);
             if (result) {
                 logger.info(`✅ Found as local variable (stripped): ${searchWord}`);
                 return result;

--- a/server/src/test/HoverProvider.ClassFieldDeclaration.test.ts
+++ b/server/src/test/HoverProvider.ClassFieldDeclaration.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+// TokenHelper.getEnclosingDataStructure (added for GROUP/QUEUE fields — see
+// HoverProvider.GroupFieldDeclaration.test.ts) only recognized
+// QUEUE/GROUP/FILE/RECORD/VIEW/REPORT as a "field of X" container. A CLASS
+// property's own declaration line fell through the same generic fallback a
+// bare top-level variable gets, mislabeling it "Local procedure variable"
+// instead of noting it belongs to the class. Method declarations were
+// already unaffected — they route through a separate "Method Declaration:"
+// formatter, not this one.
+//
+// Real repro (found live):
+//   MyOwn:CLASS   CLASS
+//   my:Value        ULONG
+//   My:My:Method    PROCEDURE(),LONG
+//                 END
+//
+// Hovering my:Value's own declaration showed "🔧 Local procedure variable"
+// instead of noting it's a field of MyOwn:CLASS.
+suite('HoverProvider — declaring a property inside a local CLASS', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    const code = [
+        'MyProc PROCEDURE()',
+        '',
+        'MyClass   CLASS',
+        'my:Value        ULONG',
+        'DoWork          PROCEDURE(),LONG',
+        '              END',
+        '',
+        'CODE',
+        '  RETURN',
+    ].join('\n');
+
+    test('hovering a CLASS property declaration notes which CLASS it belongs to, not "Local procedure variable"', async () => {
+        const doc = TextDocument.create('test://class-property-parent-note.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = hoverText(await provider.provideHover(doc, Position.create(3, 2))); // "my:Value        ULONG"
+        assert.ok(hover.includes('Field of local procedure CLASS') && hover.includes('MyClass'),
+            `Should note my:Value is a field of the local procedure CLASS MyClass; got: ${hover}`);
+        assert.ok(!hover.includes('Local procedure variable'),
+            `Should not claim my:Value is itself "a local procedure variable"; got: ${hover}`);
+        assert.ok(hover.includes('ULONG'), `Should still show the field's own type; got: ${hover}`);
+    });
+
+    test('negative sentinel — hovering the CLASS METHOD declaration is unaffected (routes through Method Declaration formatter)', async () => {
+        const doc = TextDocument.create('test://class-method-declaration-sentinel.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = hoverText(await provider.provideHover(doc, Position.create(4, 2))); // "DoWork          PROCEDURE(),LONG"
+        assert.ok(hover.includes('Method Declaration') && hover.includes('MyClass.DoWork'),
+            `Method declaration hover should be unaffected by this fix; got: ${hover}`);
+        assert.ok(!hover.includes('Field of'),
+            `Method declaration should not get a "Field of" note; got: ${hover}`);
+    });
+});

--- a/server/src/test/HoverProvider.GroupFieldDeclaration.test.ts
+++ b/server/src/test/HoverProvider.GroupFieldDeclaration.test.ts
@@ -1,0 +1,174 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+// A field of a PRE()-less GROUP/QUEUE can only be REFERENCED via dot
+// qualification (Structure.Field — issue #350), but that rule was also being
+// applied to the DECLARATION token itself, which is never a "bare reference"
+// — you're pointing straight at it. SymbolFinderService.findLocalVariable had
+// no way to prefer "the exact token under the cursor" over either (a) a
+// same-named symbol elsewhere winning the name-based symbol-tree search, or
+// (b) the #350 exclusion rejecting the token outright.
+//
+// Real repro (found live, exact structure from the reporting session):
+//   Order  LONG
+//   Name    STRING(32)
+//   Filter GROUP
+//   Name      LONG      <- collides with the top-level Name above
+//   Type      LONG
+//   Flag      LONG
+//   Integer   LONG
+//          END
+//
+// Hovering Filter's own Name field showed the top-level Name's declaration
+// instead; hovering Type/Flag/Integer (no name collision to mask the miss)
+// showed nothing, which in the real project fell through to an unrelated
+// same-named field in an unrelated INCLUDE file (WinApi.inc).
+suite('HoverProvider — declaring a field inside a PRE()-less GROUP', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    const code = [
+        'MyProc PROCEDURE()',
+        '',
+        'Order  LONG',
+        'Name    STRING(32)',
+        'Filter GROUP',
+        'Name      LONG',
+        'Type      LONG',
+        'Flag      LONG',
+        'Integer   LONG',
+        '       END',
+        '',
+        'CODE',
+        '  RETURN',
+    ].join('\n');
+
+    test('hovering the GROUP field "Name" shows itself (LONG), not the colliding top-level Name (STRING)', async () => {
+        const doc = TextDocument.create('test://group-name-collision.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(5, 2)); // "Name      LONG" inside Filter
+        const content = hoverText(hover);
+        assert.ok(content.includes('LONG'),
+            `Should show the GROUP field's own LONG type; got: ${content}`);
+        assert.ok(!content.includes('STRING'),
+            `Should not show the colliding top-level STRING Name; got: ${content}`);
+        assert.ok(content.includes(':6') || content.includes('line 6') || /clw:6\b/.test(content),
+            `Should cite its own declaration line (6, 1-based), not the top-level Name's line; got: ${content}`);
+    });
+
+    test('hovering GROUP field "Type" (no name collision) resolves to itself, not (none) or an unrelated builtin/attribute', async () => {
+        const doc = TextDocument.create('test://group-type-field.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(6, 2)); // "Type      LONG"
+        const content = hoverText(hover);
+        assert.ok(content.length > 0, 'Expected a hover, got none');
+        assert.ok(content.includes('LONG') && !content.includes('(Attribute)') && !content.includes('(Procedure)'),
+            `Should resolve as the field itself, not an attribute/builtin card; got: ${content}`);
+    });
+
+    test('hovering a GROUP field declaration notes which GROUP it belongs to, as ONE accurate line', async () => {
+        // The declaration-line fast path returns a plain local-variable SymbolInfo
+        // with no structural context, so its hover looked identical to a genuinely
+        // standalone variable — unlike the dotted USE(Filter.Flag) reference, which
+        // already says "Filter Field: Flag". Reported live by the developer after
+        // the declaration-hover fix landed.
+        //
+        // First attempt showed BOTH "Local procedure variable" and "Field of GROUP
+        // Filter" as two adjacent lines — the developer asked whether that was even
+        // correct. It wasn't: `Flag` isn't itself a variable at all (it has no
+        // independent existence — it's an offset into `Filter`'s storage), so
+        // calling it "a local procedure variable" is a category error; the
+        // procedure-local-ness belongs to `Filter`. Fixed to state one accurate
+        // combined line instead of two adjacent, partially-wrong claims.
+        const doc = TextDocument.create('test://group-field-parent-note.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = hoverText(await provider.provideHover(doc, Position.create(7, 2))); // "Flag      LONG"
+        assert.ok(hover.includes('Field of local procedure GROUP') && hover.includes('Filter'),
+            `Should note Flag is a field of the local procedure GROUP Filter; got: ${hover}`);
+        assert.ok(!hover.includes('Local procedure variable'),
+            `Should not ALSO claim Flag is itself "a local procedure variable" — that's Filter, not Flag; got: ${hover}`);
+    });
+
+    test('negative sentinel — a plain top-level variable declaration gets no "Field of" note', async () => {
+        const doc = TextDocument.create('test://plain-variable-no-note.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = hoverText(await provider.provideHover(doc, Position.create(2, 2))); // top-level "Order"
+        assert.ok(!hover.includes('Field of'),
+            `A plain top-level variable must not show a "Field of" note; got: ${hover}`);
+    });
+
+    test('hovering GROUP field "Flag" (no name collision) resolves to itself', async () => {
+        const doc = TextDocument.create('test://group-flag-field.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(7, 2)); // "Flag      LONG"
+        const content = hoverText(hover);
+        assert.ok(content.includes('LONG'), `Should resolve the Flag field itself; got: ${content}`);
+    });
+
+    test('hovering GROUP field "Integer" (no name collision) resolves to itself', async () => {
+        const doc = TextDocument.create('test://group-integer-field.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(8, 2)); // "Integer   LONG"
+        const content = hoverText(hover);
+        assert.ok(content.includes('LONG'), `Should resolve the Integer field itself; got: ${content}`);
+    });
+
+    test('negative sentinel — the top-level Name/Order declarations still resolve to themselves', async () => {
+        const doc = TextDocument.create('test://toplevel-sentinels.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const nameHover = hoverText(await provider.provideHover(doc, Position.create(3, 2))); // top-level Name
+        assert.ok(nameHover.includes('STRING'), `Top-level Name must still resolve as STRING; got: ${nameHover}`);
+
+        const orderHover = hoverText(await provider.provideHover(doc, Position.create(2, 2))); // Order
+        assert.ok(orderHover.includes('LONG'), `Order must still resolve as LONG; got: ${orderHover}`);
+    });
+
+    test('negative sentinel — a bare (dotted) reference to Filter.Name via USE(...) still resolves to the GROUP field', async () => {
+        const codeWithUse = [
+            code.slice(0, code.indexOf('CODE')),
+            "Window WINDOW('Caption'),AT(,,119,93)",
+            "  CHECK('c1'),AT(10,14),USE(Filter.Name)",
+            'END',
+            '',
+            'CODE',
+            '  RETURN',
+        ].join('\n');
+        const doc = TextDocument.create('test://dotted-reference-sentinel.clw', 'clarion', 1, codeWithUse);
+        tokenCache.getTokens(doc);
+
+        const lines = codeWithUse.split('\n');
+        const useLine = lines.findIndex(l => l.includes('USE(Filter.Name)'));
+        const nameCol = lines[useLine].indexOf('Filter.Name') + 'Filter.'.length;
+
+        const hover = hoverText(await provider.provideHover(doc, Position.create(useLine, nameCol + 1)));
+        assert.ok(hover.includes('Filter Field') && hover.includes('LONG'),
+            `Dotted Filter.Name reference must still resolve to the GROUP field; got: ${hover}`);
+    });
+});

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -105,14 +105,25 @@ export class TokenHelper {
     }
 
     /**
-     * Finds the nearest enclosing GROUP/QUEUE/FILE/RECORD/VIEW/REPORT ancestor of
-     * `t`, for DISPLAY purposes (e.g. a hover noting "field of GROUP `Filter`").
+     * Finds the nearest enclosing GROUP/QUEUE/FILE/RECORD/VIEW/REPORT/CLASS ancestor
+     * of `t`, for DISPLAY purposes (e.g. a hover noting "field of GROUP `Filter`").
      * Unlike {@link requiresDotQualification} this doesn't stop early at a
-     * `structurePrefix` (PRE) or bail out on CLASS/INTERFACE/MAP/MODULE — it's
+     * `structurePrefix` (PRE) or bail out on INTERFACE/MAP/MODULE — it's
      * answering a different question ("what data structure, if any, directly
      * contains this field") rather than "can a bare word legally bind here".
+     *
+     * CLASS is found differently from the others. DocumentStructure only
+     * `.parent`-links member tokens of RECORD/GROUP/QUEUE/FILE/VIEW/WINDOW/REPORT
+     * (its "Add label tokens as children" branch) — class members are deliberately
+     * left unlinked because their resolution lives in ClassMemberResolver, and
+     * several resolvers rely on `parent === undefined` / `isStructureField` to
+     * tell a bare label from a structure field. So the parent walk can never see
+     * a CLASS; when `structure` is supplied, fall back to its CLASS index instead
+     * (the same `isInClassBlock` + `getClasses` pair VariableHoverResolver already
+     * uses for global class properties). Display-only: nothing is stamped on the
+     * token, so no other consumer's view of it changes.
      */
-    public static getEnclosingDataStructure(t: Token): { label: string; type: string } | undefined {
+    public static getEnclosingDataStructure(t: Token, structure?: DocumentStructure): { label: string; type: string } | undefined {
         let anc = t.parent;
         while (anc) {
             if (anc.type === TokenType.Structure) {
@@ -122,6 +133,23 @@ export class TokenHelper {
                 }
             }
             anc = anc.parent;
+        }
+
+        if (structure && structure.isInClassBlock(t.line)) {
+            // Nearest CLASS opening above `t` whose extent still covers it. CLASSes don't
+            // nest, so "nearest preceding that contains" is the unique owner.
+            let owner: Token | undefined;
+            for (const cls of structure.getClasses()) {
+                if (cls.line < t.line &&
+                    (cls.finishesAt === undefined || cls.finishesAt >= t.line) &&
+                    (!owner || cls.line > owner.line)) {
+                    owner = cls;
+                }
+            }
+            const label = owner?.label ?? owner?.value;
+            if (owner && label) {
+                return { label, type: 'CLASS' };
+            }
         }
         return undefined;
     }

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -105,6 +105,28 @@ export class TokenHelper {
     }
 
     /**
+     * Finds the nearest enclosing GROUP/QUEUE/FILE/RECORD/VIEW/REPORT ancestor of
+     * `t`, for DISPLAY purposes (e.g. a hover noting "field of GROUP `Filter`").
+     * Unlike {@link requiresDotQualification} this doesn't stop early at a
+     * `structurePrefix` (PRE) or bail out on CLASS/INTERFACE/MAP/MODULE — it's
+     * answering a different question ("what data structure, if any, directly
+     * contains this field") rather than "can a bare word legally bind here".
+     */
+    public static getEnclosingDataStructure(t: Token): { label: string; type: string } | undefined {
+        let anc = t.parent;
+        while (anc) {
+            if (anc.type === TokenType.Structure) {
+                const v = anc.value.toUpperCase();
+                if (TokenHelper.DOT_ONLY_STRUCTURES.has(v) && anc.label) {
+                    return { label: anc.label, type: v };
+                }
+            }
+            anc = anc.parent;
+        }
+        return undefined;
+    }
+
+    /**
      * Gets the innermost scope at a line (optimized version using DocumentStructure)
      * 🚀 PERFORMANCE: O(log n) using document structure instead of O(n) filter
      * @param structure DocumentStructure instance


### PR DESCRIPTION
# fix(hover): GROUP/QUEUE field declarations resolve to the wrong or no local variable

**Branch:** `geircodes/Clarion-Extension:fix/group-field-declaration-hover` → `msarson/Clarion-Extension:version-1.0.2`

## What happened

Hovering the DECLARATION of a field inside a `PRE()`-less `GROUP`/`QUEUE` — a field only reachable
elsewhere as `Structure.Field`, per the existing field-qualification rule — was broken in two ways.
Repro (see `HoverProvider.GroupFieldDeclaration.test.ts`):

```
Order  LONG
Name    STRING(32)
Filter GROUP
Name      LONG        <- collides with the top-level Name above
Type      LONG
Flag      LONG
Integer   LONG
       END
```

- Hovering `Filter`'s own `Name` field (line 4 above) shows the TOP-LEVEL `Name`'s declaration
  (`STRING(32)`) instead of itself (`LONG`) — wrong symbol, wrong type, wrong line.
- Hovering `Type`/`Flag`/`Integer` (no name collision to mask the miss) produces no hover at all.

## Root cause

`SymbolFinderService.findLocalVariable`'s name-based symbol-tree search has no line-awareness — when
two symbols share a name, it returns whichever one the traversal order happens to find first,
regardless of where the cursor actually is. Separately, the existing "a field of a `PRE()`-less
structure requires dot qualification" exclusion — correct for a bare REFERENCE to the field
elsewhere in code — was also being applied to the DECLARATION token itself. That's wrong: pointing
straight at a declaration is never a "bare reference" in the sense that rule is guarding against.

## Fix

Added a fast path to `findLocalVariable`: if the hover position is exactly on a `Label`/`Variable`
token matching the search word, that token IS the answer — checked before both the ambiguous
name-based search and the dot-qualification exclusion. Kept the existing MAP/method-declaration
exclusion so it can't misfire there. Threaded a new `hoverLine` parameter through to the two call
sites shared with go-to-definition's `findSymbol`, so F12 gets the same fix.

Separately, such a field's hover didn't mention which structure it belongs to, making it look like
an ordinary standalone variable — unlike the existing dotted-reference hover, which already says
e.g. "Filter Field: Flag". Added `TokenHelper.getEnclosingDataStructure` to find the nearest
enclosing `GROUP`/`QUEUE`/`FILE`/`RECORD`/`VIEW`/`REPORT` ancestor, folded into one accurate combined
line (`🔧 Field of local procedure GROUP \`Filter\``) rather than showing it alongside a separate
"Local procedure variable" line — the field itself is not independently a variable (it has no
existence apart from `Filter`'s storage); it's a field of one, and saying both makes a category
error.

## Testing

New test file `HoverProvider.GroupFieldDeclaration.test.ts`: the name-collision case, three
no-collision cases, negative sentinels confirming the top-level declarations and a dotted
`USE(Filter.Name)` reference are unaffected, and a case pinning the single combined scope+structure
line.

`npx tsc -b`: clean. `npm run test:server`: 2459 passing, 4 pending (pre-existing), 0 failing.

## Scope

Five files: `SymbolFinderService.ts`, `VariableHoverResolver.ts`, `TokenHelper.ts`,
`HoverFormatter.ts`, plus the new test file. Independent of the attribute/builtin/keyword collision
fix in the companion PR — different subsystem (symbol resolution for a token everyone agrees is a
variable/field, vs. misclassifying the token's kind in the first place) — though both were found in
the same investigation.

## Follow-up commit (`f907c76`) — the same gap for CLASS properties

Found live after the first commit was deployed: a property declared inside a procedure-local
CLASS still hovered as the generic `🔧 Local procedure variable`, exactly the label this PR
removed for GROUP fields.

```
MyClass   CLASS
my:Value        ULONG          <- hovered as "Local procedure variable"
DoWork          PROCEDURE(),LONG
              END
```

**Why the first commit didn't cover it.** `getEnclosingDataStructure` walks `token.parent`, and
`DocumentStructure` only `.parent`-links member tokens of
`RECORD/GROUP/QUEUE/FILE/VIEW/WINDOW/REPORT` (its "Add label tokens as children" branch). CLASS
members are deliberately left unlinked — their resolution lives in `ClassMemberResolver`, and
several resolvers (`SymbolFinderService`, `ReferencesProvider`, `DefinitionProvider`,
`WordCompletionProvider`) use `parent === undefined` / `isStructureField` to tell a bare label
from a structure field. So the walk never sees a CLASS.

**Fix (display-only).** `getEnclosingDataStructure` takes an optional `DocumentStructure`; when
the parent walk finds nothing and the line is inside a CLASS body, it resolves the owning class
from the structure's CLASS index — `isInClassBlock` + `getClasses`, the same pair
`VariableHoverResolver.buildGlobalVariableHover` already uses for *global* class properties. The
declaration fast path passes the structure. Result:

```
**my:Value** — `ULONG`
🔧 Field of local procedure CLASS `MyClass`
```

Nothing is stamped on the token, so no other consumer's view of it changes. Method declarations
are unaffected (they route through the separate "Method Declaration:" formatter) — pinned by a
sentinel test.

**Considered and rejected: adding `CLASS` to `DocumentStructure`'s field-parenting list.** It
would have been a one-word change, but that list feeds more than hover: `maxLabelLength` /
`childMaxLabel` iterate Label children, so `ClarionFormatter` would start widening CLASS-body
alignment to the longest property name; and `SymbolFinderService.findStructureField` would start
matching property declarations, routing F12/references into the PRE/dot `'field'` path that has
no notion of `SELF.member` usages. Both are plausible improvements, but each is its own change
with its own test surface — not something to smuggle in under a hover fix.

**Alternative worth noting for a later pass.** The global-class path already labels these
`🔷 Class property of \`X\``; this commit keeps the `Field of <scope> CLASS \`X\`` wording so the
local path stays consistent with the GROUP/QUEUE line introduced in the parent commit. Unifying
the two paths on one wording (and one code path) is a reasonable follow-up.

**Testing.** New `HoverProvider.ClassFieldDeclaration.test.ts` (2 tests). Reverting just the two
fix files makes the property test fail with the reported label; restoring them makes it pass.
Full suite on this branch: 2425 passing (+2), 4 pending, 3 failing — the 3 are this PR's own
`GroupFieldDeclaration` `Name`/`Type` cases, which depend on the attribute/builtin collision
guards in the companion PR (#425) and pass on a tree that has both. The parent commit's
"0 failing" was measured on such a tree.

