### PR TITLE
fix(diagnostics,hover): attribute/builtin/keyword name collisions with variables/fields

### DIFF
--- a/server/src/providers/diagnostics/AttributeDiagnostics.ts
+++ b/server/src/providers/diagnostics/AttributeDiagnostics.ts
@@ -3,6 +3,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver/nod
 import { Token, TokenType } from '../../ClarionTokenizer';
 import { DocumentStructure } from '../../DocumentStructure';
 import { AttributeService } from '../../utils/AttributeService';
+import { isDotSuffix, isDotBase, isNestedInsideAttributeArgs } from '../../utils/AttributeContextGuards';
 
 const attributeService = AttributeService.getInstance();
 
@@ -112,11 +113,14 @@ export function validateAttributeApplicability(tokens: Token[], document: TextDo
             continue;
         }
 
-        // Dot-suffix guard: skip Attribute tokens used as member names in dot access,
-        // e.g. SELF.Sectors.Type or Obj.Item.Type. In these contexts TYPE/ITEM/etc.
-        // are identifiers, not Clarion attribute applications.
+        // Dot-suffix / dot-base guards (shared with HoverRouter's identical attribute-
+        // vs-variable ambiguity — see AttributeContextGuards.ts): skip Attribute
+        // tokens used as either end of a dotted member-access chain, e.g. the `Type`
+        // in `SELF.Sectors.Type` (suffix) or the `Filter` in `USE(Filter.Item[1])`
+        // (base). In these contexts the token is an identifier/variable reference,
+        // not a Clarion attribute application.
         const lineText = lines[token.line] ?? '';
-        if (token.start > 0 && lineText[token.start - 1] === '.') {
+        if (isDotSuffix(lineText, token.start) || isDotBase(lineText, token.start, token.value.length)) {
             continue;
         }
 
@@ -145,6 +149,18 @@ export function validateAttributeApplicability(tokens: Token[], document: TextDo
 
         const controlType = ctx.controlType.toUpperCase();
         if (!VALIDATABLE_CONTROLS.has(controlType)) continue; // Ambiguous context — skip
+
+        // Paren-nesting guard (shared with HoverRouter — see AttributeContextGuards.ts):
+        // skip Attribute tokens that sit inside the argument parentheses of a
+        // PRECEDING attribute in this same control's declaration — e.g. the `Filter`
+        // in `USE(Filter.Item[1])`, or a bare `USE(Filter)` with no dotted suffix at
+        // all. Either way, `Filter` here is the VALUE passed to USE(), not a second,
+        // standalone attribute application. Subsumes the dot-base guard above for
+        // the control-declaration case, but is kept alongside it since the dot-base
+        // guard also covers dotted access with no enclosing parens at all.
+        if (ctx.controlToken && isNestedInsideAttributeArgs(tokens, i, ctx.controlToken)) {
+            continue;
+        }
 
         const isValid = isAttributeValidForControl(attrName, controlType, attrDef.applicableTo);
         if (isValid) continue;

--- a/server/src/providers/hover/ContextualHoverHandler.ts
+++ b/server/src/providers/hover/ContextualHoverHandler.ts
@@ -2,6 +2,7 @@ import { Hover } from 'vscode-languageserver-protocol';
 import { Token, TokenType } from '../../ClarionTokenizer';
 import { BuiltinFunctionService } from '../../utils/BuiltinFunctionService';
 import { AttributeService } from '../../utils/AttributeService';
+import { KeywordService } from '../../utils/KeywordService';
 import LoggerManager from '../../logger';
 
 const logger = LoggerManager.getLogger("ContextualHoverHandler");
@@ -12,6 +13,8 @@ logger.setLevel("error");
  * that have different meanings depending on where they appear
  */
 export class ContextualHoverHandler {
+    private keywordService = KeywordService.getInstance();
+
     constructor(
         private builtinService: BuiltinFunctionService,
         private attributeService: AttributeService
@@ -49,14 +52,12 @@ export class ContextualHoverHandler {
      */
     handleModuleKeyword(isInMapBlock: boolean): Hover | null {
         if (isInMapBlock) {
-            // MODULE in MAP context - it's a builtin keyword
-            const signatures = this.builtinService.getSignatures('MODULE');
-            if (signatures.length > 0) {
-                const sig = signatures[0];
-                const docText = typeof sig.documentation === 'string' 
-                    ? sig.documentation 
-                    : (sig.documentation as any)?.value || '';
-                const formattedDoc = `**MODULE** (Keyword)\n\n${docText}\n\n**Syntax:** \`${sig.label}\``;
+            // MODULE in MAP context - it's a language keyword (clarion-keywords.json),
+            // NOT a builtin function — BuiltinFunctionService has no MODULE entry at
+            // all, so looking it up there always returned null here.
+            const entry = this.keywordService.getKeyword('MODULE');
+            if (entry) {
+                const formattedDoc = `**MODULE** (Keyword)\n\n${entry.description}\n\n**Syntax:** \`${entry.syntax}\``;
                 return {
                     contents: {
                         kind: 'markdown',

--- a/server/src/providers/hover/HoverRouter.ts
+++ b/server/src/providers/hover/HoverRouter.ts
@@ -8,6 +8,7 @@ import { RoutineHoverResolver } from './RoutineHoverResolver';
 import { ContextualHoverHandler } from './ContextualHoverHandler';
 import { BuiltinFunctionService } from '../../utils/BuiltinFunctionService';
 import { AttributeService } from '../../utils/AttributeService';
+import { isDotSuffix, isDotBase, isNestedInsideAttributeArgs, isDeclarationLabel, HANDLED_BY_SPECIAL_KEYWORDS } from '../../utils/AttributeContextGuards';
 import { PropertyService } from '../../utils/PropertyService';
 import { EventService } from '../../utils/EventService';
 import { DirectiveService } from '../../utils/DirectiveService';
@@ -126,7 +127,7 @@ export class HoverRouter {
             if (symbolHover) return symbolHover;
 
             // 9. Handle attributes
-            const attributeHover = this.handleAttribute(word, line, wordRange, document, position, documentStructure, isInClassBlock);
+            const attributeHover = this.handleAttribute(word, line, wordRange, document, position, documentStructure, isInClassBlock, tokens);
             mark('attribute');
             if (attributeHover) return attributeHover;
 
@@ -151,7 +152,7 @@ export class HoverRouter {
             if (languageKeywordHover) return languageKeywordHover;
 
             // 10. Handle built-in functions (AFTER method declarations to avoid shadowing)
-            const builtinHover = await this.handleBuiltin(word, line, wordRange, document, position, tokens);
+            const builtinHover = await this.handleBuiltin(word, line, wordRange, document, position, tokens, documentStructure);
             mark('builtin');
             if (builtinHover) return builtinHover;
 
@@ -166,7 +167,7 @@ export class HoverRouter {
      * Handle special keywords (MODULE, TO, ELSE, PROCEDURE, HIDE, DISABLE, TYPE)
      */
     private handleSpecialKeywords(context: HoverContext): Hover | null {
-        const { word, line, tokens, position, isInMapBlock, isInClassBlock, isInWindowContext, documentStructure } = context;
+        const { word, line, tokens, position, isInMapBlock, isInClassBlock, documentStructure, currentLineTokens } = context;
         const upperWord = word.toUpperCase();
 
         if (upperWord === 'WINDOW' || upperWord === 'APPLICATION' || upperWord === 'REPORT') {
@@ -184,7 +185,25 @@ export class HoverRouter {
         }
 
         if (upperWord === 'MODULE') {
-            return this.contextHandler.handleModuleKeyword(isInMapBlock);
+            // MODULE (a CLASS-only attribute) is ALSO a MAP-block builtin keyword.
+            // In a MAP block it's unambiguous. Outside one, only treat it as the
+            // CLASS attribute when it's genuinely on/beside a CLASS structure's own
+            // declaration line — a dotted/nested reference (`Module.Something`,
+            // `SomeCall(Module)`) or a plain unrelated variable must fall through
+            // to variable resolution instead.
+            if (isInMapBlock) {
+                return this.contextHandler.handleModuleKeyword(true);
+            }
+            if (this.isDottedOrNestedKeywordReference(context)) {
+                return null;
+            }
+            const lineHasClassKeyword = currentLineTokens.some(t =>
+                (t.type === TokenType.Structure || t.type === TokenType.WindowElement) &&
+                t.value.toUpperCase() === 'CLASS');
+            if (!lineHasClassKeyword) {
+                return null;
+            }
+            return this.contextHandler.handleModuleKeyword(false);
         }
 
         if (upperWord === 'TO') {
@@ -200,16 +219,106 @@ export class HoverRouter {
         }
 
         if (upperWord === 'HIDE' || upperWord === 'DISABLE') {
-            // Attribute when inside a window/control declaration; builtin when in code section
-            return this.contextHandler.handleWindowBuiltin(word, isInWindowContext);
+            // HIDE/DISABLE (applicableTo: CONTROL) are ALSO builtin runtime
+            // functions. A dotted/nested reference is neither. Otherwise: show
+            // the attribute card only when genuinely inside a control/class
+            // declaration; show the builtin card only when actually CALLED
+            // (`HIDE(?List)`) — a bare, uncalled, non-declaration word is a
+            // plain variable, not either of these.
+            if (this.isDottedOrNestedKeywordReference(context)) {
+                return null;
+            }
+            const controlContext = documentStructure.getControlContextAt(position.line, position.character);
+            const inDeclarationContext = isInClassBlock || controlContext.structureType !== null || controlContext.controlType !== null;
+            if (inDeclarationContext) {
+                return this.contextHandler.handleWindowBuiltin(word, true);
+            }
+            const isActualCall = /^\s*\(/.test(line.slice(context.wordRange.end.character));
+            if (isActualCall) {
+                return this.contextHandler.handleWindowBuiltin(word, false);
+            }
+            return null;
         }
 
         if (upperWord === 'TYPE') {
-            // Attribute on GROUP/QUEUE/CLASS (outside window); builtin TYPE(string) inside REPORT
-            return this.contextHandler.handleWindowBuiltin(word, !isInWindowContext);
+            // TYPE (applicableTo: GROUP/QUEUE/CLASS/INTERFACE) is ALSO the
+            // TYPE(string) report builtin. A dotted/nested reference is neither.
+            // Otherwise: show the attribute card only when genuinely on a
+            // GROUP/QUEUE/CLASS/INTERFACE structure's own declaration line; show
+            // the builtin card only when actually CALLED (`TYPE('text')`) — a
+            // bare, uncalled, unrelated word (e.g. a local variable named Type)
+            // is neither.
+            if (this.isDottedOrNestedKeywordReference(context)) {
+                return null;
+            }
+            const lineHasStructureKeyword = currentLineTokens.some(t =>
+                (t.type === TokenType.Structure || t.type === TokenType.WindowElement) &&
+                ['GROUP', 'QUEUE', 'CLASS', 'INTERFACE'].includes(t.value.toUpperCase()));
+            if (lineHasStructureKeyword) {
+                return this.contextHandler.handleWindowBuiltin(word, true);
+            }
+            const isActualCall = /^\s*\(/.test(line.slice(context.wordRange.end.character));
+            if (isActualCall) {
+                return this.contextHandler.handleWindowBuiltin(word, false);
+            }
+            return null;
         }
 
         return null;
+    }
+
+    /**
+     * Shared suppression check for the HIDE/DISABLE/TYPE/MODULE branches above:
+     * true when `word` is being used as the BASE of a dotted member-access chain
+     * (e.g. the `Hide` in `Hide.Something`) or is nested inside another
+     * attribute's argument list (e.g. the `Type` in `USE(Type)`) — either way
+     * it's a variable/field reference, not a keyword/attribute/builtin
+     * application, and callers should fall through to variable resolution.
+     *
+     * Mirrors handleAttribute/handleBuiltin's guards (see
+     * AttributeContextGuards.ts) but anchors the paren-nesting walk on the
+     * FIRST TOKEN OF THE CURRENT LINE when there's no recognised control token
+     * (e.g. QUEUE/CLASS/INTERFACE aren't in ControlService's control set, unlike
+     * GROUP) — sufficient for the common single-line case; a multi-line
+     * `|`-continued declaration falls back to the pre-existing behavior.
+     */
+    private isDottedOrNestedKeywordReference(context: HoverContext): boolean {
+        const { word, line, wordRange, tokens, position, documentStructure } = context;
+
+        if (isDotBase(line, wordRange.start.character, word.length)) {
+            return true;
+        }
+
+        // A word immediately followed by '(' is making its OWN call (e.g. the
+        // TYPE in `STRING(TYPE('x'))`) — that's a legitimate nested builtin
+        // call, not a bare value passed to the enclosing attribute/call (e.g.
+        // the Filter in `USE(Filter)`), so paren-nesting suppression must not
+        // apply to it.
+        if (/^\s*\(/.test(line.slice(wordRange.end.character))) {
+            return false;
+        }
+
+        const tokenIndex = tokens.findIndex(t =>
+            t.line === position.line &&
+            position.character >= t.start &&
+            position.character <= t.start + t.value.length);
+        if (tokenIndex < 0) return false;
+
+        const controlContext = documentStructure.getControlContextAt(position.line, position.character);
+        const anchor = controlContext.controlToken ?? tokens.find(t => t.line === position.line);
+        if (!anchor) return false;
+
+        // The anchor must actually precede the token, or the backward walk can
+        // never terminate on it and instead runs its full step bound across
+        // earlier, unrelated statements. That happens when the hovered word IS
+        // the first token on its line (fallback anchor === the token itself),
+        // in which case there is nothing before it on this line to be nested in.
+        if (anchor.line > position.line ||
+            (anchor.line === position.line && anchor.start >= tokens[tokenIndex].start)) {
+            return false;
+        }
+
+        return isNestedInsideAttributeArgs(tokens, tokenIndex, anchor);
     }
 
     /**
@@ -380,10 +489,31 @@ export class HoverRouter {
         wordRange: any,
         document: any,
         position: { line: number; character: number },
-        documentStructure: { getControlContextAt(line: number, character: number): { structureType: string | null; controlType: string | null } },
-        isInClassBlock: boolean
+        documentStructure: { getControlContextAt(line: number, character: number): { structureType: string | null; controlType: string | null; controlToken: Token | null } },
+        isInClassBlock: boolean,
+        tokens: Token[]
     ): Hover | null {
         if (!this.attributeService.isAttribute(word)) {
+            return null;
+        }
+
+        // Declaration-label guard (shared with handleBuiltin below — see
+        // AttributeContextGuards.ts): a field/variable being DECLARED with a name
+        // that happens to match an attribute keyword (e.g. a `Create` field inside
+        // a CLASS body) is not an attribute application — inDeclarationContext
+        // below only checks "is this line inside a declaration", not "is this word
+        // the thing being declared", so it doesn't catch this on its own.
+        if (isDeclarationLabel(tokens, position.line, position.character)) {
+            return null;
+        }
+
+        // Dot-suffix / dot-base guards (shared with AttributeDiagnostics — see
+        // AttributeContextGuards.ts): a word that matches an attribute keyword but
+        // is actually one end of a dotted member-access chain (e.g. the `Filter`
+        // in `USE(Filter.Type)`) is a variable/field reference, not an attribute
+        // application — let downstream variable/member-access hover handle it
+        // instead of showing the unrelated builtin attribute's doc card.
+        if (isDotSuffix(line, wordRange.start.character) || isDotBase(line, wordRange.start.character, word.length)) {
             return null;
         }
 
@@ -391,6 +521,21 @@ export class HoverRouter {
         const inDeclarationContext = isInClassBlock || controlContext.structureType !== null || controlContext.controlType !== null;
         if (!inDeclarationContext) {
             return null;
+        }
+
+        // Paren-nesting guard (shared with AttributeDiagnostics): a word matching an
+        // attribute keyword but sitting inside another attribute's argument list
+        // (e.g. a bare `USE(Filter)` with no dotted suffix at all) is the VALUE
+        // passed to that attribute, not a second, standalone attribute application.
+        if (controlContext.controlToken) {
+            const tokenIndex = tokens.findIndex(t =>
+                t.line === position.line &&
+                position.character >= t.start &&
+                position.character <= t.start + t.value.length
+            );
+            if (tokenIndex >= 0 && isNestedInsideAttributeArgs(tokens, tokenIndex, controlContext.controlToken)) {
+                return null;
+            }
         }
 
         logger.info(`Found Clarion attribute: ${word}`);
@@ -435,6 +580,7 @@ export class HoverRouter {
      * Handle language keywords (IF, CASE, PROCEDURE, SELF, NEW, etc.).
      */
     private handleKeyword(word: string): Hover | null {
+        if (HANDLED_BY_SPECIAL_KEYWORDS.has(word.toUpperCase())) return null;
         const entry = this.keywordService.getKeyword(word);
         if (!entry) return null;
         logger.info(`Found language keyword: ${word}`);
@@ -444,8 +590,28 @@ export class HoverRouter {
     /**
      * Handle built-in functions
      */
-    private async handleBuiltin(word: string, line: string, wordRange: any, document: any, position: any, tokens: Token[]): Promise<Hover | null> {
+    private async handleBuiltin(
+        word: string,
+        line: string,
+        wordRange: any,
+        document: any,
+        position: any,
+        tokens: Token[],
+        documentStructure: { getControlContextAt(line: number, character: number): { controlToken: Token | null } }
+    ): Promise<Hover | null> {
         if (!this.builtinService.isBuiltin(word)) {
+            return null;
+        }
+
+        if (HANDLED_BY_SPECIAL_KEYWORDS.has(word.toUpperCase())) return null;
+
+        // Declaration-label guard (shared with handleAttribute above — see
+        // AttributeContextGuards.ts): a variable being DECLARED with a name that
+        // happens to match a builtin function (e.g. `Name LONG`, `Clip STRING(10)`)
+        // is not a call to that builtin. Without this, the "not an actual call"
+        // fallback below had no context check at all and showed the builtin's
+        // bare-constant card for the declaration itself.
+        if (isDeclarationLabel(tokens, position.line, position.character)) {
             return null;
         }
 
@@ -458,6 +624,34 @@ export class HoverRouter {
         if (textBeforeWord.trimEnd().endsWith('.')) {
             logger.info(`Word ${word} is preceded by dot - treating as class method, not built-in`);
             return null;
+        }
+
+        // Dot-base guard (shared with AttributeDiagnostics/handleAttribute — see
+        // AttributeContextGuards.ts): a word matching a builtin function name but
+        // immediately followed by '.' is the BASE of a dotted member-access chain
+        // (e.g. the `Name` in `Name.First`), not a call to the builtin.
+        if (isDotBase(line, wordRange.start.character, word.length)) {
+            logger.info(`Word ${word} is the base of a dotted reference - treating as a variable, not built-in`);
+            return null;
+        }
+
+        // Paren-nesting guard (shared with AttributeDiagnostics/handleAttribute):
+        // a word matching a builtin function name (e.g. NAME, which is both the
+        // NAME attribute AND the NAME(file) builtin) but sitting inside another
+        // attribute's argument list on a control declaration (e.g. `USE(Name)`
+        // with no dotted suffix at all) is the VALUE passed to that attribute,
+        // not a call to the builtin.
+        const controlContext = documentStructure.getControlContextAt(position.line, position.character);
+        if (controlContext.controlToken) {
+            const tokenIndex = tokens.findIndex(t =>
+                t.line === position.line &&
+                position.character >= t.start &&
+                position.character <= t.start + t.value.length
+            );
+            if (tokenIndex >= 0 && isNestedInsideAttributeArgs(tokens, tokenIndex, controlContext.controlToken)) {
+                logger.info(`Word ${word} is nested inside another attribute's argument list - treating as a variable, not built-in`);
+                return null;
+            }
         }
 
         const signatures = this.builtinService.getSignatures(word);

--- a/server/src/providers/hover/SymbolHoverResolver.ts
+++ b/server/src/providers/hover/SymbolHoverResolver.ts
@@ -1,6 +1,7 @@
 import { Hover } from 'vscode-languageserver-protocol';
 import { DataTypeService } from '../../utils/DataTypeService';
 import { ControlService } from '../../utils/ControlService';
+import { HANDLED_BY_SPECIAL_KEYWORDS } from '../../utils/AttributeContextGuards';
 import LoggerManager from '../../logger';
 
 const logger = LoggerManager.getLogger("SymbolHoverResolver");
@@ -70,6 +71,15 @@ export class SymbolHoverResolver {
      * Check if word is a Clarion data type
      */
     private checkDataType(word: string): Hover | null {
+        // MODULE is BOTH a data-type-ish structure keyword AND (outside a MAP
+        // block) a CLASS attribute — HoverRouter.handleSpecialKeywords already
+        // makes the authoritative, context-aware call for it (dotted/nested
+        // reference vs. genuine usage vs. plain unrelated variable). Reaching
+        // here means that call already ran and came back null; matching it
+        // again via the plain data-type lookup would silently overrule it.
+        if (HANDLED_BY_SPECIAL_KEYWORDS.has(word.toUpperCase())) {
+            return null;
+        }
         if (this.dataTypeService.hasDataType(word)) {
             logger.info(`Found Clarion data type: ${word}`);
             const dataType = this.dataTypeService.getDataType(word);

--- a/server/src/test/AttributeCompletionsAndDiagnostics.test.ts
+++ b/server/src/test/AttributeCompletionsAndDiagnostics.test.ts
@@ -792,4 +792,111 @@ suite('validateAttributeApplicability', () => {
                 `Expected no invalid-attribute-context for PROCEDURE parameter name "Type"; got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
         });
     });
+
+    suite('dot-base guard and paren-nesting guard — attribute-keyword-named variable used as another attribute\'s argument', () => {
+        test('no diagnostic for USE(Filter.Item[1]) where Filter is a GROUP variable, not the FILTER attribute', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  CHECK('X'),AT(10,10,50,14),USE(Filter.Item[1])",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.strictEqual(attrDiags.length, 0,
+                `Expected no invalid-attribute-context for USE(Filter.Item[1]); got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+        });
+
+        test('no diagnostic for bare USE(Filter) with no dotted suffix at all', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  CHECK('X'),AT(10,10,50,14),USE(Filter)",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.strictEqual(attrDiags.length, 0,
+                `Expected no invalid-attribute-context for bare USE(Filter); got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+        });
+
+        test('no diagnostic for USE(Filter) on an ENTRY field (same bug family, different control)', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  ENTRY(@s20),AT(10,10,50,10),USE(Filter)",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.strictEqual(attrDiags.length, 0,
+                `Expected no invalid-attribute-context for USE(Filter) on ENTRY; got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+        });
+
+        test('misapplied FILTER attribute (no dotted suffix, not nested in another attribute) still fires on CHECK', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  CHECK('X'),AT(10,10,50,14),FILTER",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.ok(attrDiags.length > 0,
+                'a genuine bare FILTER attribute on CHECK must STILL fire');
+        });
+
+        test('misapplied FILTER attribute still fires on ENTRY (negative sentinel for the ENTRY case)', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  ENTRY(@s20),AT(10,10,50,10),FILTER",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.ok(attrDiags.length > 0,
+                'a genuine bare FILTER attribute on ENTRY must STILL fire');
+        });
+
+        // Clarion's `.` is the END-shorthand terminator as well as the member-access
+        // separator, so `...,FILTER.` closing a structure is NOT `Filter.member`.
+        // An earlier version of the dot-base guard keyed purely on a following `.`
+        // and silently swallowed this genuine warning; member access requires an
+        // identifier after the dot.
+        test('misapplied attribute followed by a period END-terminator still fires', () => {
+            const doc = makeDoc([
+                'MyWin WINDOW',
+                "  CHECK('X'),AT(10,10,50,14),FILTER.",
+                'END',
+            ]);
+            const tokens = tokenize(doc);
+            const diagnostics = validateAttributeApplicability(tokens, doc);
+            const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+            assert.ok(attrDiags.length > 0,
+                'a bare FILTER attribute closed by a period terminator must STILL fire — `.` here is END, not member access');
+        });
+
+        // The guard is keyword-agnostic — it fires on paren-nesting position, not on
+        // which attribute name matched. These cover other VIEW/DATA_TYPE/GROUP-only
+        // keywords (ORDER, NAME, TYPE) that double as plausible field/variable names,
+        // confirming the fix isn't specific to FILTER.
+        test('no diagnostic for other attribute-keyword-shaped variable names used as USE() arguments', () => {
+            const cases: [string, string][] = [
+                ["  ENTRY(@s20),AT(10,10,50,10),USE(Order.CustNo)", 'Order (VIEW-only attr) dotted base on ENTRY'],
+                ["  ENTRY(@s20),AT(10,10,50,10),USE(Order)", 'bare Order on ENTRY'],
+                ["  BUTTON('X'),AT(10,10,50,10),USE(Name.First)", 'Name (DATA_TYPE/FILE_FIELD attr) dotted base on BUTTON'],
+                ["  BUTTON('X'),AT(10,10,50,10),USE(Name)", 'bare Name on BUTTON'],
+                ["  CHECK('X'),AT(10,10,50,10),USE(Type.Code)", 'Type dotted base on CHECK'],
+            ];
+            for (const [line, label] of cases) {
+                const doc = makeDoc(['MyWin WINDOW', line, 'END']);
+                const tokens = tokenize(doc);
+                const diagnostics = validateAttributeApplicability(tokens, doc);
+                const attrDiags = diagnostics.filter(d => d.code === 'invalid-attribute-context');
+                assert.strictEqual(attrDiags.length, 0,
+                    `${label}: expected no invalid-attribute-context; got: ${JSON.stringify(attrDiags.map(d => d.message))}`);
+            }
+        });
+    });
 });

--- a/server/src/test/HoverProvider.AttributeDotAccess.test.ts
+++ b/server/src/test/HoverProvider.AttributeDotAccess.test.ts
@@ -1,0 +1,465 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+// Companion to AttributeDiagnostics' dot-base / paren-nesting guards: hovering
+// an identifier that happens to match a Clarion attribute keyword (FILTER,
+// ORDER, NAME, TYPE, ...) must not show that attribute's doc card when the
+// identifier is really a variable/field reference dotted or nested inside
+// another attribute's argument list, e.g. the `Filter` in `USE(Filter.Type)`
+// or a bare `USE(Filter)`.
+suite('HoverProvider — attribute keyword vs. dotted/nested variable reference', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('does not show the FILTER attribute card for USE(Filter.Type) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Filter.Type)
+END`;
+        const doc = TextDocument.create('test://filter-dotted.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Filter"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('Attribute: FILTER'),
+            `Should not show the builtin FILTER attribute card; got: ${content}`);
+    });
+
+    test('does not show the FILTER attribute card for a bare USE(Filter) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Filter)
+END`;
+        const doc = TextDocument.create('test://filter-bare-nested.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Filter"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('Attribute: FILTER'),
+            `Should not show the builtin FILTER attribute card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine bare FILTER attribute (not dotted, not nested) still shows its doc card', async () => {
+        // handleAttribute only checks "is this a known attribute inside SOME
+        // declaration context", not applicability to the specific control (that's
+        // AttributeDiagnostics' job) — so any control declaration works here, as
+        // long as FILTER is a bare, top-level, comma-separated attribute.
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),FILTER
+END`;
+        const doc = TextDocument.create('test://filter-genuine.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 32)); // inside "FILTER"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Attribute: FILTER'),
+            `A genuine bare FILTER attribute must still show its doc card; got: ${content}`);
+    });
+
+    // NAME is a third occurrence of the same collision, but through a DIFFERENT
+    // resolver: it's both the NAME attribute (DATA_TYPE/FILE_FIELD) AND the
+    // NAME(file) builtin function. handleAttribute correctly steps aside for
+    // USE(Name), but handleBuiltin — next in the router chain — picked it up
+    // right after with none of the same guards.
+    test('does not show the builtin NAME() card for a bare USE(Name) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Name)
+END`;
+        const doc = TextDocument.create('test://name-bare-nested.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Name"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('Attribute: NAME'),
+            `Should not show the NAME attribute card; got: ${content}`);
+        assert.ok(!content.toUpperCase().includes('RETURNS THE FILENAME'),
+            `Should not show the builtin NAME() function card; got: ${content}`);
+    });
+
+    test('does not show the builtin NAME() card for USE(Name.First) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Name.First)
+END`;
+        const doc = TextDocument.create('test://name-dotted.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Name"
+        const content = hoverText(hover);
+        assert.ok(!content.toUpperCase().includes('RETURNS THE FILENAME'),
+            `Should not show the builtin NAME() function card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine NAME(file) call still shows the builtin doc card', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  MESSAGE(NAME(SomeFile))`;
+        const doc = TextDocument.create('test://name-genuine-builtin.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 12)); // inside "NAME("
+        const content = hoverText(hover);
+        assert.ok(content.toUpperCase().includes('RETURNS THE FILENAME'),
+            `A genuine NAME(file) call must still show the builtin doc card; got: ${content}`);
+    });
+});
+
+// HIDE, DISABLE, TYPE, and MODULE are a FOURTH occurrence, through a THIRD
+// resolver: HoverRouter.handleSpecialKeywords runs at step 1 — before routine,
+// procedure, and variable resolution even start — and originally decided
+// attribute-vs-builtin (or keyword-vs-attribute for MODULE) using only a single
+// coarse boolean (isInWindowContext / isInMapBlock), with no dot-base,
+// paren-nesting, or declaration-context awareness at all. That made these four
+// words misfire far more broadly than FILTER/NAME: even a PLAIN, undotted,
+// unnested local variable named Type/Hide/Disable, anywhere outside (or, for
+// TYPE, inside) a WINDOW/REPORT, always showed the wrong card.
+suite('HoverProvider — HIDE/DISABLE/TYPE/MODULE special-keyword collisions', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('a plain local variable named Type shows its own hover, not the TYPE attribute', async () => {
+        const code = `MyProc PROCEDURE()
+Type LONG
+CODE
+  x = Type`;
+        const doc = TextDocument.create('test://type-plain-var.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(3, 6)); // inside "Type"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Attribute)') && !content.includes('(Procedure)'),
+            `Should show the local variable, not an attribute/builtin card; got: ${content}`);
+        assert.ok(content.includes('Local procedure variable'),
+            `Should resolve as the local variable; got: ${content}`);
+    });
+
+    test('a plain local variable named Hide shows its own hover, not the HIDE builtin', async () => {
+        const code = `MyProc PROCEDURE()
+Hide LONG
+CODE
+  x = Hide`;
+        const doc = TextDocument.create('test://hide-plain-var.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(3, 6)); // inside "Hide"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Local procedure variable'),
+            `Should resolve as the local variable; got: ${content}`);
+    });
+
+    test('a plain local variable named Disable shows its own hover, not the DISABLE builtin', async () => {
+        const code = `MyProc PROCEDURE()
+Disable LONG
+CODE
+  x = Disable`;
+        const doc = TextDocument.create('test://disable-plain-var.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(3, 6)); // inside "Disable"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Local procedure variable'),
+            `Should resolve as the local variable; got: ${content}`);
+    });
+
+    test('does not show the HIDE attribute card for USE(Hide.Something) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Hide.Something)
+END`;
+        const doc = TextDocument.create('test://hide-dotted.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Hide"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Attribute)'),
+            `Should not show the HIDE attribute card; got: ${content}`);
+    });
+
+    test('does not show the DISABLE attribute card for USE(Disable.Something) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Disable.Something)
+END`;
+        const doc = TextDocument.create('test://disable-dotted.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Disable"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Attribute)'),
+            `Should not show the DISABLE attribute card; got: ${content}`);
+    });
+
+    test('does not show the TYPE builtin card for a bare USE(Type) on an ENTRY', async () => {
+        const code = `MyWin WINDOW
+  ENTRY(@s10),AT(10,10,50,10),USE(Type)
+END`;
+        const doc = TextDocument.create('test://type-bare-nested.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 36)); // inside "Type"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Procedure)') && !content.includes('(Attribute)'),
+            `Should not show either the TYPE attribute or builtin card; got: ${content}`);
+    });
+
+    test('does not show the MODULE attribute card for a dotted Module.Something reference outside a MAP block', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  x = Module.Something`;
+        const doc = TextDocument.create('test://module-dotted.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 6)); // inside "Module"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Attribute)'),
+            `Should not show the MODULE attribute card; got: ${content}`);
+    });
+
+    test('does not show the MODULE attribute card for Module used as a plain call argument outside a MAP block', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  SomeCall(Module)`;
+        const doc = TextDocument.create('test://module-bare-nested.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 12)); // inside "Module"
+        const content = hoverText(hover);
+        assert.ok(!content.includes('(Attribute)'),
+            `Should not show the MODULE attribute card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine bare HIDE attribute on a control still shows its doc card', async () => {
+        const code = `MyWin WINDOW
+  BUTTON('X'),AT(10,10,50,10),HIDE
+END`;
+        const doc = TextDocument.create('test://hide-genuine-attr.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 32)); // inside "HIDE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('HIDE') && content.includes('(Attribute)'),
+            `A genuine bare HIDE attribute must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine HIDE(?Control) builtin call still shows its doc card', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  HIDE(?List)`;
+        const doc = TextDocument.create('test://hide-genuine-call.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 4)); // inside "HIDE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('HIDE') && content.includes('(Procedure)'),
+            `A genuine HIDE(...) builtin call must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine bare TYPE attribute on GROUP,TYPE still shows its doc card', async () => {
+        const code = `MyGroup GROUP,TYPE
+Field1 LONG
+       END`;
+        const doc = TextDocument.create('test://type-genuine-attr.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(0, 15)); // inside "TYPE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('TYPE') && content.includes('(Attribute)'),
+            `A genuine bare TYPE attribute on GROUP,TYPE must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine TYPE(string) builtin call inside a REPORT still shows its doc card', async () => {
+        const code = `MyRep REPORT
+  DETAIL
+    STRING(TYPE('x'))
+  END
+END`;
+        const doc = TextDocument.create('test://type-genuine-call.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 12)); // inside "TYPE("
+        const content = hoverText(hover);
+        assert.ok(content.includes('TYPE') && content.includes('(Procedure)'),
+            `A genuine TYPE(string) builtin call must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine MODULE attribute on a CLASS declaration line still shows its doc card', async () => {
+        const code = `MyClass CLASS,MODULE('MyClass.clw')
+END`;
+        const doc = TextDocument.create('test://module-genuine-attr.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(0, 16)); // inside "MODULE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('MODULE') && content.includes('(Attribute)'),
+            `A genuine MODULE attribute on a CLASS line must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — an attribute closed by a period END-terminator keeps its doc card', async () => {
+        // `.` is Clarion's END shorthand as well as the member-access separator, so
+        // `...,HIDE.` is a bare attribute closing the WINDOW, NOT `Hide.member`.
+        const code = `MyWin WINDOW
+  BUTTON('X'),AT(10,10,50,10),HIDE.`;
+        const doc = TextDocument.create('test://hide-period-terminator.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 32)); // inside "HIDE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('HIDE') && content.includes('(Attribute)'),
+            `A bare HIDE attribute closed by a period terminator must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine MODULE keyword inside a MAP block still shows its doc card', async () => {
+        const code = `MyMap MAP
+  MODULE('somefile.clw')
+    ExternalProc PROCEDURE()
+  END
+END`;
+        const doc = TextDocument.create('test://module-genuine-keyword.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 4)); // inside "MODULE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('MODULE') && content.includes('(Keyword)'),
+            `A genuine MODULE keyword inside a MAP block must still show its doc card; got: ${content}`);
+    });
+});
+
+// A field/variable's own DECLARATION label is a fifth, more fundamental
+// occurrence of this bug class: `handleAttribute`'s declaration-context check
+// asks "is this line inside a GROUP/QUEUE/CLASS/control declaration", never
+// "is this word the thing being declared" — so a genuine field named e.g.
+// `Create` inside a CLASS body showed the CREATE attribute's card instead of
+// its own declaration. `handleBuiltin`'s bare-constant fallback had no
+// declaration check at all, so ANY declaration anywhere (`Name LONG` in a
+// procedure's DATA section) showed the builtin's card. Reported live via
+// `USE(Name)` now hovering correctly, but the separate `Name LONG` DECLARATION
+// two lines above still showing the wrong card.
+suite('HoverProvider — declaration label vs. attribute/builtin collision', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('a local variable declared "Name LONG" hovers as the variable, not the NAME builtin', async () => {
+        const code = `MyProc PROCEDURE()
+Name LONG
+CODE
+  x = 1`;
+        const doc = TextDocument.create('test://name-declaration.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 2)); // inside "Name"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Local procedure variable'),
+            `Should resolve the declaration as the local variable; got: ${content}`);
+        assert.ok(!content.toUpperCase().includes('RETURNS THE FILENAME'),
+            `Should not show the NAME builtin's card; got: ${content}`);
+    });
+
+    test('a local variable declared "Clip LONG" hovers as the variable, not the CLIP builtin', async () => {
+        const code = `MyProc PROCEDURE()
+Clip LONG
+CODE
+  x = 1`;
+        const doc = TextDocument.create('test://clip-declaration.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 2)); // inside "Clip"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Local procedure variable'),
+            `Should resolve the declaration as the local variable; got: ${content}`);
+    });
+
+    test('a CLASS property declared "Create LONG" hovers as the property, not the CREATE attribute', async () => {
+        // This is the deeper case: the declaration line genuinely IS inside a
+        // declaration context (a CLASS body), so handleAttribute's
+        // inDeclarationContext check alone can't tell this apart from a real
+        // CREATE attribute application — only checking whether Create is the
+        // token BEING DECLARED (not applied) can.
+        const code = `MyClass CLASS
+Create LONG
+       END`;
+        const doc = TextDocument.create('test://create-class-property.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 2)); // inside "Create"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Class property'),
+            `Should resolve as the class property, not the attribute; got: ${content}`);
+        assert.ok(!content.includes('Attribute: CREATE'),
+            `Should not show the CREATE attribute card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine bare CREATE attribute (not a declaration) still shows its doc card', async () => {
+        const code = `MyWin WINDOW
+  OLECtrl OLE,AT(0,0,100,100),CREATE
+END`;
+        const doc = TextDocument.create('test://create-genuine-attr.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(1, 32)); // inside "CREATE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Attribute: CREATE'),
+            `A genuine bare CREATE attribute must still show its doc card; got: ${content}`);
+    });
+
+    test('negative sentinel — a genuine CREATE(file) builtin call (not a declaration) still shows its doc card', async () => {
+        const code = `MyProc PROCEDURE()
+CODE
+  CREATE(MyFile)`;
+        const doc = TextDocument.create('test://create-genuine-call.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(2, 4)); // inside "CREATE"
+        const content = hoverText(hover);
+        assert.ok(content.includes('Built-in Function: CREATE'),
+            `A genuine CREATE(...) builtin call must still show its doc card; got: ${content}`);
+    });
+});

--- a/server/src/utils/AttributeContextGuards.ts
+++ b/server/src/utils/AttributeContextGuards.ts
@@ -1,0 +1,118 @@
+import { Token, TokenType } from '../ClarionTokenizer';
+
+/**
+ * Shared guards for distinguishing a genuine Clarion attribute application
+ * (e.g. the `FILTER` in a VIEW declaration) from an unrelated variable/field
+ * whose name happens to match an attribute keyword (e.g. the `Filter` GROUP in
+ * `USE(Filter.Type)`). Used by both AttributeDiagnostics (should this fire a
+ * warning?) and HoverRouter (should this show the attribute's doc card?) so the
+ * two providers can't drift into disagreeing about the same token.
+ */
+
+/**
+ * True when the token at `tokenStart` is the SUFFIX of a dotted member-access
+ * chain, e.g. the `Type` in `SELF.Sectors.Type`. In this position it's an
+ * identifier being accessed, not a Clarion attribute application.
+ */
+export function isDotSuffix(lineText: string, tokenStart: number): boolean {
+    return tokenStart > 0 && lineText[tokenStart - 1] === '.';
+}
+
+/**
+ * True when the token at `tokenStart` is the BASE of a dotted member-access
+ * chain, e.g. the `Filter` in `Filter.Contact[1]`. Clarion attributes are never
+ * themselves written as `KEYWORD.member`, so a following `.` means this token is
+ * a variable/field reference, not an attribute application.
+ *
+ * The `.` must be followed by an identifier character to count. In Clarion `.`
+ * is ALSO the END-shorthand terminator (`BUTTON('OK'),AT(1,1),USE(?Ok).` closes
+ * the enclosing structure), and a bare terminator directly after an attribute
+ * is NOT member access — treating it as such silently suppressed a genuine
+ * diagnostic/hover on the last attribute of a period-terminated declaration.
+ */
+export function isDotBase(lineText: string, tokenStart: number, tokenLength: number): boolean {
+    const dotIndex = tokenStart + tokenLength;
+    if (lineText[dotIndex] !== '.') return false;
+    const afterDot = lineText[dotIndex + 1];
+    return afterDot !== undefined && /[A-Za-z_]/.test(afterDot);
+}
+
+const MAX_PAREN_WALK_STEPS = 500;
+
+/**
+ * True when the token at `tokenIndex` sits inside the argument parentheses of a
+ * PRECEDING attribute in the same control/structure declaration (e.g. the
+ * `Filter` in `USE(Filter)`, with no dotted suffix at all), rather than being a
+ * top-level, comma-separated attribute of the control itself.
+ *
+ * Walks backward from `tokenIndex` counting parens: a `)` opens a nested pair
+ * (depth++), a matching `(` closes it (depth--); an unmatched `(` (encountered
+ * while depth is 0) means the token lives inside that paren's argument list.
+ * The walk stops as soon as it reaches `anchorToken` (identified by line+start,
+ * since it is not necessarily the same array/object instance as `tokens`) —
+ * everything between the anchor and the target token is that declaration's own
+ * attribute list, so nothing outside this span needs to be considered.
+ *
+ * Bounded to MAX_PAREN_WALK_STEPS as a defensive fallback: if `anchorToken` is
+ * never found (e.g. an unexpected token-stream shape), fail safe by returning
+ * false (not nested) so callers fall back to their pre-existing behavior rather
+ * than silently suppressing a real warning or a real attribute hover.
+ */
+export function isNestedInsideAttributeArgs(tokens: Token[], tokenIndex: number, anchorToken: Token): boolean {
+    let depth = 0;
+    let steps = 0;
+    for (let j = tokenIndex - 1; j >= 0 && steps < MAX_PAREN_WALK_STEPS; j--, steps++) {
+        const t = tokens[j];
+        if (t.line === anchorToken.line && t.start === anchorToken.start && t.value === anchorToken.value) {
+            return false; // reached the anchor keyword itself — nothing left to be nested in
+        }
+        if (t.value === ')') {
+            depth++;
+        } else if (t.value === '(') {
+            if (depth === 0) return true; // unmatched '(' before the anchor → nested
+            depth--;
+        }
+    }
+    return false;
+}
+
+/**
+ * True when the token at this line/character position is itself the LABEL of
+ * its own declaration — e.g. the `Name` in `Name LONG`, or the `Create` field
+ * declared inside a CLASS body — rather than a reference to something else.
+ *
+ * A declaration label can never legitimately BE an attribute application or a
+ * builtin function call: those are things a name is used WITH, not something
+ * a name-being-declared can itself be. So this holds regardless of which
+ * attribute/builtin/keyword the label's text happens to collide with, and
+ * regardless of dotting/nesting/declaration-context — unlike the other guards
+ * here, it needs no case-by-case reasoning about surrounding syntax.
+ *
+ * Without this, `handleAttribute`'s declaration-context check (which asks "is
+ * this line inside a GROUP/QUEUE/CLASS/control declaration", not "is this
+ * word the thing being declared") let a genuine field named e.g. `Create`
+ * inside a CLASS body show the CREATE attribute's card instead of its own
+ * declaration; `handleBuiltin`'s bare-constant fallback had no context check
+ * at all and did the same for any declaration anywhere, e.g. `Name LONG`.
+ */
+export function isDeclarationLabel(tokens: Token[], line: number, character: number): boolean {
+    const token = tokens.find(t =>
+        t.line === line &&
+        character >= t.start &&
+        character <= t.start + t.value.length);
+    return token?.type === TokenType.Label;
+}
+
+/**
+ * Words fully owned by HoverRouter.handleSpecialKeywords' MODULE/HIDE/DISABLE/
+ * TYPE branches (each is BOTH an attribute/keyword/data-type AND a builtin).
+ * Those branches make the authoritative call for every case: genuine
+ * attribute usage, genuine builtin call, AND "neither, fall through to
+ * variable resolution". Every OTHER hover resolver that might also
+ * independently recognize one of these names by coincidence (handleKeyword,
+ * handleBuiltin, SymbolHoverResolver's data-type lookup, ...) must defer to
+ * that decision — checking this set and returning null keeps a downstream
+ * resolver from silently overruling it and reintroducing the same false
+ * positive one step later.
+ */
+export const HANDLED_BY_SPECIAL_KEYWORDS = new Set(['MODULE', 'HIDE', 'DISABLE', 'TYPE']);


### PR DESCRIPTION
## What happened

A Clarion attribute keyword that also happens to be a real variable or field name gets
misclassified as the attribute application instead of the variable — in several distinct places,
found by following one false positive through the codebase.

Repro (see `AttributeCompletionsAndDiagnostics.test.ts` / `HoverProvider.AttributeDotAccess.test.ts`
for the exact cases):

- **Diagnostics:** a control declaring `USE(Filter.Item[1])`, where `Filter` is a GROUP variable,
  falsely warns `'Filter' is not applicable to CHECK (valid for: VIEW)`. Same for a bare
  `USE(Filter)` with no dotted suffix at all.
- **Hover, same false positive:** hovering `Filter` in `USE(Filter.Type)` shows the FILTER
  attribute's doc card instead of the variable.
- **Hover, HIDE/DISABLE/TYPE/MODULE specifically:** these four are intercepted by a hardcoded
  special-case branch that runs before ANY other resolution, using only a single coarse boolean
  (is the cursor inside a WINDOW/REPORT, or inside a MAP block), with no dot/paren/declaration-context
  awareness at all. A plain, undotted, unnested local variable named e.g. `Type` shows the TYPE
  attribute's card everywhere outside a WINDOW/REPORT — not just in the `USE(...)` edge case.
- **Hover, declaration sites specifically:** a field or variable's own DECLARATION (not a reference
  to it) with a name matching an attribute or builtin shows the attribute/builtin's card instead of
  its own declaration — `Name LONG` hovers as the NAME builtin's "Built-in constant" card; a field
  named `Create` genuinely declared inside a CLASS body shows the CREATE attribute's card instead of
  the property it actually is.

## Root cause

The tokenizer classifies any identifier whose text matches a known attribute keyword as an
`Attribute` token, purely by name, with no awareness of surrounding syntax — a dotted member-access
chain (`Filter.Type`), sitting inside another attribute's argument parentheses (`USE(Filter)`), or
being the LABEL of the declaration itself, rather than an application of the keyword. Several
resolvers independently do their own "is this word a known X" check with no shared guard, so the
same false positive recurs across `AttributeDiagnostics`, `HoverRouter.handleAttribute`,
`HoverRouter.handleBuiltin`, `HoverRouter.handleSpecialKeywords`, and `SymbolHoverResolver`.

## Fix

- New `server/src/utils/AttributeContextGuards.ts`: `isDotSuffix`, `isDotBase`,
  `isNestedInsideAttributeArgs`, `isDeclarationLabel` — shared by `AttributeDiagnostics` and
  `HoverRouter` so the two can't drift apart on the same token. `isDotBase` requires an identifier
  character after the `.`, not just the `.` itself — Clarion's `.` is also the END-shorthand
  terminator (`...,FILTER.` closes the enclosing structure), and treating any trailing `.` as member
  access silently swallowed a genuine warning/hover on a period-terminated declaration.
- `isNestedInsideAttributeArgs` walks backward from the token counting parens until it hits the
  control keyword; an unmatched `(` means the token is a VALUE passed to a preceding attribute like
  `USE(...)`, not a second attribute application. Refined so a legitimate NESTED CALL
  (`STRING(TYPE('x'))`) isn't confused with a nested VALUE (`USE(Filter)`).
- `HoverRouter.handleSpecialKeywords`'s four branches now require either an actual call
  (`TYPE('x')` vs. bare `Type`) or a genuine declaration context (the relevant structure keyword
  actually present on the line) before claiming the word.
- New `HANDLED_BY_SPECIAL_KEYWORDS` set lets `handleKeyword`, `handleBuiltin`, and
  `SymbolHoverResolver.checkDataType` defer to `handleSpecialKeywords`' authoritative decision
  instead of re-claiming the word independently one step later.
- `isDeclarationLabel` — a token whose type is `Label` can never legitimately be an attribute/builtin
  application, since it's the thing being declared, not something being applied to it. Unconditional
  guard, no case-by-case reasoning needed (unlike the others above).
- Fixed a separate, pre-existing bug exposed by closing the `SymbolHoverResolver` leak:
  `ContextualHoverHandler.handleModuleKeyword`'s MAP-block branch looked up `MODULE` in
  `BuiltinFunctionService` (which has no `MODULE` entry at all — it's a `clarion-keywords.json`
  entry) instead of `KeywordService`, so it always returned `null` for genuine `MODULE(...)` usage
  inside a MAP.

## Testing

New tests in `AttributeCompletionsAndDiagnostics.test.ts` (dot-base, paren-nesting, period-terminator
regression, genericity across other attribute names that collide with builtins) and
`HoverProvider.AttributeDotAccess.test.ts` (hover equivalents, plus the HIDE/DISABLE/TYPE/MODULE and
declaration-label cases, with negative sentinels confirming genuine attribute/builtin/keyword usage
still works).

`npx tsc -b`: clean. `npm run test:server`: 2451 passing, 4 pending (pre-existing), 0 failing.

## Scope

Seven files: `AttributeDiagnostics.ts`, `HoverRouter.ts`, `SymbolHoverResolver.ts`,
`ContextualHoverHandler.ts`, `AttributeContextGuards.ts` (new), plus the two test files. Unrelated to
any in-flight feature work.
