### PR TITLE
 fix(hover,f12): colon in SELF/PARENT scope line no longer truncates

### DIFF
--- a/server/src/providers/DefinitionProvider.ts
+++ b/server/src/providers/DefinitionProvider.ts
@@ -161,7 +161,7 @@ export class DefinitionProvider {
                 const rawBeforeDot = line.substring(0, dotBeforeIndex).trim();
                 const beforeDot = ChainedPropertyResolver.extractChain(rawBeforeDot);
                 const afterDot = line.substring(dotBeforeIndex + 1).trim();
-                const methodMatch = afterDot.match(/^(\w+)/);
+                const methodMatch = afterDot.match(/^([\w:]+)/);
                 const isPureChain = /^[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/i.test(beforeDot.trim());
                 const isSelfParentChain = isPureChain && /^\s*(self|parent)\b/i.test(beforeDot);
                 
@@ -386,7 +386,7 @@ export class DefinitionProvider {
 
             // ✅ 3-part method implementation: ClassName.InterfaceName.MethodName PROCEDURE
             // When cursor is on the InterfaceName segment, navigate to the INTERFACE declaration
-            const threePartMatch = line.match(/^(\w+)\.(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i);
+            const threePartMatch = line.match(/^([\w:]+)\.([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i);
             if (threePartMatch) {
                 const [, clsName, ifacePart, methodPart] = threePartMatch;
                 const ifaceStart = line.indexOf(ifacePart, clsName.length + 1);
@@ -818,8 +818,8 @@ export class DefinitionProvider {
             const afterDot = line.substring(dotIndex + 1).trim();
 
             // Extract structure name and field name
-            const structureMatch = beforeDot.match(/(\w+)\s*$/);
-            const fieldMatch = afterDot.match(/^(\w+)/);
+            const structureMatch = beforeDot.match(/([\w:]+)\s*$/);
+            const fieldMatch = afterDot.match(/^([\w:]+)/);
             
             if (structureMatch && fieldMatch) {
                 const structureName = structureMatch[1];
@@ -1268,7 +1268,7 @@ export class DefinitionProvider {
             logger.info(`Scope line text: "${scopeLine}"`);
             
             // Match ClassName.MethodName PROCEDURE pattern
-            const classMethodMatch = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+            const classMethodMatch = scopeLine.match(/^([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
             if (classMethodMatch) {
                 className = classMethodMatch[1];
                 logger.info(`Extracted class name from line: ${className}`);

--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -206,7 +206,7 @@ export class HoverProvider {
 
             // ✅ Hover on 3-part method line (ClassName.InterfaceName.MethodName PROCEDURE)
             // When cursor is on the interface-name segment, show the INTERFACE hover
-            const threePartMatch = line.match(/^(\w+)\.(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i);
+            const threePartMatch = line.match(/^([\w:]+)\.([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i);
             if (threePartMatch) {
                 const [, cls, iface, meth] = threePartMatch;
                 const ifaceStart = line.indexOf(iface, cls.length + 1);

--- a/server/src/providers/ImplementationProvider.ts
+++ b/server/src/providers/ImplementationProvider.ts
@@ -435,7 +435,7 @@ export class ImplementationProvider {
                 const beforeDot = ChainedPropertyResolver.extractChain(rawBeforeDot);
                 if (/^\s*(self|parent)\b/i.test(beforeDot) && beforeDot.includes('.')) {
                     const afterDot = line.substring(dotBeforeIndex + 1).trim();
-                    const methodMatch = afterDot.match(/^(\w+)/);
+                    const methodMatch = afterDot.match(/^([\w:]+)/);
                     if (methodMatch) {
                         const memberName = methodMatch[1];
                         const hasParens = afterDot.includes('(') || line.substring(position.character).trimStart().startsWith('(');
@@ -469,7 +469,7 @@ export class ImplementationProvider {
                 // Multi-segment variable chain: variable.property.method (e.g., thisStartup.Settings.PutGlobalSetting)
                 if (!/^\s*(self|parent)\b/i.test(beforeDot) && beforeDot.includes('.')) {
                     const afterDot = line.substring(dotBeforeIndex + 1).trim();
-                    const methodMatch = afterDot.match(/^(\w+)/);
+                    const methodMatch = afterDot.match(/^([\w:]+)/);
                     if (methodMatch) {
                         const memberName = methodMatch[1];
                         const hasParens = afterDot.includes('(') || line.substring(position.character).trimStart().startsWith('(');

--- a/server/src/providers/ReferencesProvider.ts
+++ b/server/src/providers/ReferencesProvider.ts
@@ -341,7 +341,7 @@ export class ReferencesProvider {
 
         // ── Route A: 3-part method implementation (Class.Interface.Method PROCEDURE) ──
         // Must run before word.includes('.') to intercept the dot-prefixed word.
-        const threePartImplMatch = fullLine.match(/^(\w+)\.(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i);
+        const threePartImplMatch = fullLine.match(/^([\w:]+)\.([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i);
         if (threePartImplMatch) {
             const [, clsName, ifacePart, methPart] = threePartImplMatch;
             const ifaceStart = clsName.length + 1;

--- a/server/src/providers/SignatureHelpProvider.ts
+++ b/server/src/providers/SignatureHelpProvider.ts
@@ -195,8 +195,10 @@ export class SignatureHelpProvider {
         // Extract the method name and prefix (if any) before the opening paren
         const beforeParen = line.substring(0, lastOpenParen).trim();
         
-        // Match pattern: [prefix.]methodName
-        const match = beforeParen.match(/(\w+\.)?(\w+)\s*$/);
+        // Match pattern: [prefix.]methodName — [\w:] so a colon-containing prefix
+        // (SELF is fine, but a chained "SELF.Order.") or method name (My:My:Method)
+        // doesn't get truncated at the colon.
+        const match = beforeParen.match(/([\w:]+\.)?([\w:]+)\s*$/);
         if (!match) {
             return null;
         }
@@ -315,7 +317,7 @@ export class SignatureHelpProvider {
                     const content = document.getText();
                     const lines = content.split('\n');
                     const scopeLine = lines[currentScope.line];
-                    const classMethodMatch = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+                    const classMethodMatch = scopeLine.match(/^([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
                     if (classMethodMatch) {
                         className = classMethodMatch[1];
                         logger.info(`Extracted class name from line: ${className}`);

--- a/server/src/test/ColonInScopeLine.SelfPartnerFamily.test.ts
+++ b/server/src/test/ColonInScopeLine.SelfPartnerFamily.test.ts
@@ -1,0 +1,281 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { DefinitionProvider } from '../providers/DefinitionProvider';
+import { CompletionProvider } from '../providers/CompletionProvider';
+import { SignatureHelpProvider } from '../providers/SignatureHelpProvider';
+import { setServerInitialized } from '../serverState';
+import { TokenCache } from '../TokenCache';
+
+/**
+ * Clarion allows a literal ':' inside an identifier (MyOwn:CLASS, My:My:Method — a
+ * common naming convention). A whole family of hand-rolled `\w`-only regexes across
+ * this codebase assumed identifiers never contain one, and silently truncate at the
+ * colon whenever they parse:
+ *   (a) the ENCLOSING PROCEDURE's own declaration line, to learn what class SELF/
+ *       PARENT means inside it ("ClassName.MethodName PROCEDURE") — breaks EVERY
+ *       SELF./PARENT. access inside such a method, regardless of what's accessed;
+ *   (b) the ACCESSED member name itself, after the dot (SELF.My:Value) — fixed for
+ *       hover in HoverProvider.SelfColonPropertyAccess.test.ts; this file covers the
+ *       sibling occurrences in F12, completion, and signature help.
+ *
+ * Real repro (found live, verified in the real IDE 2026-09-04):
+ *   MyOwn:CLASS   CLASS
+ *   my:Value        ULONG
+ *   MyValue         LONG
+ *   My:My:Method    PROCEDURE(),LONG
+ *                 END
+ *
+ *   MyOwn:CLASS.My:My:Method PROCEDURE()
+ *     CODE
+ *        SELF.My:Value = 1        ! F12 jumped to an unrelated StringTheory.inc symbol
+ *        SELF.MyValue  = 1        ! (colon-free control — proves it's the SCOPE line's
+ *                                 !  colons at fault, not the accessed member's)
+ *        SELF.My:My:Method()
+ *        SELF.My                 ! completion suggested only the method, not either property
+ *     RETURN(1)
+ *
+ * Fixed by widening every `\w` to `[\w:]` in the affected regexes (mechanical, no
+ * control-flow change):
+ *   - ClassMemberResolver.ts:300,619,683 (className-from-scope-line, 3 call sites)
+ *   - ChainedPropertyResolver.ts:185 (same, backs SELF./PARENT. completion)
+ *   - DefinitionProvider.ts:164 (methodMatch after dot, gates the whole F12 dot-access
+ *     block — this is what actually caused the StringTheory.inc jump: it isn't the
+ *     scope-line regex, it's this one truncating "My:Value" to "My" before the
+ *     className lookup is even reached)
+ *   - DefinitionProvider.ts:822 (structureMatch/fieldMatch, plain variable.field F12)
+ *   - DefinitionProvider.ts:1271 (className-from-scope-line, F12's own copy)
+ *   - SignatureHelpProvider.ts:318 (className-from-scope-line) and :199
+ *     ([prefix.]methodName immediately before '(' — a different shape, same defect:
+ *     "SELF.My:My:Method(" resolved methodName to "Method" only)
+ *   - ImplementationProvider.ts:438,472 (methodMatch after dot, chained/self impl jump)
+ *   - DefinitionProvider.ts:389, HoverProvider.ts:209, ReferencesProvider.ts:344
+ *     (3-part Class.Interface.Method line — same shape, 3 call sites)
+ *   - ClarionPatterns.ts METHOD_IMPLEMENTATION / _STRICT / _LEGACY (the shared
+ *     constants backing DefinitionProvider/MethodHoverResolver/ImplementationProvider/
+ *     ClassMemberResolver's OTHER, already-correct call sites)
+ *
+ * NOT covered here — PARENT.member resolution. `ClassMemberResolver
+ * .findMemberInParentChain` resolves the parent class via `StructureDeclarationIndexer`,
+ * a project-wide index that a lone in-memory test document is never registered into;
+ * a colon-free PARENT.member control hits the identical "not found in index" path and
+ * only succeeds by chance via an unrelated same-file bare-word fallback that a
+ * colon-named member doesn't reach either. That's indistinguishable from a real
+ * regression using only this harness — needs a live check in an actual indexed
+ * solution, not a synthetic unit test.
+ *
+ * ALSO not covered — chained access (SELF.Something.member). Verified this returns
+ * null on this branch's base REGARDLESS of colons (a colon-free control on the exact
+ * same chain shape fails identically), so it isn't part of this defect family at all
+ * — some other, not-yet-upstream fix apparently covers chained hover, unrelated to
+ * anything touched here. Dropped the test rather than assert on a fix this PR doesn't
+ * provide.
+ */
+
+let docCounter = 0;
+function makeDoc(lines: string[]): TextDocument {
+    const doc = TextDocument.create(`test://colon-scope-line-${++docCounter}.clw`, 'clarion', 1, lines.join('\n'));
+    // SignatureHelpProvider (and others) read from TokenCache's cache directly and
+    // do NOT lazily tokenize on a miss — prime it here so every test in this file
+    // doesn't have to remember to.
+    TokenCache.getInstance().getTokens(doc);
+    return doc;
+}
+
+function lineOf(lines: string[], needle: string): number {
+    return lines.findIndex(l => l.includes(needle));
+}
+
+suite('Colon in the enclosing scope line breaks SELF./PARENT. resolution family', () => {
+    setup(() => {
+        setServerInitialized(true);
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    const CODE = [
+        'MyOwn:CLASS   CLASS',
+        'my:Value        ULONG',
+        'MyValue         LONG',
+        'My:My:Method    PROCEDURE(),LONG',
+        '              END',
+        '',
+        'MyOwn:CLASS.My:My:Method PROCEDURE()',
+        '  CODE',
+        '     SELF.My:Value = 1',
+        '     SELF.MyValue = 1',
+        '     SELF.My:My:Method()',
+        '  RETURN(1)',
+    ];
+
+    suite('F12 / Go to Definition', () => {
+        test('SELF.My:Value (colon-named property) resolves to its own declaration, not an unrelated symbol', async () => {
+            const doc = makeDoc(CODE);
+            const lines = CODE;
+            const line = lineOf(lines, 'SELF.My:Value = 1');
+            const ch = lines[line].indexOf('My:Value');
+
+            const def = await new DefinitionProvider().provideDefinition(doc, { line, character: ch });
+            assert.ok(def, 'Expected a definition location for SELF.My:Value');
+            const loc = Array.isArray(def) ? def[0] : def;
+            assert.strictEqual(loc.range.start.line, 1, // "my:Value        ULONG"
+                `Expected the property's own declaration line (1); got line ${loc.range.start.line}`);
+        });
+
+        // NOTE: this is a plain correctness check, not a fail-then-pass proof — in a
+        // tiny single-symbol file, DefinitionProvider's bare-word-label fallback
+        // (unrelated to the scope-line regex) happens to find "MyValue" correctly
+        // even with the bug present, so this test passes either way. The claim that
+        // the scope-line's OWN colons (not the accessed member's) are what break
+        // resolution is proven for hover in HoverProvider.SelfColonPropertyAccess
+        // .test.ts, where no such rescue path exists.
+        test('SELF.MyValue (colon-free property, colon-named enclosing method) resolves correctly', async () => {
+            const doc = makeDoc(CODE);
+            const lines = CODE;
+            const line = lineOf(lines, 'SELF.MyValue = 1');
+            const ch = lines[line].indexOf('MyValue');
+
+            const def = await new DefinitionProvider().provideDefinition(doc, { line, character: ch });
+            assert.ok(def, 'Expected a definition location for SELF.MyValue');
+            const loc = Array.isArray(def) ? def[0] : def;
+            assert.strictEqual(loc.range.start.line, 2, // "MyValue         LONG"
+                `Expected the property's own declaration line (2); got line ${loc.range.start.line}`);
+        });
+
+        test('SELF.My:My:Method() (colon-named method call) resolves to its own declaration', async () => {
+            const doc = makeDoc(CODE);
+            const lines = CODE;
+            const line = lineOf(lines, 'SELF.My:My:Method()');
+            const ch = lines[line].indexOf('My:My:Method');
+
+            const def = await new DefinitionProvider().provideDefinition(doc, { line, character: ch });
+            assert.ok(def, 'Expected a definition location for SELF.My:My:Method()');
+            const loc = Array.isArray(def) ? def[0] : def;
+            assert.strictEqual(loc.range.start.line, 3, // "My:My:Method    PROCEDURE(),LONG"
+                `Expected the method's own declaration line (3); got line ${loc.range.start.line}`);
+        });
+    });
+
+    suite('Completion after SELF.', () => {
+        test('SELF.My lists all three colon-aware members, not just the one bare-word completion happens to see', async () => {
+            const lines = [...CODE.slice(0, -1), '     SELF.My', 'RETURN(1)'];
+            const doc = makeDoc(lines);
+            // Exact match, not lineOf's `.includes()` — "     SELF.My" is a substring
+            // of "     SELF.MyValue = 1" earlier in this same fixture.
+            const line = lines.indexOf('     SELF.My');
+
+            const items = await new CompletionProvider().onCompletion(
+                { textDocument: { uri: doc.uri }, position: { line, character: lines[line].length } } as any,
+                doc
+            );
+            const labels = items.map(i => i.label.toLowerCase());
+            assert.ok(labels.some(l => l.startsWith('my:value')), `Expected my:Value in completions; got: ${items.map(i => i.label)}`);
+            assert.ok(labels.some(l => l.startsWith('myvalue')), `Expected MyValue in completions; got: ${items.map(i => i.label)}`);
+            assert.ok(labels.some(l => l.startsWith('my:my:method')), `Expected My:My:Method in completions; got: ${items.map(i => i.label)}`);
+
+            // Discriminates real class-member completion from the bare-word-completion
+            // fallback CompletionProvider silently drops to when chain resolution fails
+            // (per its own doc comment at completeMemberAccess). The fallback ALSO
+            // happens to surface the three names above in this tiny fixture — labels
+            // alone don't prove which path answered — but only real member completion
+            // sets insertText, and only the fallback would additionally list the CLASS
+            // itself ("MyOwn:CLASS") as if it were one of its own members.
+            assert.ok(items.every(i => typeof i.insertText === 'string' && i.insertText.length > 0),
+                `Expected every item to carry insertText (real member completion); got: ${JSON.stringify(items)}`);
+            assert.ok(!labels.includes('myown:class'.toLowerCase()) && !items.some(i => i.label.toLowerCase() === 'myown:class'),
+                `Bare-word fallback would list the CLASS itself as a candidate; got: ${items.map(i => i.label)}`);
+        });
+    });
+
+    suite('Signature help', () => {
+        test('SELF.My:My:Method( shows the colon-named method\'s own parameters', async () => {
+            const lines = [
+                'MyOwn:CLASS   CLASS',
+                'My:My:Method    PROCEDURE(LONG p1, STRING p2),LONG',
+                '              END',
+                '',
+                'MyOwn:CLASS.My:My:Method PROCEDURE(LONG p1, STRING p2)',
+                '  CODE',
+                '     SELF.My:My:Method(',
+                '  RETURN(1)',
+            ];
+            const doc = makeDoc(lines);
+            const line = lineOf(lines, 'SELF.My:My:Method(');
+
+            const sig = await new SignatureHelpProvider().provideSignatureHelp(doc, { line, character: lines[line].length });
+            assert.ok(sig, 'Expected signature help for SELF.My:My:Method(');
+            assert.ok(sig!.signatures[0].label.includes('My:My:Method'),
+                `Expected the signature label to name the method; got: ${sig!.signatures[0].label}`);
+            assert.strictEqual(sig!.signatures[0].parameters?.length, 2,
+                `Expected both parameters; got: ${JSON.stringify(sig!.signatures[0].parameters)}`);
+        });
+    });
+
+    suite('3-part interface implementation (Class.Interface.Method), colon-heavy names', () => {
+        const IFACE_CODE = [
+            'My:IFace   INTERFACE,TYPE',
+            'My:Method    PROCEDURE',
+            '           END',
+            '',
+            'My:Impl:CLASS   CLASS,IMPLEMENTS(My:IFace)',
+            '              END',
+            '',
+            '  CODE',
+            '',
+            'My:Impl:CLASS.My:IFace.My:Method PROCEDURE',
+            '  CODE',
+            '  RETURN',
+        ];
+
+        test('hovering the interface segment shows the INTERFACE declaration', async () => {
+            const doc = makeDoc(IFACE_CODE);
+            const line = lineOf(IFACE_CODE, 'My:Impl:CLASS.My:IFace.My:Method');
+            const ch = IFACE_CODE[line].indexOf('My:IFace');
+
+            const hover = await new HoverProvider().provideHover(doc, { line, character: ch });
+            assert.ok(hover, 'Expected hover on the 3-part line\'s interface segment');
+            const text = (hover!.contents as any).value as string;
+            assert.ok(text.includes('My:IFace') && /interface/i.test(text),
+                `Expected the INTERFACE card for My:IFace; got: ${text}`);
+        });
+
+        test('F12 on the interface segment navigates to the INTERFACE declaration', async () => {
+            const doc = makeDoc(IFACE_CODE);
+            const line = lineOf(IFACE_CODE, 'My:Impl:CLASS.My:IFace.My:Method');
+            const ch = IFACE_CODE[line].indexOf('My:IFace');
+
+            const def = await new DefinitionProvider().provideDefinition(doc, { line, character: ch });
+            assert.ok(def, 'Expected a definition for the 3-part line\'s interface segment');
+            const loc = Array.isArray(def) ? def[0] : def;
+            assert.strictEqual(loc.range.start.line, 0, // "My:IFace   INTERFACE,TYPE"
+                `Expected the INTERFACE's own declaration line (0); got line ${loc.range.start.line}`);
+        });
+    });
+
+    suite('Regression sentinel — ordinary colon-free classes are unaffected', () => {
+        const PLAIN_CODE = [
+            'PlainClass   CLASS',
+            'PlainValue     ULONG',
+            '             END',
+            '',
+            'PlainClass.DoWork PROCEDURE()',
+            '  CODE',
+            '     SELF.PlainValue = 1',
+            '  RETURN',
+        ];
+
+        test('hover and F12 on a plain SELF.member still resolve correctly', async () => {
+            const doc = makeDoc(PLAIN_CODE);
+            const line = lineOf(PLAIN_CODE, 'SELF.PlainValue');
+            const ch = PLAIN_CODE[line].indexOf('PlainValue');
+
+            const hover = await new HoverProvider().provideHover(doc, { line, character: ch });
+            assert.ok(hover, 'Expected hover on the plain SELF.member');
+            assert.ok((hover!.contents as any).value.includes('PlainClass'));
+
+            const def = await new DefinitionProvider().provideDefinition(doc, { line, character: ch });
+            assert.ok(def, 'Expected a definition for the plain SELF.member');
+            const loc = Array.isArray(def) ? def[0] : def;
+            assert.strictEqual(loc.range.start.line, 1);
+        });
+    });
+});

--- a/server/src/utils/ChainedPropertyResolver.ts
+++ b/server/src/utils/ChainedPropertyResolver.ts
@@ -182,7 +182,7 @@ export class ChainedPropertyResolver {
 
         const lines = document.getText().split('\n');
         const scopeLine = lines[currentScope.line];
-        const m = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+        const m = scopeLine.match(/^([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
         return m ? m[1] : null;
     }
 

--- a/server/src/utils/ClarionPatterns.ts
+++ b/server/src/utils/ClarionPatterns.ts
@@ -34,20 +34,20 @@ export class ClarionPatterns {
      * 
      * Use getMethodImplParts() for a unified API.
      */
-    public static readonly METHOD_IMPLEMENTATION = /^\s*(\w+)\.(\w+)(?:\.(\w+))?\s+(?:PROCEDURE|FUNCTION)\s*(?:\(([^)]*)\))?/i;
-    
+    public static readonly METHOD_IMPLEMENTATION = /^\s*([\w:]+)\.([\w:]+)(?:\.([\w:]+))?\s+(?:PROCEDURE|FUNCTION)\s*(?:\(([^)]*)\))?/i;
+
     /**
      * Matches a method implementation line (strict - must be at start of line)
      * Same as METHOD_IMPLEMENTATION but enforces no leading whitespace
      */
-    public static readonly METHOD_IMPLEMENTATION_STRICT = /^(\w+)\.(\w+)(?:\.(\w+))?\s+(?:PROCEDURE|FUNCTION)\s*(?:\(([^)]*)\))?/i;
-    
+    public static readonly METHOD_IMPLEMENTATION_STRICT = /^([\w:]+)\.([\w:]+)(?:\.([\w:]+))?\s+(?:PROCEDURE|FUNCTION)\s*(?:\(([^)]*)\))?/i;
+
     /**
      * Matches a method implementation line (legacy - requires parentheses)
      * This pattern is deprecated - use METHOD_IMPLEMENTATION instead
      * @deprecated Use METHOD_IMPLEMENTATION which supports optional parens
      */
-    public static readonly METHOD_IMPLEMENTATION_LEGACY = /^(\w+)\.(\w+)\s+PROCEDURE\s*\((.*?)\)/i;
+    public static readonly METHOD_IMPLEMENTATION_LEGACY = /^([\w:]+)\.([\w:]+)\s+PROCEDURE\s*\((.*?)\)/i;
     
     /**
      * Tests if a line is a method implementation (2-part or 3-part)

--- a/server/src/utils/ClassMemberResolver.ts
+++ b/server/src/utils/ClassMemberResolver.ts
@@ -297,7 +297,10 @@ export class ClassMemberResolver {
             const content = document.getText();
             const lines = content.split('\n');
             const scopeLine = lines[currentScope.line];
-            const classMethodMatch = scopeLine.match(/^(\w+)\.(?:\w+\.)?(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+            // Clarion labels may contain ':' (MyOwn:CLASS.My:My:Method) — \w alone stops at the
+            // colon, the match fails, and every SELF.member hover inside such a method dies here
+            // with "Could not determine className" regardless of what member is hovered.
+            const classMethodMatch = scopeLine.match(/^([\w:]+)\.(?:[\w:]+\.)?([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
             if (classMethodMatch) {
                 className = classMethodMatch[1];
             }
@@ -613,7 +616,7 @@ export class ClassMemberResolver {
         } else {
             const lines = document.getText().split('\n');
             const scopeLine = lines[currentScope.line];
-            const m = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+            const m = scopeLine.match(/^([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
             if (m) className = m[1];
         }
         if (!className) return null;
@@ -677,7 +680,7 @@ export class ClassMemberResolver {
         } else {
             const lines = document.getText().split('\n');
             const scopeLine = lines[currentScope.line];
-            const m = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
+            const m = scopeLine.match(/^([\w:]+)\.([\w:]+)\s+(?:PROCEDURE|FUNCTION)/i); // #247
             if (m) className = m[1];
         }
         if (!className) return null;


### PR DESCRIPTION
# fix(hover,definition,completion,signature-help): a colon in the enclosing SELF/PARENT scope line stops truncating identifiers

## What happened

Clarion allows a literal `:` inside an identifier (`MyOwn:CLASS`, `My:My:Method`). A family of hand-rolled `\w`-only regexes across this
codebase assumed identifiers never contain one, and silently truncated at the colon
whenever they parsed either:

- **(a)** the ENCLOSING PROCEDURE's own declaration line, to learn what class   `SELF`/`PARENT` means inside it (`"ClassName.MethodName PROCEDURE"`) — breaks   EVERY `SELF.`/`PARENT.` access inside such a method, regardless of what's accessed; or - **(b)** the ACCESSED member name itself, after the dot (`SELF.My:Value`)

Repro:

```clarion
MyOwn:CLASS   CLASS
my:Value        ULONG
MyValue         LONG
My:My:Method    PROCEDURE(),LONG
              END

MyOwn:CLASS.My:My:Method PROCEDURE()
  CODE
     SELF.My:Value = 1        ! F12 jumped to an unrelated symbol elsewhere in the workspace
     SELF.MyValue  = 1        ! (colon-free control — proves it's the SCOPE line's
                              !  colons at fault, not the accessed member's)
     SELF.My:My:Method()
     SELF.My                 ! completion suggested only the method, not either property
  RETURN(1)
```

Live-verified symptoms:
- **F12** on `SELF.My:Value` jumped to a completely unrelated symbol in another file.
- **Completion** after `SELF.My` suggested only the method, not either property —
  `CompletionProvider.completeMemberAccess` silently falls back to generic   bare-word completion when chain resolution fails (per its own doc comment), which is what actually answered, not real member completion.
- **Signature help** on `SELF.My:My:Method(` resolved the method name to `"Method"`  only and showed nothing.

## Root cause

`DefinitionProvider.ts`'s dot-access gate:

```ts
const methodMatch = afterDot.match(/^(\w+)/);
...
if (methodMatch && methodMatch[1].toLowerCase() === methodName.toLowerCase()) {
```

`\w` doesn't include `:`, so for `SELF.My:Value`, `methodMatch[1]` truncates to `"My"` — mismatches the correctly-extracted `methodName` (`"My:Value"`), and the **entire** SELF/PARENT/chained dot-access block is skipped, regardless of receiver.
This is what actually caused the wrong F12 jump — not the scope-line regex, which never even gets reached.

Separately, several className-from-scope-line regexes (used to determine what class `SELF`/`PARENT` refers to inside the current method) have the same defect:

```ts
const m = scopeLine.match(/^(\w+)\.(\w+)\s+(?:PROCEDURE|FUNCTION)/i);
```

For `MyOwn:CLASS.My:My:Method PROCEDURE()`, this fails to match at all (the class
and method segments both contain colons), so `className` never resolves and the
whole SELF/PARENT resolution bails before ever getting to the accessed member.

## The fix

Widened every `\w` to `[\w:]` in the affected regexes — mechanical, no control-flow
change, matching patterns already used elsewhere in this codebase for colon-aware
matching (e.g. `isPureChain`'s `[A-Za-z0-9_:]*`):

| File | What it backs |
|---|---|
| `ClassMemberResolver.ts` (3 call sites) | className-from-scope-line for hover/F12's SELF/PARENT resolution |
| `ChainedPropertyResolver.ts` | same, backs `SELF.`/`PARENT.` completion |
| `DefinitionProvider.ts` (3 sites) | methodMatch after dot (the actual F12 wrong-jump cause); structureMatch/fieldMatch for plain `variable.field` F12; its own className-from-scope-line copy |
| `SignatureHelpProvider.ts` (2 sites) | `[prefix.]methodName` immediately before `(` — a different shape, same defect; and its own className-from-scope-line copy |
| `ImplementationProvider.ts` (2 sites) | methodMatch after dot, chained/self implementation jump |
| `DefinitionProvider.ts`, `HoverProvider.ts`, `ReferencesProvider.ts` | 3-part `Class.Interface.Method` line — same shape, 3 call sites |
| `ClarionPatterns.ts` | `METHOD_IMPLEMENTATION`/`_STRICT`/`_LEGACY` — shared constants backing these same files' other, already-correct call sites |

## Testing

`ColonInScopeLine.SelfPartnerFamily.test.ts` — 8 tests:
- F12 on a colon-named property and a colon-named method call, both resolving to   their own declaration (not an unrelated symbol).
- F12 on a colon-**free** property from inside the same colon-named method — a   plain correctness check (see Scope note below on why it can't be a strict fail-then-pass proof for F12 specifically).
- Completion after `SELF.My` lists all three members. Asserts on `insertText` presence and the absence of the CLASS itself from the list — the two things that actually distinguish real member completion from the bare-word fallback; label text alone doesn't, since the fallback happens to surface the same three names in a small fixture (caught this while writing the test — an early version of this assertion passed vacuously with the bug still present).
- Signature help on `SELF.My:My:Method(` shows both parameters.
- 3-part interface hover and F12, colon-heavy names throughout.
- Regression sentinel — an ordinary colon-free class is unaffected.

Proved real: reverting all 8 fix files makes exactly 4 tests fail with the reported symptoms (both F12 cases, completion, signature help); restoring them passes. Full suite: **2426 passing, 0 failing, 4 pending** (pre-existing).

## Scope — what's deliberately left out

- **`PARENT.member` resolution.** `ClassMemberResolver.findMemberInParentChain`  resolves the parent class via `StructureDeclarationIndexer`, a project-wide index  a synthetic test document is never registered into. Live-tested in the real IDE  instead: confirmed **NOT colon-specific** — a colon-free control   (`PARENT.PlainData`) fails identically in shape to the colon case   (`PARENT.Master:DATA`), both for a class declared inside a procedure's own DATA   section. This points to `StructureDeclarationIndexer` not tracking procedure-local   CLASS declarations at all (only global/reusable ones) — a separate, more   architectural gap, filed on its own for later, not part of this PR.
- **Chained access (`SELF.Something.member`).** Verified this returns null on this   branch's base regardless of colons (a colon-free control on the exact same chain   shape fails identically) — not part of this defect family either. Dropped the test that would have asserted on it rather than claim a fix this PR doesn't   provide; some other, not-yet-upstream fix apparently covers chained hover.


