### PR TITLE
refactor(document-symbols): drop the redundant "in <Parent>" symbol d…

### DIFF
--- a/server/src/providers/ClarionDocumentSymbolProvider.ts
+++ b/server/src/providers/ClarionDocumentSymbolProvider.ts
@@ -2032,15 +2032,18 @@ export class ClarionDocumentSymbolProvider {
                 logger.info(`   ℹ️ No explicit type found, defaulting to STRING`);
             }
             
-            // Create proper detail with parent context
+            // #418: no parent context in the detail. The outline/structure tree already shows the
+            // parent through hierarchy, and the breadcrumb dropdown only ever lists the siblings of
+            // one already-visible parent, so "in <Parent>" repeated what was on screen either way.
+            // Commented rather than deleted for one release.
             let detail = "";
-            if (currentProcedure) {
-                detail = `in ${currentProcedure.name}`;
-            } else if (lastMethodImplementation) {
-                detail = `in ${lastMethodImplementation.name}`;
-            } else if (currentStructure) {
-                detail = `in ${currentStructure.name}`;
-            }
+            // if (currentProcedure) {
+            //     detail = `in ${currentProcedure.name}`;
+            // } else if (lastMethodImplementation) {
+            //     detail = `in ${lastMethodImplementation.name}`;
+            // } else if (currentStructure) {
+            //     detail = `in ${currentStructure.name}`;
+            // }
 
             // Create the symbol name with variable name and type
             const symbolName = `${variableName} ${fullType}`;
@@ -2216,12 +2219,14 @@ export class ClarionDocumentSymbolProvider {
                 }
             }
 
-            // CRITICAL FIX: Update the variable's detail to match its actual parent
-            // This ensures variables inside GROUPs show "in GROUP(...)" instead of "in Method(...)"
+            // #418: this used to correct the detail to the variable's real parent, so a field of a
+            // GROUP read "in GROUP(...)" instead of "in Method(...)". With the parent context gone
+            // there is nothing to correct — the tree itself shows which structure a field sits in.
+            // The target trace is the useful half of the block and stays.
             if (target) {
                 logger.info(`   🔍 DEBUG: target type=${target.kind}, target.name="${target.name}"`);
-                variableSymbol.detail = `in ${target.name}`;
-                logger.info(`   ✅ Updated variable detail to match target: "${variableSymbol.detail}"`);
+                // variableSymbol.detail = `in ${target.name}`;
+                // logger.info(`   ✅ Updated variable detail to match target: "${variableSymbol.detail}"`);
             }
             
             this.addSymbolToParent(variableSymbol, target, symbols);
@@ -2371,20 +2376,26 @@ export class ClarionDocumentSymbolProvider {
 
         symbol.sortText = sortName.toLowerCase();
 
-        // Enhance breadcrumb navigation by improving symbol details
-        if (!symbol.detail && parent) {
-            // Add context information to the detail for better breadcrumb navigation
-            if (isMethod || isMethodDeclaration) {
-                if (!symbol.detail) {
-                    symbol.detail = `in ${parent.name}`;
-                }
-            } else if (isVariable) {
-                // For variables, add the parent context if not already present
-                if (!symbol.detail && parent.name) {
-                    symbol.detail = `in ${parent.name}`;
-                }
-            }
-        }
+        // #418: the last-resort parent context, for symbols that reached here with no detail of
+        // their own. The method branch could never fire — createProcedureSymbol always sets one of
+        // "Method Implementation" / "Global Procedure" / describeSubType(), and describeSubType()
+        // has a "Procedure" default, so a Function/Method symbol is never detail-less here. The
+        // variable branch was reachable, but only for a WINDOW control mapped to SymbolKind.Variable
+        // with no USE() to describe it (ENTRY) — which the tree also already places under its
+        // WINDOW. Commented rather than deleted for one release.
+        // if (!symbol.detail && parent) {
+        //     // Add context information to the detail for better breadcrumb navigation
+        //     if (isMethod || isMethodDeclaration) {
+        //         if (!symbol.detail) {
+        //             symbol.detail = `in ${parent.name}`;
+        //         }
+        //     } else if (isVariable) {
+        //         // For variables, add the parent context if not already present
+        //         if (!symbol.detail && parent.name) {
+        //             symbol.detail = `in ${parent.name}`;
+        //         }
+        //     }
+        // }
 
         if (parent) {
             // CRITICAL FIX: Check if parent is a method implementation

--- a/server/src/test/SymbolDetailParentContext.test.ts
+++ b/server/src/test/SymbolDetailParentContext.test.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import { ClarionTokenizer } from '../ClarionTokenizer';
+import { ClarionDocumentSymbolProvider, ClarionDocumentSymbol } from '../providers/ClarionDocumentSymbolProvider';
+import { setServerInitialized } from '../serverState';
+
+/**
+ * #418 — document symbols no longer carry the redundant "in <Parent>" detail.
+ *
+ * The detail was set at three sites in ClarionDocumentSymbolProvider: on every variable as it was
+ * created, again once its real parent was known, and as a last resort in addSymbolToParent() for a
+ * symbol that arrived with no detail of its own. The tree, the breadcrumb dropdown and
+ * WorkspaceSymbolProvider (which derives its own containerName from the parent's name) all already
+ * carry the parent, so the text only ever repeated what was on screen.
+ *
+ * What must NOT change: the details that mean something — "Method Implementation",
+ * "Global Procedure", describeSubType() — and the method-detection path in addSymbolToParent(),
+ * which reads symbol.detail?.includes("Method") to route methods into the Methods container.
+ */
+suite('#418 - redundant "in <Parent>" symbol detail', () => {
+
+    setup(() => {
+        setServerInitialized(true);
+    });
+
+    const code = `
+MyClass       CLASS,TYPE
+Counter         LONG
+Init            PROCEDURE(LONG pId)
+Kill            PROCEDURE
+              END
+
+MyClass.Init  PROCEDURE(LONG pId)
+LocalCount      LONG
+Settings        GROUP,PRE(SET)
+Timeout           LONG
+              END
+Win             WINDOW('Test'),AT(,,200,100)
+                  ENTRY(@s20),AT(10,10,80,10)
+                END
+  CODE
+  SELF.Counter = pId
+
+MyClass.Kill  PROCEDURE
+  CODE
+  RETURN
+
+MyGlobalProc  PROCEDURE()
+GlobalLocal     STRING(20)
+  CODE
+  RETURN
+    `.trim();
+
+    function buildSymbols(): ClarionDocumentSymbol[] {
+        const tokens = new ClarionTokenizer(code).tokenize();
+        return new ClarionDocumentSymbolProvider().provideDocumentSymbols(tokens, 'test://in-parent.clw');
+    }
+
+    /** Every symbol in the tree, flattened, each paired with the path that reaches it. */
+    function flatten(symbols: ClarionDocumentSymbol[], path: string = ''): Array<{ symbol: ClarionDocumentSymbol, path: string }> {
+        const all: Array<{ symbol: ClarionDocumentSymbol, path: string }> = [];
+        for (const symbol of symbols) {
+            const here = path ? `${path} > ${symbol.name}` : symbol.name;
+            all.push({ symbol, path: here });
+            if (symbol.children && symbol.children.length > 0) {
+                all.push(...flatten(symbol.children as ClarionDocumentSymbol[], here));
+            }
+        }
+        return all;
+    }
+
+    function find(symbols: ClarionDocumentSymbol[], name: string): ClarionDocumentSymbol | undefined {
+        return flatten(symbols).find(entry => entry.symbol.name === name || entry.symbol.name.startsWith(`${name} `))?.symbol;
+    }
+
+    test('no symbol anywhere in the tree carries an "in <Parent>" detail', () => {
+        const offenders = flatten(buildSymbols())
+            .filter(entry => /^in\s/i.test(entry.symbol.detail ?? ''))
+            .map(entry => `${entry.path} → detail="${entry.symbol.detail}"`);
+
+        assert.deepStrictEqual(offenders, [],
+            `No symbol should carry parent context in its detail, but found:\n  ${offenders.join('\n  ')}`);
+    });
+
+    test('a USE-less WINDOW control carries no detail either (the addSymbolToParent fallback)', () => {
+        // ENTRY maps to SymbolKind.Variable and USE() is optional, so this was the one symbol that
+        // actually reached the addSymbolToParent() fallback with an empty detail.
+        const entry = find(buildSymbols(), 'ENTRY(@s20)');
+
+        assert.ok(entry, 'Should find the USE-less ENTRY control');
+        assert.strictEqual(entry.detail ?? '', '', `USE-less ENTRY should have no detail, got "${entry.detail}"`);
+    });
+
+    test('variables keep the type information consumers actually read', () => {
+        // HoverProvider and SymbolFinderService read `_clarionType || detail` — dropping the detail
+        // must not touch the first half of that, or a variable's hover loses its type.
+        const localCount = find(buildSymbols(), 'LocalCount');
+
+        assert.ok(localCount, 'Should find LocalCount');
+        assert.strictEqual(localCount.detail ?? '', '', `LocalCount should have no detail, got "${localCount.detail}"`);
+        assert.strictEqual((localCount as any)._clarionType?.toUpperCase(), 'LONG',
+            `LocalCount should still know its type, got "${(localCount as any)._clarionType}"`);
+    });
+
+    test('the details that mean something are untouched', () => {
+        const symbols = buildSymbols();
+
+        const init = find(symbols, 'MyClass.Init');
+        assert.ok(init, 'Should find the MyClass.Init implementation');
+        assert.strictEqual(init.detail, 'Method Implementation',
+            `MyClass.Init should still read "Method Implementation", got "${init.detail}"`);
+
+        const globalProc = find(symbols, 'MyGlobalProc');
+        assert.ok(globalProc, 'Should find MyGlobalProc');
+        assert.strictEqual(globalProc.detail, 'Global Procedure',
+            `MyGlobalProc should still read "Global Procedure", got "${globalProc.detail}"`);
+    });
+
+    test('method detection still routes declarations under their class', () => {
+        // addSymbolToParent() classifies with symbol.detail?.includes("Method") — the one reader of
+        // `detail` that drives structure rather than display. It keys off "Method Implementation"
+        // and describeSubType()'s "Method (...)", never off the parent context, so the routing has
+        // to survive: both declarations stay under the CLASS, and the implementation's own locals
+        // stay under the implementation.
+        const paths = flatten(buildSymbols()).map(entry => entry.path);
+
+        assert.ok(paths.some(p => /^CLASS \(MyClass\) > Init$/.test(p)),
+            `Init should still be routed under the CLASS, tree was:\n  ${paths.join('\n  ')}`);
+        assert.ok(paths.some(p => /^CLASS \(MyClass\) > Kill$/.test(p)),
+            `Kill should still be routed under the CLASS, tree was:\n  ${paths.join('\n  ')}`);
+        assert.ok(paths.some(p => /^MyClass\.Init .* > LocalCount LONG$/.test(p)),
+            `LocalCount should still hang off the method implementation, tree was:\n  ${paths.join('\n  ')}`);
+    });
+
+    test('method declarations keep their signature as detail', () => {
+        const init = flatten(buildSymbols()).find(entry => entry.path === 'CLASS (MyClass) > Init')?.symbol;
+
+        assert.ok(init, 'Should find the Init declaration under the CLASS');
+        assert.ok((init.detail ?? '').includes('LONG pId'),
+            `Init's declaration detail should still be its signature, got "${init.detail}"`);
+    });
+});


### PR DESCRIPTION
# fix(document-symbols): drop the redundant "in <Parent>" symbol detail (#418)

Closes #418.

## What

Comments out (not deletes, per your ask) the three sites in `ClarionDocumentSymbolProvider.ts`
that wrote `in <Parent>` into a symbol's `detail`:

- the variable's initial detail (as it's created)
- the parent-matching correction once its real target is known
- the last-resort fill in `addSymbolToParent()`

Left untouched: `Method Implementation`, `Global Procedure`, `describeSubType()`, and the
method-detection path (`addSymbolToParent`'s `symbol.detail?.includes("Method")`) that routes
methods into their container.

Targets `version-1.0.2` (#382 already landed there).

## Test

New `server/src/test/SymbolDetailParentContext.test.ts`, 6 tests — pins that no symbol carries an
`in <Parent>` detail, that the meaningful details and method-routing are untouched, and that a
variable's type (read via `_clarionType || detail` in `HoverProvider`/`SymbolFinderService`) still
comes through.

Full suite: 2424 passing / 0 failing / 4 pending (was 2418 / 0 / 4 before). Confirmed non-vacuous
by stashing the provider change — the three behavior tests fail against unmodified
`version-1.0.2`.

Locally verified in the Clarion IDE (Document Structure outline): rows are clean, no `in <Proc>`
suffix.

## One thing found while checking the risk claim

`symbol.detail` has one more in-repo reader beyond the `addSymbolToParent` one you named:
`client/src/views/StructureViewProvider.ts`'s `symbolOrDescendantsMatch` (~L1171) matches the
Structure View's filter box against `detail` as well as `name`, and computes each node's
visibility independently. Today, filtering that view on a procedure's name keeps its variables
visible too, via their `in <Proc>` detail. After this change the procedure still matches by name,
but its own variables no longer match on their own and get hidden unless they match by name
directly.

Client-side only, filter-only, and arguably fine (arguably even correct — showing an unrelated
variable just because its *procedure* name matched isn't obviously right either) — flagging it
since it's a real behavior change, not purely display, and wasn't in the original risk
assessment.

Also for the record: `HoverProvider.ts`/`SymbolFinderService.ts` both read
`_clarionType || detail` for a variable's type — unaffected, since `handleVariableToken` always
sets `_clarionType` on the same symbol; the new test pins that so it stays that way.
