### PR TITLE
Fix/bare class self instance receiver

### DIFF
--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -1801,9 +1801,11 @@ export class MemberLocatorService {
         const isReference = idx + 1 < lineTokens.length && lineTokens[idx + 1].type === TokenType.ReferenceVariable;
 
         if (!typeStr || typeStr === 'UNKNOWN') {
+            // Bare local structure declaration, no `(TypeName)` argument: `Label CLASS ... END`,
+            // same shape as `Label QUEUE/GROUP/FILE ... END`. The label doubles as both the type
+            // and the single instance — use it as the navigable type name for all four alike.
             if (token.type === TokenType.Structure && token.label) {
                 const structureKeyword = token.value.toUpperCase();
-                if (structureKeyword === 'CLASS') return null;
                 return {
                     typeName: token.label,
                     isClass: structureKeyword === 'CLASS',
@@ -1814,12 +1816,12 @@ export class MemberLocatorService {
                 const structureToken = lineTokens.find(t =>
                     t.type === TokenType.Structure &&
                     t.start > token.start &&
-                    ['QUEUE', 'GROUP', 'FILE'].includes(t.value.toUpperCase())
+                    ['CLASS', 'QUEUE', 'GROUP', 'FILE'].includes(t.value.toUpperCase())
                 );
                 if (structureToken) {
                     return {
                         typeName: token.value,
-                        isClass: false,
+                        isClass: structureToken.value.toUpperCase() === 'CLASS',
                         isReference
                     };
                 }
@@ -1846,7 +1848,6 @@ export class MemberLocatorService {
             // Use its own label as navigable structure name for chained lookups.
             if (token.type === TokenType.Structure && token.label) {
                 const structureKeyword = typeStr.toUpperCase();
-                if (structureKeyword === 'CLASS') return null;
                 return {
                     typeName: token.label,
                     isClass: structureKeyword === 'CLASS',
@@ -1857,7 +1858,7 @@ export class MemberLocatorService {
                 const structureToken = lineTokens.find(t =>
                     t.type === TokenType.Structure &&
                     t.start > token.start &&
-                    ['QUEUE', 'GROUP', 'FILE'].includes(t.value.toUpperCase())
+                    ['CLASS', 'QUEUE', 'GROUP', 'FILE'].includes(t.value.toUpperCase())
                 );
                 if (structureToken) {
                     const structureKeyword = structureToken.value.toUpperCase();

--- a/server/src/test/MemberLocatorService.test.ts
+++ b/server/src/test/MemberLocatorService.test.ts
@@ -169,12 +169,14 @@ suite('MemberLocatorService', () => {
             assert.strictEqual(result!.isClass, true);
         });
 
-        test('bare CLASS keyword → null (no named type arg)', async () => {
+        test('bare CLASS keyword (no named type arg) → self as navigable type, same as bare QUEUE/GROUP/FILE', async () => {
             const doc = makeDoc('rv5.clw', 'LocalCls  CLASS\n  Foo PROCEDURE()\nEND\n');
             const tokens = tokenCache.getTokens(doc);
             const result = await service.resolveVariableType('LocalCls', tokens, doc);
 
-            assert.strictEqual(result, null, 'Bare CLASS should return null');
+            assert.ok(result, 'Bare CLASS should resolve to its own label, mirroring bare QUEUE/GROUP/FILE');
+            assert.strictEqual(result!.typeName, 'LocalCls');
+            assert.strictEqual(result!.isClass, true);
         });
 
         test('PROCEDURE type → null (not a class member target)', async () => {
@@ -478,6 +480,24 @@ suite('MemberLocatorService', () => {
             const result = await service.resolveDotAccess('myWidget', 'Width', doc);
 
             assert.ok(result, 'Should resolve myWidget.Width when declared as CLASS(WidgetClass)');
+            assert.ok(result!.type.toUpperCase().includes('LONG'));
+        });
+
+        test('resolves bare local CLASS self-instance (no ,TYPE, no separate instance var) → member', async () => {
+            // `Label CLASS ... END` with no ,TYPE and no separate `obj Label` declaration:
+            // the label doubles as both the class and its single instance, same shape as a
+            // bare `Label QUEUE/GROUP/FILE ... END` local — this is resolveDotAccess, the
+            // documented entry point for hover/F12/Ctrl+F12, so this pins that all three
+            // now see this receiver shape, not just resolveVariableType in isolation.
+            const docContent = [
+                'MyOwn:CLASS CLASS',
+                'My:My:Method  PROCEDURE(), LONG',
+                '            END',
+            ].join('\n');
+            const doc = makeDoc('da_bareclass.clw', docContent);
+            const result = await service.resolveDotAccess('MyOwn:CLASS', 'My:My:Method', doc);
+
+            assert.ok(result, 'Should resolve MyOwn:CLASS.My:My:Method on a bare self-instance CLASS');
             assert.ok(result!.type.toUpperCase().includes('LONG'));
         });
 

--- a/server/src/test/ReturnValueDiagnostics.BareClassSelfInstance.test.ts
+++ b/server/src/test/ReturnValueDiagnostics.BareClassSelfInstance.test.ts
@@ -1,0 +1,101 @@
+/**
+ * validateDiscardedReturnValues — bare local CLASS self-instance receiver.
+ *
+ * `Label CLASS ... END` with no `,TYPE` and no separate instance variable — the
+ * label doubles as both the class and its single instance, exactly like a bare
+ * `Label QUEUE/GROUP/FILE ... END` local. The compiler warns "Calling function
+ * as procedure" on a discarded non-PROC return through this receiver just like
+ * any other; the extension previously stayed silent because
+ * MemberLocatorService.extractTypeFromToken returned null for a bare CLASS
+ * specifically (QUEUE/GROUP/FILE already resolved to themselves).
+ *
+ * The real-world repro that surfaced this also had colons in the receiver AND
+ * method names (`MyOwn:CLASS.My:My:Method()`) — that half is a SEPARATE fix
+ * (DOTCALL_PREFIX in ReturnValueDiagnostics.ts, `fix/discarded-return-colon-receiver`,
+ * not part of this branch) and isn't exercisable end-to-end here alone, since
+ * without it the line never matches DOTCALL_PREFIX regardless of this fix. The
+ * plain-name test below proves this CLASS fix end-to-end through the real
+ * diagnostic; `MemberLocatorService.test.ts`'s
+ * "resolves bare local CLASS self-instance ... → member" pins the colon-named
+ * case directly at the resolveDotAccess layer (hover/F12/Ctrl+F12's own entry
+ * point), bypassing DOTCALL_PREFIX. Once both PRs land, the colon+bare-CLASS
+ * combo works through the full pipeline too — confirmed manually, not repeated
+ * here as an automated test to avoid a cross-branch test dependency.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MemberLocatorService } from '../services/MemberLocatorService';
+import { validateDiscardedReturnValues } from '../providers/diagnostics/ReturnValueDiagnostics';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function createDoc(filename: string, code: string): TextDocument {
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, code);
+    const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+    return TextDocument.create(uri, 'clarion', 1, code);
+}
+
+suite('ReturnValueDiagnostics — bare local CLASS self-instance receiver', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvdBareClass_'));
+    });
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+    teardown(() => TokenCache.getInstance().clearAllTokens());
+
+    const discarded = (diags: { message: string }[]) =>
+        diags.filter(d => /is discarded/.test(d.message));
+
+    test('plain-name repro (no colons anywhere) — full pipeline, end to end', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'MyClass CLASS',
+            'Method  PROCEDURE(), LONG',
+            '      END',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  MyClass.Method()',
+        ].join('\n');
+        const doc = createDoc('rvdBareClassPlain.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        const warns = discarded(diags);
+        assert.strictEqual(warns.length, 1,
+            `plain-name bare CLASS self-instance must warn too — confirms the gap was never colon-specific; got: ${warns.map(w => w.message).join(' | ')}`);
+        assert.ok(warns[0].message.includes("'MyClass.Method'"));
+    });
+
+    test('PROC-attributed method on a bare CLASS self-instance stays silent', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'MyClass CLASS',
+            'Method  PROCEDURE(), LONG, PROC',
+            '      END',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  MyClass.Method()',
+        ].join('\n');
+        const doc = createDoc('rvdBareClassProc.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        assert.strictEqual(discarded(diags).length, 0, 'PROC-attributed method must not warn');
+    });
+});


### PR DESCRIPTION
# fix(hover,definition,references,diagnostics): bare local CLASS self-instance never resolves as a dot-call receiver

Confirmed working end-to-end: the discarded-return-value diagnostic now correctly fires on a
bare-CLASS-self-instance dot-call, where it used to silently skip. Full suite 2488 passing / 0
failing on this clean branch (was bundled with an unrelated fix during earlier WIP; split out
cleanly before push).

## What happened

A local `CLASS` declared with no `,TYPE` and no separate instance variable — the label doubles as
both the class and its single instance, exactly like a bare `QUEUE`/`GROUP`/`FILE` local — never
resolves as a navigable receiver for hover, F12/definition, Ctrl+F12/implementation, completion,
signature help, or the discarded-return-value diagnostic:

```clarion
MyClass CLASS
Method  PROCEDURE(), LONG
      END

Caller PROCEDURE()
  CODE
  MyClass.Method()   ! compiler warns "Calling function as procedure" — every LSP feature is blind to this receiver
```

Confirmed colon-independent (unlike the sibling `fix/discarded-return-colon-receiver` PR) — this
reproduces identically with or without `:` in the names.

**Not affected:** the extremely common `ThisWindow CLASS(WindowManager)` window-procedure pattern —
that's the explicit-base-class form (`CLASS(TypeName)`), handled by a different, always-correct
branch of the same function. This gap is specifically the *no-parens-at-all* bare form.

## Root cause

`MemberLocatorService.extractTypeFromToken` resolves a bare local structure declaration (no
`(TypeName)` argument) to its own label as a navigable type — for `QUEUE`/`GROUP`/`FILE` only.
`CLASS` was excluded in four places inside the same function (two `if (structureKeyword === 'CLASS')
return null` guards, and two `['QUEUE','GROUP','FILE'].includes(...)` allowlists that silently
excluded CLASS from a lookahead match). Traced to commit `45104d4` ("Fix nested queue/group chain
completion", 2026-07-05), which extended self-instance resolution from "always null" to cover
QUEUE/GROUP/FILE — CLASS was left out, and a test was written at the time
(`MemberLocatorService.test.ts`, April 2026, predates that commit) that pins the old
"bare CLASS → null" behavior, which is why this wasn't just an oversight to grep for: it was an
explicitly tested contract.

## Fix

Mirror the QUEUE/GROUP/FILE branches for CLASS in all four spots — remove the two early-return
guards, and add `'CLASS'` to the two `.includes(...)` allowlists (computing `isClass` from the
matched keyword instead of hardcoding `false`). Net diff: 3 lines removed, 2 lines changed, in one
function.

## Implications for other functionality (why this took investigation, not just a grep)

`extractTypeFromToken` is the single choke point for `resolveVariableType`, which in turn feeds
`resolveDotAccess` — documented in-source as *"the primary entry point for hover, F12, and Ctrl+F12
dot-access lookups."* Production callers of `resolveVariableType` alone span 8 files:
`CompletionProvider`, `DefinitionProvider` (×2 call sites), `ReturnValueDiagnostics`,
`StructureFieldResolver` (hover), `ImplementationProvider`, `SignatureHelpProvider`,
`ArgumentTypeResolver`, `ChainedPropertyResolver`. This fix is a net-new capability for all of them
on this one receiver shape — previously they all silently did nothing.

Risk was that the QUEUE/GROUP/FILE precedent might have a CLASS-specific reason to differ (member
scanning gated on `,TYPE` somehow, name collisions, etc.) — checked: `findMemberInClass` /
`enumerateMembersInClass` (the class-body scanners) have no `,TYPE` dependency anywhere, so member
enumeration for a bare-instance CLASS works identically to a `,TYPE`-declared one once the receiver
resolves. Confirmed by testing, not just reading: full clean-rebuild suite (`rm -rf out && tsc -b
--force`, avoiding the stale-`out/`-artifact trap noted below) is **2421 passing, 4 pending, 0
failing** — zero regressions across hover/definition/references/completion/etc.

## Testing

- `MemberLocatorService.test.ts`: flipped the pinned `'bare CLASS keyword → null'` test to assert
  the new resolved-to-self behavior (matching the QUEUE/GROUP/FILE sibling tests already there);
  added a `resolveDotAccess` end-to-end test (the actual hover/F12/Ctrl+F12 entry point) using the
  real colon-named repro shape (`MyOwn:CLASS.My:My:Method`) — passes standalone here since
  `resolveDotAccess` doesn't go through `ReturnValueDiagnostics`' `DOTCALL_PREFIX` regex.
- New `ReturnValueDiagnostics.BareClassSelfInstance.test.ts`: plain-name repro warns end-to-end
  through the real diagnostic; PROC-attributed method on the same receiver shape stays silent.
  The colon-named RVD-level case is *not* repeated here — it depends on the sibling
  `fix/discarded-return-colon-receiver` PR's `DOTCALL_PREFIX` widening too (verified manually by
  combining both diffs locally: the exact original repro
  `MyOwn:CLASS.My:My:Method()` produces the correct single warning once both land — not committed
  as an automated test to avoid a cross-branch test dependency).

`npx tsc -b`: clean. Full clean-rebuild suite: 2421 passing, 4 pending, 0 failing.

## Scope

One source file (`MemberLocatorService.ts`), two test files (one modified, one new). No other
files touched.

