### PR TITLE
fix(tokenizer): method implementation misclassified when its qualified name contains colons

### DIFF
--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -1997,9 +1997,14 @@ export class DocumentStructure {
         let isMethodImpl = false;
         let fullProcedureName = prevToken?.value ?? "AnonymousProcedure";
         
-        // Check if prevToken is a label, variable, attribute, or structure field that might be part of a method name
+        // Check if prevToken is a label, variable, attribute, or structure field that might be part of a method name.
+        // StructurePrefix counts too: a method name carrying a SINGLE colon (e.g. `Free:qLegend` in
+        // `GraphLegendClass.Free:qLegend PROCEDURE`) is captured whole by StructurePrefix's
+        // `Prefix:Field` pattern, so it arrives here as the prevToken. Without it such a line never
+        // enters this block at all and falls through to GlobalProcedure named just the colon segment.
         if (prevToken?.type === TokenType.Label || prevToken?.type === TokenType.Variable ||
-            prevToken?.type === TokenType.Attribute || prevToken?.type === TokenType.StructureField) {
+            prevToken?.type === TokenType.Attribute || prevToken?.type === TokenType.StructureField ||
+            prevToken?.type === TokenType.StructurePrefix) {
             // Check if the previous token contains dots (entire qualified name in one token)
             if (prevToken.value.includes(".")) {
                 // The previous token itself contains dots (e.g., "IConnection.CloseSocket" for 3-part)

--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -2015,27 +2015,48 @@ export class DocumentStructure {
                 // Build the full name by looking back at previous tokens on the same line
                 // Collect all tokens before PROCEDURE that are part of the qualified name
                 const nameParts: string[] = [prevToken.value];
+                let segmentStart = prevToken.start;
                 let lookbackIndex = index - 2;
-                
+
+                const isNamePartToken = (t: Token) =>
+                    t.type === TokenType.Label || t.type === TokenType.Variable ||
+                    t.type === TokenType.Attribute || t.type === TokenType.StructurePrefix;
+
                 // Look back to collect ClassName.InterfaceName.MethodName pattern
                 while (lookbackIndex >= 0) {
                     const lookbackToken = this.tokens[lookbackIndex];
-                    
+
                     // Stop if we're on a different line
                     if (lookbackToken.line !== token.line) break;
-                    
-                    // Stop if we hit a non-name token
-                    if (lookbackToken.type !== TokenType.Label && 
-                        lookbackToken.type !== TokenType.Variable && 
-                        lookbackToken.type !== TokenType.Attribute) {
+
+                    // A bare ':' immediately touching the segment being built continues a
+                    // chained colon-qualified identifier (e.g. "My:My:Method") rather than
+                    // ending the name. StructurePrefix's own pattern only captures ONE colon
+                    // segment ("Prefix:Field"), so a second colon in the chain gets tokenized
+                    // as a stray Delimiter — glue it (and the piece before it) back onto the
+                    // segment instead of letting it stop the walk.
+                    if (lookbackToken.type === TokenType.Delimiter && lookbackToken.value === ':' &&
+                        lookbackToken.start + 1 === segmentStart) {
+                        const before = lookbackIndex >= 1 ? this.tokens[lookbackIndex - 1] : undefined;
+                        if (before && before.line === token.line && isNamePartToken(before) &&
+                            before.start + before.value.length === lookbackToken.start) {
+                            nameParts[0] = before.value + ':' + nameParts[0];
+                            segmentStart = before.start;
+                            lookbackIndex -= 2;
+                            continue;
+                        }
                         break;
                     }
-                    
+
+                    // Stop if we hit a non-name token
+                    if (!isNamePartToken(lookbackToken)) break;
+
                     // Add this part to the beginning
                     nameParts.unshift(lookbackToken.value);
+                    segmentStart = lookbackToken.start;
                     lookbackIndex--;
                 }
-                
+
                 // If we collected more than one part, it's a method implementation
                 if (nameParts.length > 1) {
                     fullProcedureName = nameParts.join('.');

--- a/server/src/test/DocumentStructure.ChainedColonMethodImplementation.test.ts
+++ b/server/src/test/DocumentStructure.ChainedColonMethodImplementation.test.ts
@@ -71,6 +71,38 @@ const CHAINED_COLON_METHOD = [
     ''
 ].join('\n');
 
+// The SINGLE-colon variant, which fails by a different mechanism. With one colon the whole
+// trailing name is captured by StructurePrefix's own `Prefix:Field` pattern, so it arrives as
+// the prevToken — and the outer guard admitted only Label/Variable/Attribute/StructureField,
+// so the line never entered the name-reconstruction block at all.
+//
+// Real shape, from Clarion's own shipped LibSrc/win/svgraph.clw (8 occurrences there):
+//   GraphLegendClass.Free:qLegend      procedure
+//
+//  0 PROGRAM
+//  1   MAP
+//  2   END
+//  4 GraphLegendClass CLASS
+//  5 Free:qLegend PROCEDURE
+//  6       END
+//  8 GraphLegendClass.Free:qLegend      procedure
+//  9   CODE
+// 10   RETURN
+const SINGLE_COLON_METHOD = [
+    'PROGRAM',
+    '  MAP',
+    '  END',
+    '',
+    'GraphLegendClass CLASS',
+    'Free:qLegend PROCEDURE',
+    '      END',
+    '',
+    'GraphLegendClass.Free:qLegend      procedure',
+    '  CODE',
+    '  RETURN',
+    ''
+].join('\n');
+
 suite('DocumentStructure — chained colon-qualified method implementation name', () => {
     test('the implementation line is tagged MethodImplementation with the full qualified label', () => {
         const tokens = build(CHAINED_COLON_METHOD);
@@ -93,5 +125,36 @@ suite('DocumentStructure — chained colon-qualified method implementation name'
         const declaringProc = tokens.find(t => t.subType === TokenType.GlobalProcedure && t.label === 'Caller');
         assert.ok(declaringProc, 'expected the declaring procedure token');
         assert.strictEqual(implToken!.declaringProcedureLine, declaringProc!.line);
+    });
+
+    test('a SINGLE-colon method name (whole name captured as StructurePrefix) is also a method implementation', () => {
+        const tokens = build(SINGLE_COLON_METHOD);
+
+        const implToken = tokens.find(t => t.line === 8 && t.type === TokenType.Procedure);
+        assert.ok(implToken, 'expected a Procedure token on the implementation line');
+        assert.strictEqual(implToken!.subType, TokenType.MethodImplementation,
+            `expected MethodImplementation, got ${implToken!.subType === TokenType.GlobalProcedure ? 'GlobalProcedure' : implToken!.subType}`);
+        assert.strictEqual(implToken!.label, 'GraphLegendClass.Free:qLegend');
+    });
+
+    test('a standalone global procedure whose own name carries colons stays a global procedure', () => {
+        // Guards the outer-guard widening: at column 0 the whole colon-bearing name is a Label
+        // (Label's pattern allows colons), so there is no class prefix to collect and nothing
+        // should promote this to a method implementation.
+        const tokens = build([
+            'PROGRAM',
+            '  MAP',
+            '  END',
+            '',
+            'My:Global:Proc PROCEDURE()',
+            '  CODE',
+            '  RETURN',
+            ''
+        ].join('\n'));
+
+        const procToken = tokens.find(t => t.line === 4 && t.type === TokenType.Procedure);
+        assert.ok(procToken, 'expected a Procedure token');
+        assert.strictEqual(procToken!.subType, TokenType.GlobalProcedure,
+            'a colon-bearing standalone procedure name must NOT be read as a class method');
     });
 });

--- a/server/src/test/DocumentStructure.ChainedColonMethodImplementation.test.ts
+++ b/server/src/test/DocumentStructure.ChainedColonMethodImplementation.test.ts
@@ -1,0 +1,97 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { Token, TokenType } from '../tokenizer/TokenTypes';
+
+/**
+ * A procedure-local CLASS whose method name is itself a chained colon-qualified
+ * identifier with MORE THAN ONE colon (e.g. `My:My:Method`) is misclassified when
+ * IMPLEMENTED — `ClassName.My:My:Method PROCEDURE()` — as an ordinary global procedure
+ * named just the last identifier segment, rather than as that class's method
+ * implementation.
+ *
+ * Root cause: `StructurePrefix`'s pattern (TokenPatterns.ts) captures only ONE colon
+ * segment ("Prefix:Field"). For `My:My:Method` it grabs `My:My` and strands the second
+ * colon as a bare `Delimiter` token. DocumentStructure.handleProcedureToken's backward
+ * walk (reconstructing the qualified name before a PROCEDURE keyword) stops at the
+ * first token whose type isn't Label/Variable/Attribute — so it stops at that stray
+ * Delimiter and never sees the class name at all.
+ *
+ * The SAME identifier as a bare DECLARATION (no preceding "ClassName." to confuse the
+ * walk) tokenizes correctly as one Label — this bug is specific to the *implementation*
+ * line's backward-reconstruction.
+ *
+ * Note: this bug predates and is independent of the local-derived-method hover fix
+ * (declaringProcedureLine / Issue #233 Rule 4) — it was masked there by a name-only
+ * text-based fallback search that doesn't depend on correct tokenization. Once that
+ * fallback is removed for a registered local class (as that fix does), a class using
+ * this naming shape loses ITS masking too, which is how this was found.
+ */
+function createTestDocument(content: string, uri: string = 'file:///chained-colon-method.clw'): TextDocument {
+    return TextDocument.create(uri, 'clarion', 1, content);
+}
+
+function build(content: string): Token[] {
+    const cache = TokenCache.getInstance();
+    cache.clearAllTokens();
+    return cache.getTokens(createTestDocument(content));
+}
+
+// 0 PROGRAM
+// 1   MAP
+// 2   END
+// 4 Caller PROCEDURE()
+// 6 MyOwn1:CLASS CLASS
+// 7 My:My:Method  PROCEDURE(), LONG
+// 8       END
+// 10   CODE
+// 11   MyOwn1:CLASS.My:My:Method()
+// 12   RETURN
+// 14 MyOwn1:CLASS.My:My:Method PROCEDURE()
+// 15   CODE
+// 16   RETURN(1)
+const CHAINED_COLON_METHOD = [
+    'PROGRAM',
+    '  MAP',
+    '  END',
+    '',
+    'Caller PROCEDURE()',
+    '',
+    'MyOwn1:CLASS CLASS',
+    'My:My:Method  PROCEDURE(), LONG',
+    '      END',
+    '',
+    '  CODE',
+    '  MyOwn1:CLASS.My:My:Method()',
+    '  RETURN',
+    '',
+    'MyOwn1:CLASS.My:My:Method PROCEDURE()',
+    '  CODE',
+    '  RETURN(1)',
+    ''
+].join('\n');
+
+suite('DocumentStructure — chained colon-qualified method implementation name', () => {
+    test('the implementation line is tagged MethodImplementation with the full qualified label', () => {
+        const tokens = build(CHAINED_COLON_METHOD);
+
+        const implToken = tokens.find(t => t.line === 14 && t.type === TokenType.Procedure);
+        assert.ok(implToken, 'expected a Procedure token on the implementation line');
+        assert.strictEqual(implToken!.subType, TokenType.MethodImplementation,
+            `expected MethodImplementation, got ${implToken!.subType === TokenType.GlobalProcedure ? 'GlobalProcedure' : implToken!.subType}`);
+        assert.strictEqual(implToken!.label, 'MyOwn1:CLASS.My:My:Method');
+    });
+
+    test('declaringProcedureLine still links the implementation to its declaring procedure once classified correctly', () => {
+        const tokens = build(CHAINED_COLON_METHOD);
+
+        const implToken = tokens.find(t =>
+            t.subType === TokenType.MethodImplementation &&
+            t.label?.toUpperCase() === 'MYOWN1:CLASS.MY:MY:METHOD');
+        assert.ok(implToken, 'expected the implementation to be registered as a MethodImplementation token');
+
+        const declaringProc = tokens.find(t => t.subType === TokenType.GlobalProcedure && t.label === 'Caller');
+        assert.ok(declaringProc, 'expected the declaring procedure token');
+        assert.strictEqual(implToken!.declaringProcedureLine, declaringProc!.line);
+    });
+});


### PR DESCRIPTION
# fix(tokenizer): method implementation misclassified when its qualified name contains colons

Independent of #444 (`fix/local-derived-method-hover-mismatch`) and lands on its own, in either
order — though #444 is how this one surfaced (see "How this was found").

Two commits, one per failure mode: method names with **two or more** colons (`My:My:Method`), and
method names with **exactly one** (`Free:qLegend`). They break by different mechanisms and are
described separately below; the second also fixes 8 occurrences in Clarion's own shipped
`LibSrc/win/svgraph.clw`.

## What happened

A procedure-local `CLASS` whose method name is itself a chained colon-qualified identifier — more
than one colon, e.g. `My:My:Method` — is misclassified when **implemented**:

```clarion
Caller PROCEDURE()

MyOwn1:CLASS CLASS
My:My:Method  PROCEDURE(), LONG
      END
  CODE
  MyOwn1:CLASS.My:My:Method()
  RETURN

MyOwn1:CLASS.My:My:Method PROCEDURE()   ! ← classified as a GLOBAL PROCEDURE named "Method"
  CODE
  RETURN(1)
```

The implementation line gets `subType = GlobalProcedure` with `label = "Method"`, instead of
`subType = MethodImplementation` with `label = "MyOwn1:CLASS.My:My:Method"`. The same identifier as
a bare **declaration** (line 4 above) tokenizes correctly as a single `Label` — the bug is specific
to reconstructing the qualified name on the *implementation* line.

Anything reading `MethodImplementation` subtype or label for such a method is affected —
references, go-to-implementation, rename, signature help, and Issue #233 Rule 4's
`declaringProcedureLine` linking itself (which only visits `MethodImplementation` tokens, so these
methods were never linked to their declaring procedure at all).

## Root cause

Two things compound:

1. `StructurePrefix`'s pattern (`TokenPatterns.ts:102`) captures exactly ONE colon segment — its
   trailing component is `[A-Za-z_][A-Za-z0-9_]*`, with no colon. Against `My:My:Method` it matches
   `My:My` and stops, stranding the second colon, which `Delimiter` (whose class does include `:`)
   then picks up as a bare token. `Variable` can't do better — its pattern excludes colons too, and
   `Label` is only tried at the start of a line. So the tokens are:

   ```
   Label("MyOwn1:CLASS")  StructurePrefix("My:My")  Delimiter(":")  Variable("Method")  PROCEDURE
   ```

2. `DocumentStructure.handleProcedureToken` reconstructs the qualified name by walking backward from
   the `PROCEDURE` keyword collecting `Label`/`Variable`/`Attribute` tokens, stopping at the first
   token of any other type. It starts at `Variable("Method")`, steps back onto the stray
   `Delimiter(":")`, and stops — never reaching `StructurePrefix("My:My")` (not an accepted type
   either) or `Label("MyOwn1:CLASS")`. With only one name part collected, `isMethodImpl` stays
   false.

## Fix

In that backward walk: when the token met is a bare `:` **immediately touching** the segment being
built, and the token before it is a valid name-part type **immediately touching** the colon in
turn, glue both back onto the current segment as a continued colon-qualified identifier rather than
stopping. `StructurePrefix` is added to the accepted name-part types, since that is what the first
half of a truncated chain lands as.

The adjacency requirements (`before.start + before.value.length === colon.start`,
`colon.start + 1 === segmentStart`) keep this from absorbing a genuinely separate `:` that merely
happens to precede the name — only characters that were contiguous in the source get rejoined.

Scoped deliberately to `DocumentStructure`'s own name reconstruction rather than widening the
shared `StructurePrefix` regex, which 15 other files depend on for genuine `PREFIX:Field`
group-member references.

## How this was found

Hover on such a method's declaration reported "Implementation not found" against a real production
file. It had been masked: `MethodHoverResolver`'s fallback resolves implementations by matching raw
line **text** with a regex, which doesn't care whether tokenization was correct, so it found the
implementation despite the misclassification. When #444 made a
registered local class resolve **solely** through the Rule 4 token link (deliberately, so a miss
means "genuinely absent" rather than a name-only guess at another procedure's same-named method),
classes using this naming shape lost that incidental masking and the underlying tokenizer defect
became visible.

Worth stating plainly: the text fallback was never *correct* here, it was *lucky* — it papered over
a tokenizer bug that was simultaneously breaking references, rename, and Rule 4 linking for these
methods with no symptom anyone had connected.

## Testing

New `DocumentStructure.ChainedColonMethodImplementation.test.ts`:

1. The implementation line is tagged `MethodImplementation` with the full qualified label.
   **Fails on baseline** with `GlobalProcedure` (36 !== 38).
2. `declaringProcedureLine` links the implementation to its declaring procedure once classified
   correctly — proving the Rule 4 chain works end to end for this shape.
   **Fails on baseline** (no `MethodImplementation` token exists to link).

Verified against the real file that surfaced this, before and after: the token goes from
`subType=GlobalProcedure, label="Method"` to
`subType=MethodImplementation, label="MyOwn1:CLASS.My:My:Method", declaringProcedureLine=3091`,
matching the declaring procedure's own line.

(Suite at this first commit: 2500 passing. The second commit below adds two more tests.)

## Blast-radius verification

Because this changes shared classification logic, the impact was measured empirically rather than
argued. Every token (not just procedures) was dumped across a real corpus with the fix applied and
with `DocumentStructure.ts` reverted to baseline, then diffed:

- **889 files, 2,445,600 tokens, 556,833 lines (~22.6 MB)** — a large private production codebase,
  the Clarion 12 ABC libsrc (`LibSrc/win`), and third-party libsrc (StringTheory, NetTalk, etc.).
- Shapes genuinely exercised: 27,422 procedure lines — 11,735 MethodDeclaration, 11,444
  MethodImplementation, 1,161 MapProcedure, 908 InterfaceMethod, 2,174 GlobalProcedure, 666
  three-part `Class.Interface.Method` labels, 386 colon-bearing labels.

**Exactly 2 token records changed by the first commit**, both the intended shape (`subType 36 → 38`, full qualified
label, plus the expected Rule 4 `declaringProcedureLine` gain). Total token counts identical — none
added or removed. Zero differences on any other line shape.

Specific false-positive risks probed, all clear:

- Adding `StructurePrefix` to the accepted name-part types cannot flip a standalone global
  procedure: the 10 corpus lines carrying a `StructurePrefix` anywhere before `PROCEDURE` were
  checked individually, and `My:Global:Proc PROCEDURE()` correctly stays `GlobalProcedure`. (Of
  those 10, the 8 where it sits *immediately* before `PROCEDURE` are the single-colon population the
  second commit addresses.)
- The colon-glue cannot absorb a genuine separator — `Alpha : Beta PROCEDURE()` correctly does not
  glue, confirming the adjacency arithmetic.
- `ROUTINE` / MAP / MODULE / INTERFACE lines return at the earlier
  `insideClassOrInterfaceOrMapDepth > 0` branch, before this code.
- The three-part path is unaffected (dots are a 1-char gap and never `Delimiter ':'`).
- Termination is guaranteed: `lookbackIndex` strictly decreases and the `-= 2` path is guarded by
  `lookbackIndex >= 1`. Adversarial probes (leading colon, bare colon line, 5-deep chain) all
  completed without hang or throw.

## Second commit — the single-colon case

A method name with **exactly one** colon fails by a *different* mechanism, and it occurs 8 times in
Clarion's own shipped `LibSrc/win/svgraph.clw`:

```
svgraph.clw:932
GraphLegendClass.Free:qLegend      procedure
```

→ classified `subType=GlobalProcedure, label="Free:qLegend"`.
(`GraphLegendClass` is declared at `svgraphb.inc:509`, `Free:qLegend` at `:527`.)

With one colon the *whole* trailing name is captured by `StructurePrefix`'s `Prefix:Field` pattern,
so it arrives as `prevToken` — and the **outer guard** (`DocumentStructure.ts:2001`) admitted only
`Label|Variable|Attribute|StructureField`. The line never entered the reconstruction block at all.
(The two-colon case differs: there a stray `Delimiter` leaves a `Variable` as `prevToken`, which the
guard already admitted — which is exactly why the first commit alone could not reach these.)

Fix: admit `StructurePrefix` as a `prevToken` too. The line then runs the same backward walk, which
collects `Label("GraphLegendClass")` and yields `MethodImplementation` labelled
`GraphLegendClass.Free:qLegend`.

A standalone procedure whose own name carries colons is unaffected, and is pinned by a test: at
column 0 the whole name is a `Label` (Label's pattern allows colons), so there is no class prefix to
collect and nothing promotes it to a method implementation.

### Verification of the guard widening

Same method, three-way (baseline → first commit → both), same corpus. This widening opens the gate
itself, so the at-risk population is every line where a `StructurePrefix` immediately precedes a
`PROCEDURE` keyword. Corpus-wide that is **exactly 8 lines** — all 8 in `svgraph.clw`, all 8
adjudicated individually against their declarations, all 8 genuine class methods:

| Implementation | Declaration |
|---|---|
| `svgraph.clw:932 GraphLegendClass.Free:qLegend` | `svgraphb.inc:527` in `GraphLegendClass` (509) |
| `svgraph.clw:943 GraphLegendClass.Clear:qLegend` | `svgraphb.inc:528` |
| `svgraph.clw:2903 GraphBasicClass.Free:qGraph` | `svgraphb.inc:788` in `GraphBasicClass` (698) |
| `svgraph.clw:2923 GraphBasicClass.Clear:qGraph` | `svgraphb.inc:789` |
| `svgraph.clw:3006 GraphBasicClass.Free:qCluster` | `svgraphb.inc:798` |
| `svgraph.clw:3016 GraphBasicClass.Clear:qCluster` | `svgraphb.inc:799` |
| `svgraph.clw:3072 GraphBasicClass.Clear:qNode` | `svgraphb.inc:803` |
| `svgraph.clw:3080 GraphBasicClass.Free:qSelectedGraph` | `svgraphb.inc:816` |

**No line that was correctly a `GlobalProcedure` became a `MethodImplementation`.** Supporting
evidence:

- The corpus holds **54** `GlobalProcedure` tokens whose label carries a colon but no dot. Exactly
  the 8 above changed; the other **46 are untouched** — including `IC:MESSAGE`, `IC:HALT`
  (`WBHOOK.CLW`), `Preview:JumpToPage` (`pdfpvw41.clw`), `toDOM:AppendCol` (`cpxml.clw`).
- Of **28,856** `StructurePrefix` tokens corpus-wide, **0** contain a dot, so the
  `prevToken.value.includes(".")` branch cannot be entered unintentionally.
- Differing records whose type is not `Procedure` : **0**. Total token counts identical across all
  three states (2,445,600) — only the `PROCEDURE` token itself ever changes.

Total for the branch (baseline → both commits): **10 records changed, all one shape**
(`subType 36 → 38`) — the 8 above plus the 2 two-colon triggers.

Full suite: 2502 passing, 4 pending, 0 failing.

### Correction to an earlier claim in this write-up

An earlier revision of this document claimed the first commit "generalises to arbitrary chain
depth", citing `K:CLASS.a:b:c:d:e PROCEDURE()`. That was **wrong**, and is retracted: the probe
happened to use a colon-bearing class name. With an ordinary class name, `Cls.a:b:c:d:e
PROCEDURE()` still failed under the first commit alone — deep chains work only once the outer guard
is widened, because the chain's first pair lands as a `StructurePrefix` and needs the guard to enter
the block at all. Verified on the final state: both `Cls.a:b:c:d:e` and `Cls.Free:qThing` resolve
correctly, and three-part `MyClass.IFace.DoIt` is unaffected.

## Known gap, pre-existing and NOT addressed here

`MyClass.IFace.Do:It PROCEDURE()` — a three-part name with a colon in the final segment — remains
`GlobalProcedure "It"`. The tokenizer emits `StructureField("IFace.Do")` there, and the inner
`isNamePartToken` accepts `Label|Variable|Attribute|StructurePrefix` but not `StructureField` — an
inconsistency with the outer guard, which does accept it. Verified identical on baseline, so this
branch neither causes nor fixes it. **Zero occurrences in the corpus**, so it is theoretical rather
than observed; adding `StructureField` to the inner list would close it, but with no real-world
instance to diff against it warrants its own change.

## Scope

One source file (`DocumentStructure.ts`), one new test file, two commits.
