### PR TITLE
Fix/local derived method hover mismatch

### DIFF
--- a/server/src/providers/hover/MethodHoverResolver.ts
+++ b/server/src/providers/hover/MethodHoverResolver.ts
@@ -222,25 +222,37 @@ export class MethodHoverResolver {
         // Count parameters in the declaration
         const paramCount = this.overloadResolver.countParametersInDeclaration(line);
 
-        // Issue #233 (Rule 4) fast path: a procedure-local CLASS's method implementation
-        // is bound to its declaring procedure via `declaringProcedureLine` (stamped by
-        // DocumentStructure.linkLocalDerivedMethodsPass()). The name-only search below
-        // (findMethodImplementationCrossFile → searchFileForImplementation) matches
-        // purely on ClassName.MethodName text and can't tell apart the same local class
-        // name reused in a different procedure elsewhere in the file — this link already
-        // resolved that ambiguity deterministically at index time, so prefer it.
-        const localImplLocation = this.findLocalDerivedMethodImplementation(
-            methodTokens, classToken, className, currentToken.label, document
-        );
+        // Issue #233 (Rule 4): for a procedure-local CLASS, the language itself fixes where
+        // the implementation lives — immediately after the declaring procedure, before the
+        // next PROCEDURE — and DocumentStructure.linkLocalDerivedMethodsPass() has already
+        // bound it via `declaringProcedureLine`. So for such a class that link is not a
+        // "fast path", it is the ONLY correct answer: a miss means the implementation is
+        // genuinely absent, and falling back to the name-only search below would then match
+        // an unrelated same-named implementation in a different procedure (or, via the
+        // solution sweep, a different file entirely) — the exact ambiguity this link exists
+        // to resolve.
+        //
+        // `localClassTokens` (set by that same pass, on GlobalProcedure tokens only) is both
+        // the test for "is this a local class" and the declaring procedure itself — so ask
+        // the pass rather than re-deriving the ownership here. An unregistered class keeps
+        // the generic search unchanged.
+        const owningProcedure = methodTokens.find(t => t.localClassTokens?.includes(classToken));
 
-        // Search for implementation using cross-file lookup
-        const implLocation = localImplLocation ?? await this.findMethodImplementationCrossFile(
-            className,
-            currentToken.label,
-            document,
-            paramCount,
-            moduleFile
-        );
+        let implLocation: string | null;
+        if (owningProcedure) {
+            implLocation = this.findLocalDerivedMethodImplementation(
+                methodTokens, owningProcedure, className, currentToken.label, document, paramCount
+            );
+        } else {
+            // Search for implementation using cross-file lookup
+            implLocation = await this.findMethodImplementationCrossFile(
+                className,
+                currentToken.label,
+                document,
+                paramCount,
+                moduleFile
+            );
+        }
         
         if (implLocation) {
             logger.info(`✅ Found implementation at ${implLocation}`);
@@ -475,54 +487,41 @@ export class MethodHoverResolver {
     }
 
     /**
-     * Issue #233 (Rule 4): if `classToken` is a procedure-local CLASS, find the
-     * `Class.Method` implementation token bound to that SAME declaring procedure
-     * (via `declaringProcedureLine`) and return it as a `uri:line` location string.
-     * Returns null for module/global-scope classes (no enclosing procedure) or when
-     * no implementation has been linked to this exact declaring procedure yet.
+     * Issue #233 (Rule 4): the `Class.Method` implementation token bound to `owningProcedure`
+     * via `declaringProcedureLine`, as a `uri:line` location string. Null means the
+     * implementation is genuinely absent — the caller must NOT fall back to a name-based
+     * search, which cannot tell this class apart from a same-named local class in another
+     * procedure.
+     *
+     * `owningProcedure` comes from the class's own `localClassTokens` registration.
      */
     private findLocalDerivedMethodImplementation(
         tokens: Token[],
-        classToken: Token,
+        owningProcedure: Token,
         className: string,
         methodName: string,
-        document: TextDocument
+        document: TextDocument,
+        paramCount?: number
     ): string | null {
-        const owningProcedure = this.findEnclosingProcedureToken(tokens, classToken.line);
-        if (!owningProcedure) return null;
-
         const qualifiedName = `${className}.${methodName}`.toUpperCase();
-        const implToken = tokens.find(t =>
+        const candidates = tokens.filter(t =>
             t.subType === TokenType.MethodImplementation &&
             t.declaringProcedureLine === owningProcedure.line &&
             t.label?.toUpperCase() === qualifiedName
         );
-        if (!implToken) return null;
+        if (candidates.length === 0) {
+            logger.info(`[Rule 4] No implementation bound to declaring procedure at line ${owningProcedure.line} for ${qualifiedName}`);
+            return null;
+        }
+
+        // Overloads all bind to the same declaring procedure under the same qualified name —
+        // pick by arity, using the tokenizer's own parsed parameter list.
+        const implToken = (paramCount !== undefined
+            ? candidates.find(t => t.parameters?.length === paramCount)
+            : undefined) ?? candidates[0];
 
         logger.info(`✅ [Rule 4] Found local derived method implementation for ${qualifiedName} bound to declaring procedure at line ${owningProcedure.line}`);
         return `${document.uri}:${implToken.line}`;
-    }
-
-    /**
-     * Find the GlobalProcedure token whose body encloses `line` (nesting-aware,
-     * via `finishesAt` — same pattern as findClassTokenForMethodDeclaration).
-     */
-    private findEnclosingProcedureToken(tokens: Token[], line: number): Token | null {
-        for (let i = tokens.length - 1; i >= 0; i--) {
-            const token = tokens[i];
-
-            if (token.line > line) {
-                continue;
-            }
-
-            if (token.subType === TokenType.GlobalProcedure) {
-                if (token.finishesAt === undefined || line <= token.finishesAt) {
-                    return token;
-                }
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/server/src/providers/hover/MethodHoverResolver.ts
+++ b/server/src/providers/hover/MethodHoverResolver.ts
@@ -221,9 +221,20 @@ export class MethodHoverResolver {
         
         // Count parameters in the declaration
         const paramCount = this.overloadResolver.countParametersInDeclaration(line);
-        
+
+        // Issue #233 (Rule 4) fast path: a procedure-local CLASS's method implementation
+        // is bound to its declaring procedure via `declaringProcedureLine` (stamped by
+        // DocumentStructure.linkLocalDerivedMethodsPass()). The name-only search below
+        // (findMethodImplementationCrossFile → searchFileForImplementation) matches
+        // purely on ClassName.MethodName text and can't tell apart the same local class
+        // name reused in a different procedure elsewhere in the file — this link already
+        // resolved that ambiguity deterministically at index time, so prefer it.
+        const localImplLocation = this.findLocalDerivedMethodImplementation(
+            methodTokens, classToken, className, currentToken.label, document
+        );
+
         // Search for implementation using cross-file lookup
-        const implLocation = await this.findMethodImplementationCrossFile(
+        const implLocation = localImplLocation ?? await this.findMethodImplementationCrossFile(
             className,
             currentToken.label,
             document,
@@ -461,6 +472,57 @@ export class MethodHoverResolver {
         }
 
         return this.formatter.formatClassMember(fieldName, chainedInfo);
+    }
+
+    /**
+     * Issue #233 (Rule 4): if `classToken` is a procedure-local CLASS, find the
+     * `Class.Method` implementation token bound to that SAME declaring procedure
+     * (via `declaringProcedureLine`) and return it as a `uri:line` location string.
+     * Returns null for module/global-scope classes (no enclosing procedure) or when
+     * no implementation has been linked to this exact declaring procedure yet.
+     */
+    private findLocalDerivedMethodImplementation(
+        tokens: Token[],
+        classToken: Token,
+        className: string,
+        methodName: string,
+        document: TextDocument
+    ): string | null {
+        const owningProcedure = this.findEnclosingProcedureToken(tokens, classToken.line);
+        if (!owningProcedure) return null;
+
+        const qualifiedName = `${className}.${methodName}`.toUpperCase();
+        const implToken = tokens.find(t =>
+            t.subType === TokenType.MethodImplementation &&
+            t.declaringProcedureLine === owningProcedure.line &&
+            t.label?.toUpperCase() === qualifiedName
+        );
+        if (!implToken) return null;
+
+        logger.info(`✅ [Rule 4] Found local derived method implementation for ${qualifiedName} bound to declaring procedure at line ${owningProcedure.line}`);
+        return `${document.uri}:${implToken.line}`;
+    }
+
+    /**
+     * Find the GlobalProcedure token whose body encloses `line` (nesting-aware,
+     * via `finishesAt` — same pattern as findClassTokenForMethodDeclaration).
+     */
+    private findEnclosingProcedureToken(tokens: Token[], line: number): Token | null {
+        for (let i = tokens.length - 1; i >= 0; i--) {
+            const token = tokens[i];
+
+            if (token.line > line) {
+                continue;
+            }
+
+            if (token.subType === TokenType.GlobalProcedure) {
+                if (token.finishesAt === undefined || line <= token.finishesAt) {
+                    return token;
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/server/src/test/MethodHoverResolver.LocalDerivedMethodAmbiguity.test.ts
+++ b/server/src/test/MethodHoverResolver.LocalDerivedMethodAmbiguity.test.ts
@@ -1,0 +1,123 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+// Two adjacent procedures each declare their OWN procedure-local CLASS under the
+// same name, each with its own method implementation placed immediately after its
+// declaring procedure (the language's own placement rule for local/derived classes —
+// see ScopeResolver.LocalDerivedMethod.test.ts's TWO_SAME_NAME fixture, reused here).
+//
+// Hovering the method DECLARATION inside ProcA's class must resolve to ProcA's own
+// implementation (line 12), never ProcB's (line 24) and never "Implementation not
+// found" — MethodHoverResolver.findMethodImplementationCrossFile matches purely by
+// ClassName.MethodName text with no positional scoping, so on a real file where a
+// bare-name-only search can genuinely turn up zero or the wrong candidate, only the
+// declaringProcedureLine link (Issue #233 Rule 4) can disambiguate correctly.
+//
+//  0 PROGRAM
+//  1   MAP
+//  2   END
+//  4 ProcA PROCEDURE
+//  5 SharedName CLASS
+//  6 Run PROCEDURE
+//  7   END
+//  8 AVar LONG
+//  9   CODE
+// 10   AVar = 1
+// 12 SharedName.Run PROCEDURE
+// 13   CODE
+// 14   AVar = 2
+// 16 ProcB PROCEDURE
+// 17 SharedName CLASS
+// 18 Run PROCEDURE
+// 19   END
+// 20 BVar LONG
+// 21   CODE
+// 22   BVar = 1
+// 24 SharedName.Run PROCEDURE
+// 25   CODE
+// 26   BVar = 2
+const TWO_SAME_NAME = [
+    'PROGRAM',
+    '  MAP',
+    '  END',
+    '',
+    'ProcA PROCEDURE',
+    'SharedName CLASS',
+    'Run PROCEDURE',
+    '  END',
+    'AVar LONG',
+    '  CODE',
+    '  AVar = 1',
+    '',
+    'SharedName.Run PROCEDURE',
+    '  CODE',
+    '  AVar = 2',
+    '',
+    'ProcB PROCEDURE',
+    'SharedName CLASS',
+    'Run PROCEDURE',
+    '  END',
+    'BVar LONG',
+    '  CODE',
+    '  BVar = 1',
+    '',
+    'SharedName.Run PROCEDURE',
+    '  CODE',
+    '  BVar = 2',
+    ''
+].join('\n');
+
+suite('MethodHoverResolver — local derived method declaration hover, same class name reused across procedures', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('hovering the method declaration in ProcA\'s class resolves to ProcA\'s own implementation, not ProcB\'s and not "not found"', async () => {
+        const doc = TextDocument.create('test://two-same-name-a.clw', 'clarion', 1, TWO_SAME_NAME);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(6, 0)); // "Run" inside ProcA's SharedName CLASS
+        const content = hoverText(hover);
+
+        assert.ok(!content.includes('Implementation not found'),
+            `should resolve an implementation; got: ${content}`);
+        assert.ok(content.includes(':13'),
+            `should resolve to ProcA's own implementation at line 13 (1-based); got: ${content}`);
+        assert.ok(!content.includes(':25'),
+            `must NOT resolve to ProcB's implementation at line 25; got: ${content}`);
+    });
+
+    test('hovering the method declaration in ProcB\'s class resolves to ProcB\'s own implementation, not ProcA\'s', async () => {
+        const doc = TextDocument.create('test://two-same-name-b.clw', 'clarion', 1, TWO_SAME_NAME);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(18, 0)); // "Run" inside ProcB's SharedName CLASS
+        const content = hoverText(hover);
+
+        assert.ok(!content.includes('Implementation not found'),
+            `should resolve an implementation; got: ${content}`);
+        assert.ok(content.includes(':25'),
+            `should resolve to ProcB's own implementation at line 25 (1-based); got: ${content}`);
+        assert.ok(!content.includes(':13'),
+            `must NOT resolve to ProcA's implementation at line 13; got: ${content}`);
+    });
+});

--- a/server/src/test/MethodHoverResolver.LocalDerivedMethodAmbiguity.test.ts
+++ b/server/src/test/MethodHoverResolver.LocalDerivedMethodAmbiguity.test.ts
@@ -1,24 +1,34 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Position } from 'vscode-languageserver-protocol';
 import { HoverProvider } from '../providers/HoverProvider';
 import { TokenCache } from '../TokenCache';
 
-// Two adjacent procedures each declare their OWN procedure-local CLASS under the
-// same name, each with its own method implementation placed immediately after its
-// declaring procedure (the language's own placement rule for local/derived classes —
-// see ScopeResolver.LocalDerivedMethod.test.ts's TWO_SAME_NAME fixture, reused here).
+/**
+ * A procedure-local CLASS's method implementation must be resolved through the
+ * Issue #233 Rule 4 link (`Token.declaringProcedureLine`, stamped by
+ * DocumentStructure.linkLocalDerivedMethodsPass()), never by a name-only text search.
+ *
+ * The language fixes the placement: a local class's method is implemented immediately
+ * after its declaring procedure, before the next PROCEDURE. Nothing stops the same
+ * local class name being reused in another procedure in the same file, so a search
+ * matching purely on `ClassName.MethodName` text cannot tell those apart — it returns
+ * whichever it hits first.
+ *
+ * These fixtures live on REAL FILES on disk, deliberately: MethodHoverResolver's
+ * fallback (findMethodImplementationCrossFile → searchFileForImplementation) reads the
+ * document's path with `fs.readFileSync`, so an in-memory-only `test://` document makes
+ * that fallback fail with ENOENT and every assertion below would pass vacuously,
+ * proving nothing about which path produced the answer.
+ */
+
+// Two adjacent procedures, each declaring its OWN local class under the same name,
+// each with its own implementation placed immediately after it (shape borrowed from
+// ScopeResolver.LocalDerivedMethod.test.ts's TWO_SAME_NAME fixture).
 //
-// Hovering the method DECLARATION inside ProcA's class must resolve to ProcA's own
-// implementation (line 12), never ProcB's (line 24) and never "Implementation not
-// found" — MethodHoverResolver.findMethodImplementationCrossFile matches purely by
-// ClassName.MethodName text with no positional scoping, so on a real file where a
-// bare-name-only search can genuinely turn up zero or the wrong candidate, only the
-// declaringProcedureLine link (Issue #233 Rule 4) can disambiguate correctly.
-//
-//  0 PROGRAM
-//  1   MAP
-//  2   END
 //  4 ProcA PROCEDURE
 //  5 SharedName CLASS
 //  6 Run PROCEDURE
@@ -26,7 +36,7 @@ import { TokenCache } from '../TokenCache';
 //  8 AVar LONG
 //  9   CODE
 // 10   AVar = 1
-// 12 SharedName.Run PROCEDURE
+// 12 SharedName.Run PROCEDURE   <- ProcA's own
 // 13   CODE
 // 14   AVar = 2
 // 16 ProcB PROCEDURE
@@ -36,7 +46,7 @@ import { TokenCache } from '../TokenCache';
 // 20 BVar LONG
 // 21   CODE
 // 22   BVar = 1
-// 24 SharedName.Run PROCEDURE
+// 24 SharedName.Run PROCEDURE   <- ProcB's own
 // 25   CODE
 // 26   BVar = 2
 const TWO_SAME_NAME = [
@@ -70,9 +80,66 @@ const TWO_SAME_NAME = [
     ''
 ].join('\n');
 
+// Same shape, except ProcA declares the method but never implements it, while ProcB's
+// same-named local class does implement its own. ProcA's declaration hover must report
+// the implementation as genuinely missing rather than borrowing ProcB's.
+//
+//  4 ProcA PROCEDURE
+//  5 SharedName CLASS
+//  6 Run PROCEDURE      <- declared, never implemented
+//  7   END
+//  8 AVar LONG
+//  9   CODE
+// 10   AVar = 1
+// 12 ProcB PROCEDURE
+// 13 SharedName CLASS
+// 14 Run PROCEDURE
+// 15   END
+// 16 BVar LONG
+// 17   CODE
+// 18   BVar = 1
+// 20 SharedName.Run PROCEDURE   <- ProcB's own, the tempting wrong answer
+// 21   CODE
+// 22   BVar = 2
+const MISSING_IN_A = [
+    'PROGRAM',
+    '  MAP',
+    '  END',
+    '',
+    'ProcA PROCEDURE',
+    'SharedName CLASS',
+    'Run PROCEDURE',
+    '  END',
+    'AVar LONG',
+    '  CODE',
+    '  AVar = 1',
+    '',
+    'ProcB PROCEDURE',
+    'SharedName CLASS',
+    'Run PROCEDURE',
+    '  END',
+    'BVar LONG',
+    '  CODE',
+    '  BVar = 1',
+    '',
+    'SharedName.Run PROCEDURE',
+    '  CODE',
+    '  BVar = 2',
+    ''
+].join('\n');
+
 suite('MethodHoverResolver — local derived method declaration hover, same class name reused across procedures', () => {
     let provider: HoverProvider;
     let tokenCache: TokenCache;
+    let tmpRoot: string;
+
+    suiteSetup(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'local-derived-hover-'));
+    });
+
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
 
     setup(() => {
         provider = new HoverProvider();
@@ -91,9 +158,18 @@ suite('MethodHoverResolver — local derived method declaration hover, same clas
             : 'value' in hover.contents ? hover.contents.value : '';
     }
 
-    test('hovering the method declaration in ProcA\'s class resolves to ProcA\'s own implementation, not ProcB\'s and not "not found"', async () => {
-        const doc = TextDocument.create('test://two-same-name-a.clw', 'clarion', 1, TWO_SAME_NAME);
+    /** Writes the fixture to a real file so the disk-reading fallback is genuinely reachable. */
+    function diskDoc(name: string, content: string): TextDocument {
+        const filePath = path.join(tmpRoot, name);
+        fs.writeFileSync(filePath, content, 'utf8');
+        const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+        const doc = TextDocument.create(uri, 'clarion', 1, content);
         tokenCache.getTokens(doc);
+        return doc;
+    }
+
+    test('hovering the method declaration in ProcA\'s class resolves to ProcA\'s own implementation, not ProcB\'s', async () => {
+        const doc = diskDoc('two-same-name-a.clw', TWO_SAME_NAME);
 
         const hover = await provider.provideHover(doc, Position.create(6, 0)); // "Run" inside ProcA's SharedName CLASS
         const content = hoverText(hover);
@@ -107,8 +183,7 @@ suite('MethodHoverResolver — local derived method declaration hover, same clas
     });
 
     test('hovering the method declaration in ProcB\'s class resolves to ProcB\'s own implementation, not ProcA\'s', async () => {
-        const doc = TextDocument.create('test://two-same-name-b.clw', 'clarion', 1, TWO_SAME_NAME);
-        tokenCache.getTokens(doc);
+        const doc = diskDoc('two-same-name-b.clw', TWO_SAME_NAME);
 
         const hover = await provider.provideHover(doc, Position.create(18, 0)); // "Run" inside ProcB's SharedName CLASS
         const content = hoverText(hover);
@@ -119,5 +194,17 @@ suite('MethodHoverResolver — local derived method declaration hover, same clas
             `should resolve to ProcB's own implementation at line 25 (1-based); got: ${content}`);
         assert.ok(!content.includes(':13'),
             `must NOT resolve to ProcA's implementation at line 13; got: ${content}`);
+    });
+
+    test('an unimplemented local class method reports a genuine miss, never borrowing another procedure\'s same-named implementation', async () => {
+        const doc = diskDoc('missing-in-a.clw', MISSING_IN_A);
+
+        const hover = await provider.provideHover(doc, Position.create(6, 0)); // "Run" inside ProcA's SharedName CLASS
+        const content = hoverText(hover);
+
+        assert.ok(!content.includes(':21'),
+            `must NOT borrow ProcB's implementation at line 21; got: ${content}`);
+        assert.ok(content.includes('Implementation not found'),
+            `ProcA never implements Run — the miss is genuine and must be reported as such; got: ${content}`);
     });
 });


### PR DESCRIPTION
# fix(hover): local-derived method declaration hover ignored declaringProcedureLine

## What happened

For a procedure-local `CLASS` (bare local class — no `,TYPE`, single self-instance), hovering a
method **declaration** resolves the implementation purely by `ClassName.MethodName` **text**,
scanning the whole file — and then other files — with no positional scoping. Reusing a generic
local class name across procedures in the same file (a common convention for small procedure-scoped
helpers) makes those candidates indistinguishable to a name-only search:

```clarion
ProcA PROCEDURE
SharedName CLASS
Run PROCEDURE
  END
  CODE
  ! ...

SharedName.Run PROCEDURE   ! ProcA's own implementation
  CODE
  ! ...

ProcB PROCEDURE
SharedName CLASS            ! unrelated class, same name, different procedure
Run PROCEDURE
  END
  CODE
  ! ...

SharedName.Run PROCEDURE   ! ProcB's own implementation
  CODE
  ! ...
```

Hovering `Run` inside `ProcB`'s `SharedName CLASS` must resolve to `ProcB`'s own implementation —
never `ProcA`'s, and never "not found".

Against real on-disk files, the current behaviour is demonstrably **wrong answers**, not merely a
failure to find:

| Scenario | Current | Correct |
|---|---|---|
| `ProcB`'s declaration, `ProcA` declares the same class name earlier | resolves to **ProcA's** implementation | ProcB's own |
| `ProcA` declares the method but never implements it; `ProcB` implements its own | resolves to **ProcB's** implementation | genuinely missing |

(The originally-reported live symptom was `⚠️ Implementation not found` — a third manifestation of
the same missing-positional-scoping cause.)

## Root cause

`MethodHoverResolver.resolveMethodDeclaration` resolves through
`findMethodImplementationCrossFile` → `searchFileForImplementation`, a flat regex scan matching
`ClassName.MethodName` with no notion of which procedure the class belongs to.

Clarion itself fixes the placement — a procedure-local class's method is implemented immediately
after its declaring procedure, before the next `PROCEDURE` — and
`DocumentStructure.linkLocalDerivedMethodsPass()` (Issue #233 Rule 4) **already** encodes exactly
that, binding every `MethodImplementation` token to its nearest-preceding declaring procedure via
`Token.declaringProcedureLine`. `MethodHoverResolver` never consulted this link.

## Fix

For a class that Rule 4 has **registered** as procedure-local, resolve the implementation solely
through that link; otherwise leave the existing generic search untouched.

`findLocalDerivedMethodImplementation` looks up the `MethodImplementation` token bound to the
owning procedure via `declaringProcedureLine` with a matching qualified label, disambiguating
overloads by arity using the tokenizer's own parsed parameter list.

**The link is used exclusively, not as a fast path.** For a registered local class, a miss means
the implementation is genuinely absent, so hover reports that. Falling back to the name-only search
there would reintroduce precisely the ambiguity the link exists to resolve — it would answer with
some other procedure's same-named implementation, which is strictly worse than saying "not found".

**Ownership comes from the pass, not from a re-derivation.** `localClassTokens` — set by
`linkLocalDerivedMethodsPass` on `GlobalProcedure` tokens only — is simultaneously the test for "is
this a procedure-local class" and the declaring procedure itself, so
`methodTokens.find(t => t.localClassTokens?.includes(classToken))` answers both in one lookup. An
earlier revision scanned for an enclosing procedure via `finishesAt` and then cross-checked the
registration; asking the pass directly is both simpler and immune to the two notions of "enclosing"
drifting apart.

Ordinary module/global classes and `MODULE()`-attributed cross-file classes are untouched: their
implementation tokens never carry `declaringProcedureLine`, and the enclosing-procedure lookup
returns null when the class isn't inside a procedure at all.

## Testing

New `MethodHoverResolver.LocalDerivedMethodAmbiguity.test.ts`, built on the `TWO_SAME_NAME` fixture
shape from `ScopeResolver.LocalDerivedMethod.test.ts` (two procedures, each with its own same-named
local class):

1. `ProcA`'s declaration → ProcA's own implementation.
2. `ProcB`'s declaration → ProcB's own implementation. **Fails on baseline** (returns ProcA's).
3. Method declared in `ProcA` but never implemented, while `ProcB` implements its own → reported as
   genuinely missing. **Fails on baseline** (borrows ProcB's).

**Fixtures are written to real files on disk, deliberately.** `searchFileForImplementation` reads
the document's path with `fs.readFileSync`, so an in-memory-only `test://` document makes the
fallback fail with ENOENT and every assertion passes vacuously — proving nothing about which path
produced the answer. Verified against the true pre-fix baseline (`origin/version-1.0.2` at the
time; content-identical up through this point in `version-1.0.3`, which only added dependency and
version-bump commits): 1 passing, 2
failing, with the failures showing the concrete wrong line numbers above.

Full suite after the fix: `npx tsc -b && npx mocha` → 2501 passing, 4 pending, 0 failing.

## Scope

One source file (`MethodHoverResolver.ts`), one new test file. No other files touched.

## Note on an existing test that could not have caught this

`HoverProvider.StandaloneProcAfterIndentedLocalClass.test.ts`'s "hovering the method declaration
INSIDE the local CLASS still resolves to that CLASS" asserts only `content.includes('Owner')` —
which is also true of the `⚠️ Implementation not found` fallback message, since that includes the
class name too. So it passes whether or not an implementation was found. Left alone here (out of
scope), but worth tightening.
