### PR TITLE
fix(diagnostics): Discarded-return warnings suppressed when line had a comment

### DIFF
--- a/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
+++ b/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
@@ -382,7 +382,13 @@ function validateCrossFilePlainCalls(
         if (!codeRanges.some(r => lineIdx >= r.start && lineIdx <= r.end)) continue;
 
         const rawLine = docLines[lineIdx];
-        const stripped = rawLine.replace(/!.*$/, '').trim();
+        // CRLF: `docLines` comes from a plain split('\n'), so a CRLF file leaves
+        // a trailing '\r' on every line. `.` never matches '\r' and `$` (no /m)
+        // demands the literal string end, so on a line ending in a trailing
+        // comment `!.*$` never matches at all — the comment silently survives
+        // into `stripped`. Dropping the `$` fixes it: `.` already stops at any
+        // line terminator, so `!.*` strips to end-of-line either way.
+        const stripped = rawLine.replace(/!.*/, '').trim();
         if (!stripped) continue;
 
         if (ASSIGN_RE.test(stripped)) continue;
@@ -838,7 +844,7 @@ export function validateDiscardedReturnValuesForPlainCalls(
         if (!codeRanges.some(r => lineIdx >= r.start && lineIdx <= r.end)) continue;
 
         const rawLine = docLines[lineIdx];
-        const stripped = rawLine.replace(/!.*$/, '').trim();
+        const stripped = rawLine.replace(/!.*/, '').trim(); // CRLF-safe — see comment above the first occurrence
         if (!stripped) continue;
 
         if (ASSIGN_RE.test(stripped)) continue;
@@ -1066,7 +1072,7 @@ export async function validateDiscardedReturnValues(
         if (!range) continue;
 
         const rawLine = docLines[lineIdx];
-        const stripped = rawLine.replace(/!.*$/, '').trim();
+        const stripped = rawLine.replace(/!.*/, '').trim(); // CRLF-safe — see comment above the first occurrence
         if (!stripped) continue;
 
         const prefixMatch = stripped.match(DOTCALL_PREFIX);

--- a/server/src/test/ReturnValueDiagnostics.CrlfTrailingComment.test.ts
+++ b/server/src/test/ReturnValueDiagnostics.CrlfTrailingComment.test.ts
@@ -1,0 +1,99 @@
+/**
+ * validateDiscardedReturnValues — CRLF line + trailing same-line comment.
+ *
+ * Real Clarion source is always CRLF (the compiler requires it). The comment-
+ * stripping step used to read `rawLine.replace(/!.*$/, '').trim()`. On a CRLF
+ * file, `docLines` (built from `document.getText().split('\n')`) leaves a
+ * trailing '\r' on every line. JavaScript's `.` never matches '\r', and `$`
+ * (no /m flag) demands the literal end of the string — so on a line ending in
+ * a trailing `!` comment, `!.*$` could never match at all: the comment
+ * survived into `stripped` un-stripped. The "anything after the closing
+ * paren?" check then saw that leftover comment text as junk after the call
+ * and skipped the line via `continue`, so the diagnostic was silently never
+ * produced — while the exact same source with the comment removed (or with
+ * LF-only line endings) warned correctly. Every existing test in this suite
+ * builds its fixtures via `.join('\n')` (LF-only) and none put a trailing
+ * comment on the exercised line, so this combination was never exercised
+ * before this test.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MemberLocatorService } from '../services/MemberLocatorService';
+import { validateDiscardedReturnValues } from '../providers/diagnostics/ReturnValueDiagnostics';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function createCrlfDoc(filename: string, lines: string[]): TextDocument {
+    const code = lines.join('\r\n');
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, code);
+    const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+    return TextDocument.create(uri, 'clarion', 1, code);
+}
+
+suite('ReturnValueDiagnostics — CRLF line + trailing same-line comment', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvdCrlfComment_'));
+    });
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+    teardown(() => TokenCache.getInstance().clearAllTokens());
+
+    const discarded = (diags: { message: string }[]) =>
+        diags.filter(d => /is discarded/.test(d.message));
+
+    test('CRLF file, discarded call WITH a trailing comment on the same line still warns', async () => {
+        const lines = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'MyClass  CLASS,TYPE',
+            'Method     PROCEDURE(),LONG',
+            '         END',
+            'obj  MyClass',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  obj.Method()      ! trailing comment must not suppress the warning',
+        ];
+        const doc = createCrlfDoc('rvdCrlfWithComment.clw', lines);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        const warns = discarded(diags);
+        assert.strictEqual(warns.length, 1,
+            `CRLF line with a trailing comment must still warn — got: ${warns.map(w => w.message).join(' | ')}`);
+        assert.ok(warns[0].message.includes("'obj.Method'"));
+    });
+
+    test('CRLF file, discarded call WITHOUT a trailing comment warns (control case)', async () => {
+        const lines = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'MyClass  CLASS,TYPE',
+            'Method     PROCEDURE(),LONG',
+            '         END',
+            'obj  MyClass',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  obj.Method()',
+        ];
+        const doc = createCrlfDoc('rvdCrlfNoComment.clw', lines);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        assert.strictEqual(discarded(diags).length, 1,
+            'CRLF line with no trailing comment must warn (this direction already worked pre-fix)');
+    });
+});


### PR DESCRIPTION
## What happened

The compiler warns "Calling function as procedure" for a discarded non-PROC return value on a
dot-call, but the extension's equivalent diagnostic (`validateDiscardedReturnValues`, closes #61)
silently skipped the line whenever BOTH of these held at once:

- the source file is CRLF-terminated (true of every real Clarion file — the compiler requires it), and
- the discarded call has a trailing `!` comment on the same line.

```clarion
obj  MyClass
  CODE
  obj.Method()                    ! compiler warns, extension is silent
  obj.Method()                    
  ! (no comment on the line above) — extension warns correctly
```

Removing the trailing comment (or saving the line with a bare LF ending) made the warning appear
immediately; adding the comment back made it disappear again — confirmed directly against the real
file that surfaced this.

## Root cause

The comment-stripping step read:

```ts
const stripped = rawLine.replace(/!.*$/, '').trim();
```

`rawLine` comes from `docLines = document.getText().split('\n')`. On a CRLF file, splitting on
`\n` alone leaves the preceding `\r` attached to every line. JavaScript's `.` metacharacter never
matches `\r`, and `$` without the `/m` flag demands the literal end of the string — so on a line
ending `...! some comment\r`, `!.*$` can never match anywhere: `.*` reaches right up to the `\r`
and can go no further, and `$` isn't satisfied there. The regex fails to match at all, `.replace()`
is a no-op, and the trailing comment text survives into `stripped`.

Downstream, the loop checks whether anything follows the call's closing `)`:

```ts
const afterClose = afterMatch.substring(closeIdx + 1).trim();
if (afterClose) continue;
```

With the comment left in place, `afterClose` is non-empty (it's the leftover comment text), so the
line is skipped via `continue` before a diagnostic is ever built — for a completely
unrelated-looking reason ("something follows the call", not "CRLF broke comment stripping").

This exact pattern (`rawLine.replace(/!.*$/, '')`) is duplicated 3× in this file and appears in
several other files too (`ClarionTokenizer.ts`, `FileRelationshipGraph.ts`,
`MemberLocatorService.ts`, `ClassMemberResolver.ts`, `MapDeclarationDiagnostics.ts`,
`MethodOverloadResolver.ts`) — noted here for a possible follow-up audit, not fixed in this PR since
whether CRLF-terminated text actually reaches those specific call sites wasn't confirmed.

## Fix

Drop the unnecessary `$` anchor at the three call sites in this file:

```ts
const stripped = rawLine.replace(/!.*/, '').trim();
```

`.` already stops at any line terminator, so `!.*` correctly strips from `!` to end-of-line whether
or not a trailing `\r` follows — no anchor needed.

## Testing

New `ReturnValueDiagnostics.CrlfTrailingComment.test.ts`: a CRLF-joined fixture (`.join('\r\n')`,
not the usual `.join('\n')`) with a discarded call carrying a trailing same-line comment — must
warn; a same-shape control case without the comment — must also warn. Verified the test is a real
regression guard (not a rubber stamp) by reverting the fix and confirming the "with comment" case
fails while the control case still passes, then reapplying the fix and reconfirming both pass.

**Note:** *Every* existing test in this file (and effectively the whole suite — ~130 other test files) builds
its Clarion source fixtures via `.join('\n')`, plain LF, so no prior test ever exercised a
genuinely CRLF-terminated line; none of the existing `ReturnValueDiagnostics` tests put a trailing
comment on the exercised call line either. The bug needed both conditions at once, and the suite's
own fixture-authoring convention structurally never produced either one — which is presumably why
this went unnoticed until it hit a real file.

`npx tsc -b --force`: clean. Full suite (`rm -rf out && tsc -b --force` then `npx mocha`), run in a
clean worktree off `version-1.0.2` with only this change applied: **2420 passing, 4 pending, 0
failing** (baseline on that same base is 2418/4/0 — the delta is exactly the 2 new tests).

## How this was found

This started as an investigation into why two specific lines in a large real-world `.clw` file
warned in the Clarion compiler but not in the extension. The trail went through several dead ends
before landing here, each ruled out with a direct, isolated repro rather than by inspection alone:
a stale MAP-signature mismatch on the procedure, a bare-CLASS self-instance receiver question (a
separate, real, already-in-progress fix on another branch — unrelated to this one), suspected
tokenizer/document-structure corruption, and — for a while — what looked like a stalled or racing
async validation pass on the large file (the LSP's diagnostics pipeline runs 8 validators
sequentially and only publishes the combined result once all of them finish, which made an
actually-instantaneous logic bug look for a while like a performance/timeout issue on a large,
richly cross-referenced file). Bisecting the real file's content down to a minimal fragment, then
toggling exactly one variable at a time, isolated it to "CRLF" and "trailing same-line comment" as
the two co-required conditions — confirmed both in a minimal synthetic repro and directly on the
real file (comment removed → warns; comment restored → silent again).

## Scope

One file (`ReturnValueDiagnostics.ts`, three identical one-line regex fixes) plus one new test
file. Unrelated to any in-flight feature work on this branch's base.
