### PR TITLE
fix(hover,definition): a bare local CLASS's indented END mis-attributes the next PROCEDURE as its method

### DIFF
--- a/server/src/providers/ImplementationProvider.ts
+++ b/server/src/providers/ImplementationProvider.ts
@@ -803,32 +803,24 @@ export class ImplementationProvider {
         // Search backwards from the method line to find the CLASS token
         for (let i = tokens.length - 1; i >= 0; i--) {
             const token = tokens[i];
-            
+
             // Stop if we've gone past the method line
             if (token.line > methodLine) {
                 continue;
             }
-            
+
             // Look for CLASS structure
             if (token.type === TokenType.Structure && token.value.toUpperCase() === 'CLASS') {
-                // Check if this class contains our method line
-                // Find the END of this class
-                let classEndLine = -1;
-                for (let j = i + 1; j < tokens.length; j++) {
-                    const endToken = tokens[j];
-                    if (endToken.value.toUpperCase() === 'END' && endToken.start === 0 && endToken.line > token.line) {
-                        classEndLine = endToken.line;
-                        break;
-                    }
-                }
-                
-                // Check if method is within this class
-                if (classEndLine === -1 || methodLine < classEndLine) {
+                // Use the tokenizer's own nesting-aware finishesAt (stack-based, END-marker
+                // driven — not indentation) instead of hand-scanning for a column-0 END.
+                // A local/anonymous CLASS declared inside a procedure's DATA section is
+                // closed by an indented END, which a column-0 scan would skip right past.
+                if (token.finishesAt === undefined || methodLine <= token.finishesAt) {
                     return token;  // Return the CLASS token itself
                 }
             }
         }
-        
+
         return null;
     }
 

--- a/server/src/providers/hover/MethodHoverResolver.ts
+++ b/server/src/providers/hover/MethodHoverResolver.ts
@@ -470,31 +470,24 @@ export class MethodHoverResolver {
         // Search backwards from the method line to find the CLASS token
         for (let i = tokens.length - 1; i >= 0; i--) {
             const token = tokens[i];
-            
+
             // Stop if we've gone past the method line
             if (token.line > methodLine) {
                 continue;
             }
-            
+
             // Look for CLASS structure
             if (token.type === TokenType.Structure && token.value.toUpperCase() === 'CLASS') {
-                // Check if this class contains our method line
-                let classEndLine = -1;
-                for (let j = i + 1; j < tokens.length; j++) {
-                    const endToken = tokens[j];
-                    if (endToken.value.toUpperCase() === 'END' && endToken.start === 0 && endToken.line > token.line) {
-                        classEndLine = endToken.line;
-                        break;
-                    }
-                }
-                
-                // Check if method is within this class
-                if (classEndLine === -1 || methodLine < classEndLine) {
+                // Use the tokenizer's own nesting-aware finishesAt (stack-based, END-marker
+                // driven — not indentation) instead of hand-scanning for a column-0 END.
+                // A local/anonymous CLASS declared inside a procedure's DATA section is
+                // closed by an indented END, which a column-0 scan would skip right past.
+                if (token.finishesAt === undefined || methodLine <= token.finishesAt) {
                     return token;
                 }
             }
         }
-        
+
         return null;
     }
 

--- a/server/src/test/HoverProvider.StandaloneProcAfterIndentedLocalClass.test.ts
+++ b/server/src/test/HoverProvider.StandaloneProcAfterIndentedLocalClass.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+// A local `CLASS` declared inside a procedure's DATA section (no ,TYPE, single
+// self-instance) is closed by an indented END — never at column 0. Both
+// `ImplementationProvider.findClassTokenForMethod` and
+// `MethodHoverResolver.findClassTokenForMethodDeclaration` used to determine a
+// CLASS token's extent by hand-scanning forward for the next END token sitting
+// at column 0. Against an indented END, that scan skips straight past it and
+// either finds some unrelated LATER column-0 END far down the file, or finds
+// none at all (classEndLine === -1) — and the old check
+// `classEndLine === -1 || methodLine < classEndLine` treats BOTH outcomes as
+// "still inside the class". Any bare `Label PROCEDURE()` declaration textually
+// following the class — including a genuinely standalone procedure with zero
+// relation to it — was then mis-attributed as one of that class's own methods.
+//
+// Fix: use the tokenizer's own nesting-aware `finishesAt` (stack-based, driven
+// by the real END that closed this CLASS) instead of the hand-scan.
+//
+// Real-world shape this was found in: a helper procedure with no MAP entry
+// (so ProcedureHoverResolver.resolveProcedureImplementation's MAP-declaration
+// lookup can't claim it first) declared right after a local CLASS.
+suite('HoverProvider — standalone procedure declared after an indented-END local CLASS', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    // Owner.Method's own implementation MUST appear here, before the next PROCEDURE —
+    // that's not just realism, it's a real Clarion placement rule: a procedure-local
+    // class's method implementations belong to the declaring procedure and have to be
+    // written before the next PROCEDURE begins. Omitting it (an earlier draft of this
+    // test did) is invalid Clarion and no longer proves anything about the real bug.
+    const code = [
+        'HasLocalClass PROCEDURE()',
+        '',
+        'Owner CLASS',
+        'Method  PROCEDURE(), LONG',
+        '      END',
+        '',
+        '  CODE',
+        '  RETURN',
+        '',
+        'Owner.Method PROCEDURE()',
+        '  CODE',
+        '  RETURN(1)',
+        '',
+        'StandaloneProc PROCEDURE()',
+        '  CODE',
+        '  RETURN',
+    ].join('\n');
+
+    test('hovering the standalone procedure\'s own declaration is not mis-attributed to the earlier local CLASS', async () => {
+        const doc = TextDocument.create('test://standalone-after-local-class.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(13, 2)); // "StandaloneProc"
+        const content = hoverText(hover);
+
+        assert.ok(!content.includes('Owner'),
+            `StandaloneProc must not be attributed to the unrelated local CLASS "Owner"; got: ${content}`);
+    });
+
+    test('hovering the method declaration INSIDE the local CLASS still resolves to that CLASS (no regression)', async () => {
+        const doc = TextDocument.create('test://method-inside-local-class.clw', 'clarion', 1, code);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(3, 2)); // "Method" inside Owner CLASS
+        const content = hoverText(hover);
+
+        assert.ok(content.includes('Owner'),
+            `Method declared inside Owner must still resolve as Owner's own member; got: ${content}`);
+    });
+});


### PR DESCRIPTION
## What happened

A local `CLASS` declared inside a procedure's DATA section — no `,TYPE`, single self-instance, exactly the same shape as a bare `QUEUE`/`GROUP`/`FILE` local — is closed by an **indented** `END`, never one at column 0:

```clarion
HasLocalClass PROCEDURE()

Owner CLASS
Method  PROCEDURE(), LONG
      END          ! <- indented, not column 0

  CODE
  RETURN

Owner.Method PROCEDURE()
  CODE
  RETURN(1)

StandaloneProc PROCEDURE()   ! hover on this label wrongly says "Owner.StandaloneProc"
  CODE
  RETURN
```

Hovering `StandaloneProc`'s own declaration — a genuinely standalone procedure with zero relation to `Owner` — showed:

```
**Method Declaration:** `Owner.StandaloneProc`

⚠️ Implementation not found
```

Reproduces most easily with a helper procedure that has no `MAP` entry (so `ProcedureHoverResolver.resolveProcedureImplementation`'s MAP-declaration lookup can't claim it first and the buggy fallback gets a turn) declared right after a local CLASS — a common enough shape in practice.

## Root cause

Both `ImplementationProvider.findClassTokenForMethod` and `MethodHoverResolver.findClassTokenForMethodDeclaration` determine whether a given line sits inside a preceding `CLASS` token by hand-scanning forward for the next `END` token sitting at column 0:

```ts
let classEndLine = -1;
for (let j = i + 1; j < tokens.length; j++) {
    const endToken = tokens[j];
    if (endToken.value.toUpperCase() === 'END' && endToken.start === 0 && endToken.line > token.line) {
        classEndLine = endToken.line;
        break;
    }
}
if (classEndLine === -1 || methodLine < classEndLine) {
    return token;  // treated as "inside this class"
}
```

An indented `END` (the only kind a local/anonymous CLASS in a DATA section ever has) is invisible to `endToken.start === 0`, so the scan skips straight past it. It then either:
- finds some unrelated, much-later column-0 `END` (a WINDOW, another top-level structure, etc.) and uses **that** as the class's boundary, or
- finds none at all before EOF, leaving `classEndLine === -1`.

Both outcomes hit the same branch of the bounds check and are treated as "still inside the class" — so every bare `Label PROCEDURE()` declared anywhere after it, for potentially hundreds of lines, gets misidentified as a method of that class.

## Fix

Use the tokenizer's own nesting-aware `finishesAt` (stack-based, set from the actual `END` that closed this structure — indentation-independent) instead of the hand-scan, in both files:

```ts
if (token.finishesAt === undefined || methodLine <= token.finishesAt) {
    return token;
}
```

Net diff: one hand-rolled scan removed and replaced with the existing `finishesAt` field, in each of the two files. No other logic changed.

## Testing

New `HoverProvider.StandaloneProcAfterIndentedLocalClass.test.ts`:
- Confirmed this reproduces the reported bug exactly against the pre-fix code (temporarily reverted just these two files, recompiled): hover on `StandaloneProc` showed `Method Declaration: Owner.StandaloneProc`. Restoring the fix makes it pass.
- A second case pins that hovering the method genuinely declared *inside* `Owner` (`Method`) is unaffected — it still resolves as `Owner`'s own member.

Full clean suite: **2420 passing, 0 failing, 4 pending**.

## Scope

Two source files (`ImplementationProvider.ts`, `MethodHoverResolver.ts`), one new test file. No other files touched — deliberately kept separate from the sibling `MemberLocatorService.extractTypeFromToken` fix (bare local CLASS as a *dot-call receiver*, e.g. `Owner.Method()` — a different bug in different code, its own upcoming PR) and from the unrelated `ReturnValueDiagnostics.ts` CRLF/colon fixes (#429 and its sibling, already separate).
