### PR TITLE
# fix(hover): a colon-named class member after a dot no longer mismatches its own regex

### DIFF
--- a/server/src/providers/hover/StructureFieldResolver.ts
+++ b/server/src/providers/hover/StructureFieldResolver.ts
@@ -96,7 +96,7 @@ export class StructureFieldResolver {
         const rawBeforeDot = line.substring(0, dotBeforeIndex).trim();
         const beforeDot = ChainedPropertyResolver.extractChain(rawBeforeDot);
         const afterDot = line.substring(dotBeforeIndex + 1).trim();
-        const fieldMatch = afterDot.match(/^(\w+)/);
+        const fieldMatch = afterDot.match(/^([\w:]+)/);
         
         logger.info(`resolveFieldAccess: beforeDot="${beforeDot}", afterDot="${afterDot}"`);
         

--- a/server/src/test/HoverProvider.SelfColonPropertyAccess.test.ts
+++ b/server/src/test/HoverProvider.SelfColonPropertyAccess.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Clarion allows a literal colon inside an identifier (e.g. My:Value), a common
+ * naming convention for class members. StructureFieldResolver.resolveFieldAccess
+ * extracts the member name AFTER the dot with a `\w+` regex, which stops at the
+ * colon — so "SELF.My:Value" truncates to "My", which then mismatches the
+ * correctly-extracted "My:Value" token and the whole resolver bails to null.
+ *
+ * This is the mirror case of the colon-BEFORE-the-dot bug fixed for receivers
+ * in ColonPrefixedGlobalDotAccessHover.test.ts (colon-prefixed GLOB:Thing) —
+ * here the colon is in the member name AFTER the dot, reached via SELF.
+ *
+ * NOTE: the enclosing PROCEDURE's own declared name is deliberately kept
+ * colon-free here (MyClass.DoWork, not e.g. MyClass.My:My:Method). A colon in
+ * the enclosing procedure's OWN name trips a separate, deeper bug in
+ * ClassMemberResolver.findClassMemberInfo's scope/className detection
+ * ("Could not determine className") — unrelated to this fix, not addressed
+ * here, and would mask/confound this regression test if mixed in.
+ */
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { setServerInitialized } from '../serverState';
+
+const CODE = `
+   PROGRAM
+
+MyClass   CLASS
+my:Value          ULONG
+DoWork            PROCEDURE(),LONG
+My:My:Method      PROCEDURE(),LONG
+              END
+
+MyClass.DoWork PROCEDURE()
+  CODE
+  SELF.My:Value = 1
+  SELF.My:My:Method()
+  RETURN(1)
+`;
+
+suite('Colon-named class member — SELF. dot-access hover', () => {
+    setup(() => {
+        setServerInitialized(true);
+    });
+
+    function lineOf(needle: string): number {
+        return CODE.split('\n').findIndex(l => l.includes(needle));
+    }
+
+    test('hovering a colon-named PROPERTY reached via SELF.My:Value resolves the class member', async () => {
+        const uri = 'test://SelfColonProperty.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('SELF.My:Value = 1');
+        const character = CODE.split('\n')[line].indexOf('My:Value');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for SELF.My:Value');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('My:Value') || value.toLowerCase().includes('my:value'),
+            `Hover should mention My:Value (got: ${value})`);
+        assert.ok(value.includes('ULONG'), `Hover should show the ULONG type (got: ${value})`);
+    });
+
+    test('hovering a colon-named METHOD reached via SELF.My:My:Method() resolves the class member', async () => {
+        const uri = 'test://SelfColonMethod.clw';
+        const document = TextDocument.create(uri, 'clarion', 1, CODE);
+        const provider = new HoverProvider();
+
+        const line = lineOf('SELF.My:My:Method()');
+        const character = CODE.split('\n')[line].indexOf('My:My:Method');
+
+        const hover = await provider.provideHover(document, { line, character });
+
+        assert.ok(hover, 'Hover should resolve for SELF.My:My:Method()');
+        const value = (hover!.contents as any).value as string;
+        assert.ok(value.includes('My:My:Method') || value.toLowerCase().includes('my:my:method'),
+            `Hover should mention My:My:Method (got: ${value})`);
+    });
+});


### PR DESCRIPTION
# fix(hover): a colon-named class member after a dot no longer mismatches its own regex

## What happened

Clarion allows a literal colon inside an identifier — a common naming convention for
class members (`my:Value`, `My:My:Method`). Hovering such a member reached via a dot
(`SELF.My:Value`, `SELF.My:My:Method()`, or any `variable.member` form) returned no
hover at all, and `lsp_definition` on the same position could resolve to a completely
unrelated symbol elsewhere in the workspace that happens to share the tail name.

Repro:

```clarion
MyClass   CLASS
my:Value          ULONG
DoWork            PROCEDURE(),LONG
My:My:Method      PROCEDURE(),LONG
              END

MyClass.DoWork PROCEDURE()
  CODE
  SELF.My:Value = 1          ! hovering "My:Value" here shows nothing
  SELF.My:My:Method()        ! hovering "My:My:Method" here shows nothing too
  RETURN(1)
```

## Root cause

`server/src/providers/hover/StructureFieldResolver.ts`, `resolveFieldAccess()`:

```ts
const afterDot = line.substring(dotBeforeIndex + 1).trim();
const fieldMatch = afterDot.match(/^(\w+)/);
```

For `SELF.My:Value = 1`, `afterDot` is `"My:Value = 1"`. `\w` doesn't include `:`, so
`fieldMatch[1]` comes back as `"My"` — truncated at the colon. A few lines later:

```ts
const fieldName = word.includes('.') ? word.split('.').pop()! : word;
...
if (!fieldMatch || fieldMatch[1].toLowerCase() !== fieldName.toLowerCase()) {
    return null;
}
```

`fieldName` is correctly `"My:Value"` (it comes from the token range, which already
handles colons fine). The comparison is `"my"` vs `"my:value"` — a mismatch — so the
function returns `null` before ever reaching the `isSelfMember`/`isParentMember`
branches, regardless of whether the receiver is `SELF`, `PARENT`, a chain, or a plain
variable.

## The fix

One line — widen the regex to match the colon-aware pattern already used a few lines
below at `isPureChain` (`/^[A-Za-z_][A-Za-z0-9_:]*.../`):

```ts
const fieldMatch = afterDot.match(/^([\w:]+)/);
```

No other change needed — `fieldName`, `qualifier`, and the cursor-position bounds
check further down already handle colons correctly; only this one regex was behind.

## Testing

Added `server/src/test/HoverProvider.SelfColonPropertyAccess.test.ts`, exercising
`HoverProvider.provideHover` end-to-end (not just the isolated regex) for both a
colon-named **property** and a colon-named **method** reached via `SELF.`.

Proved the test is real, not vacuous: temporarily reverted just the regex change,
rebuilt, and confirmed both new assertions fail with exactly the reported symptom
(`Hover should resolve for SELF.My:Value` / `...SELF.My:My:Method()`, both null).
Restored the fix and confirmed both pass.

Full suite: **2500 passing** (2498 before these 2 new tests), **0 failing**, 4 pending
(pre-existing, unrelated). Ran via `npm run test:server` (`tsc -b` + `mocha`).

## Scope — what's deliberately left out

- **Not the same bug as #386** (`fix/colon-prefix-dot-access-hover`, merged): that PR
  fixed a colon-containing **receiver** (`GLOB:Thing.Method()`) — colon *before* the
  dot. This is the mirror case — colon *after* the dot, in the member name.
- **A second, separate bug was found while testing this fix and is deliberately left
  alone**: if the *enclosing* PROCEDURE's own declared name contains a colon (e.g.
  `MyClass.My:My:Method PROCEDURE()`), `ClassMemberResolver.findClassMemberInfo`
  fails to determine the class name at all (`Scope: PROCEDURE` / `Could not determine
  className`) and bails before this fix's code path is even reached. That's a
  different function, a different failure mode (a tokenizer/scope-labeling issue for
  colon-heavy procedure declarations), and is NOT touched by this PR. The regression
  test's enclosing procedure is deliberately named `MyClass.DoWork` (no colon) so it
  isolates this fix's bug without tripping that other one. 
