### PR TITLE
fix(hover): resolve ?Name field equates to their window control

### DIFF
--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -2620,6 +2620,35 @@ export class DocumentStructure {
     }
 
     /**
+     * Every control DECLARATION of `?Name` in this document, paired with the
+     * container that owns it.
+     *
+     * Distinct from {@link findControlAll}, which reads the flat token index and so
+     * also returns every *reference* to the name — that index cannot tell a
+     * `USE(?Name)` declaration from a `SELECT(?Name)` use. This walks the
+     * per-structure maps instead, where only tokens inside a container's body are
+     * recorded.
+     *
+     * A control declared in a TOOLBAR or MENUBAR nested inside a WINDOW is recorded
+     * under both containers, so results are de-duplicated by control token; the
+     * outer container wins, since `linkUsesPass` indexes WINDOW/APPLICATION/REPORT
+     * before the nested keywords.
+     */
+    public findControlDeclarations(name: string): Array<{ control: Token; container: Token }> {
+        const key = name.toUpperCase();
+        const out: Array<{ control: Token; container: Token }> = [];
+        const seen = new Set<Token>();
+        for (const [container, perName] of this.fieldEquatesByStructure) {
+            const hit = perName.get(key);
+            if (hit && !seen.has(hit)) {
+                seen.add(hit);
+                out.push({ control: hit, container });
+            }
+        }
+        return out;
+    }
+
+    /**
      * What does this USE keyword token's argument resolve to? Returns the linked
      * FieldEquateLabel / Label / Variable / StructurePrefix-qualified field token
      * set by `linkUsesPass`. Returns undefined for the `USE(?)` empty-arg idiom

--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -37,6 +37,7 @@ import { StructureDeclarationIndexer } from '../utils/StructureDeclarationIndexe
 import { IncludeVerifier } from '../utils/IncludeVerifier';
 import { SymbolFinderService } from '../services/SymbolFinderService';
 import { getLocalMapScope } from '../utils/LocalMapScopeHelper';
+import { ScopeKind, ScopeNode } from '../scope/ScopeTypes';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -173,6 +174,22 @@ export class HoverProvider {
                 const sectionArg = TokenHelper.getIncludeSectionArgStringToken(preTokens, position.line, position.character);
                 if (sectionArg) {
                     return this.buildSectionRefHover(sectionArg.section, sectionArg.includeFile, document);
+                }
+
+                // A `?Name` field equate — a window control's own label. Like the two
+                // above, this must run BEFORE the context builder: `?` is a non-word
+                // character, so `getWordRangeAtPosition` either drops the sigil (leaving
+                // a bare `Cancel`, which the ladder below then matches against any
+                // unrelated EQUATE or keyword of that name) or, with the cursor on the
+                // `?` itself, returns an empty range and no hover at all. Resolving from
+                // the token keeps both cases on the control.
+                const feqToken = TokenHelper.getFieldEquateTokenAt(preTokens, position.line, position.character);
+                if (feqToken) {
+                    // Deliberately terminal: a `?Name` resolving to no control in scope
+                    // returns null rather than falling through. Nothing in the ladder
+                    // below models controls, so any match it finds on the bare name is a
+                    // coincidence rather than an answer.
+                    return this.buildFieldEquateHover(feqToken, document, position);
                 }
             }
 
@@ -921,6 +938,158 @@ export class HoverProvider {
                 sectionStr.line, sectionStr.start,
                 sectionStr.line, sectionStr.start + sectionStr.value.length)
         };
+    }
+
+    /**
+     * Hover card for a `?Name` field equate: the control's own type keyword, the
+     * structure that owns it, its declaration line, and a link to it.
+     *
+     * Scoped to the WINDOW/APPLICATION/REPORT structures declared in the CURRENT
+     * procedure, the same scope `?` completion offers — a field equate belongs to
+     * the procedure whose window declares it, so a same-named control elsewhere in
+     * the file is a different control, not this one. Returns null when the name
+     * resolves to nothing in that scope; that reference doesn't compile, and
+     * pointing at some other procedure's control instead would be a guess.
+     */
+    private buildFieldEquateHover(feqToken: Token, document: TextDocument, position: Position): Hover | null {
+        const structure = this.tokenCache.getStructure(document);
+
+        // 1. The usual case: a window declared in the enclosing procedure. The same
+        //    `?Name` — `?Cancel` above all — recurs across unrelated windows, so the
+        //    procedure's own window is the only reading that is certain.
+        for (const proc of this.enclosingProcedures(structure, position.line)) {
+            for (const win of structure.getContainerStructuresInProcedure(proc)) {
+                const hit = structure.findControl(feqToken.value, win);
+                if (hit) {
+                    return this.renderFieldEquateCard(feqToken, hit, win, document, structure);
+                }
+            }
+        }
+
+        // 2. Not the enclosing procedure's — but a window can be declared in a class
+        //    or in another source entirely, so absence here is not absence. A
+        //    declaration found elsewhere in THIS file is offered as a candidate and
+        //    labelled with its owner, never as the current procedure's control.
+        const declarations = structure.findControlDeclarations(feqToken.value);
+        if (declarations.length === 1) {
+            return this.renderFieldEquateCard(feqToken, declarations[0].control, null, document, structure);
+        }
+        if (declarations.length > 1) {
+            // The same name across several windows is ordinary Clarion. Listing the
+            // candidates is the honest answer; picking one would be a coin toss.
+            const lines: string[] = [
+                `**${feqToken.value}** — \`FIELD EQUATE\``,
+                `Declared in ${declarations.length} windows in this file — none in this procedure:`
+            ];
+            for (const { control } of declarations) {
+                const { controlType } = structure.getControlContextAt(control.line, control.start);
+                const owner = this.enclosingScopeName(structure, control.line);
+                const what = [controlType, owner ? `in \`${owner}\`` : null].filter(Boolean).join(' ');
+                lines.push(`- ${what ? what + ' — ' : ''}${this.formatter.locationLink(document.uri, control.line)}`);
+            }
+            return {
+                contents: { kind: 'markdown', value: lines.join('\n\n') },
+                range: Range.create(
+                    feqToken.line, feqToken.start,
+                    feqToken.line, feqToken.start + feqToken.value.length)
+            };
+        }
+
+        // 3. Declared in another source, or not at all. Either way this file cannot
+        //    say which — and no card beats a confident wrong one.
+        return null;
+    }
+
+    /**
+     * Procedure/method tokens whose windows a `?Name` on `line` could refer to,
+     * innermost first.
+     *
+     * The scope chain matters because of the ABC shape: a generated procedure holds
+     * its WINDOW in local data and its event handling in the methods of a locally
+     * declared `WindowManager` subclass. A `?Name` inside one of those methods is
+     * outside the method's own line range, so the method alone never resolves it —
+     * `ScopeResolver` links the method to the procedure whose local data declared
+     * its CLASS, and that is the procedure holding the window.
+     */
+    private enclosingProcedures(structure: ReturnType<TokenCache['getStructure']>, line: number): Token[] {
+        const out: Token[] = [];
+        const seen = new Set<Token>();
+        const push = (t: Token | null | undefined) => {
+            if (t && !seen.has(t)) { seen.add(t); out.push(t); }
+        };
+
+        let node: ScopeNode | null;
+        try {
+            node = structure.getScopeResolver().resolveScopeAt(line);
+        } catch {
+            return out;
+        }
+        for (let n: ScopeNode | null = node; n; n = n.parent) {
+            if (n.kind === ScopeKind.Procedure || n.kind === ScopeKind.Method) {
+                push(n.token);
+            }
+            push(n.declaringProcedure?.token);
+        }
+        return out;
+    }
+
+    /**
+     * The card itself. `container` is the owning WINDOW/APPLICATION/REPORT when the
+     * control was resolved inside the current procedure; null when it was found
+     * elsewhere in the file, which the card then says outright.
+     */
+    private renderFieldEquateCard(
+        feqToken: Token,
+        declToken: Token,
+        container: Token | null,
+        document: TextDocument,
+        structure: ReturnType<TokenCache['getStructure']>
+    ): Hover {
+        // The control keyword (BUTTON/ENTRY/LIST/…) is read at the DECLARATION's
+        // position, not the cursor's — the cursor is usually on a reference, where
+        // there is no control keyword to find.
+        const { controlType } = structure.getControlContextAt(declToken.line, declToken.start);
+
+        const lines: string[] = [
+            controlType ? `**${declToken.value}** — \`${controlType}\`` : `**${declToken.value}**`
+        ];
+
+        if (container) {
+            lines.push(`🔷 ${container.value.toUpperCase()} control`);
+        } else {
+            const owner = this.enclosingScopeName(structure, declToken.line);
+            lines.push(owner
+                ? `🔷 Control declared in \`${owner}\`, not in this procedure`
+                : '🔷 Control declared elsewhere in this file, not in this procedure');
+        }
+
+        const declLine = document.getText({
+            start: { line: declToken.line, character: 0 },
+            end: { line: declToken.line, character: Number.MAX_VALUE }
+        }).trim();
+        if (declLine) {
+            lines.push('```clarion\n' + declLine + '\n```');
+        }
+        lines.push(this.formatter.locationLink(document.uri, declToken.line));
+
+        return {
+            contents: { kind: 'markdown', value: lines.join('\n\n') },
+            range: Range.create(
+                feqToken.line, feqToken.start,
+                feqToken.line, feqToken.start + feqToken.value.length)
+        };
+    }
+
+    /** Name of the procedure/method enclosing `line`, for labelling a control found outside the current one. */
+    private enclosingScopeName(structure: ReturnType<TokenCache['getStructure']>, line: number): string | null {
+        try {
+            // A scope node's token is the PROCEDURE keyword; `label` carries the name
+            // (dotted, for a method implementation) — same accessor CodeLens uses.
+            const t = structure.getScopeResolver().resolveScopeAt(line).token;
+            return t ? (t.label ?? t.value) : null;
+        } catch {
+            return null;
+        }
     }
 
     /**

--- a/server/src/test/HoverProvider.FieldEquate.test.ts
+++ b/server/src/test/HoverProvider.FieldEquate.test.ts
@@ -1,0 +1,355 @@
+import * as assert from 'assert';
+import { Hover } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { HoverProvider } from '../providers/HoverProvider';
+import { setServerInitialized } from '../serverState';
+
+/**
+ * Hover had NO `?Name` field-equate handling at all: `getWordRangeAtPosition`
+ * treats `?` as a non-word character, so the sigil was dropped before any
+ * resolver saw the word and hover resolved the bare remainder instead. When that
+ * remainder happened to name something else in scope the card was confidently
+ * wrong — a `?Cancel` control reported an unrelated `Cancel` EQUATE, a `?List`
+ * control reported the `LIST` keyword — and when it named nothing there was no
+ * hover at all. With the cursor on the `?` glyph itself the range collapsed to
+ * empty and the context builder bailed before the ladder even started.
+ *
+ * A `?Name` only ever refers to a control declared in a window structure. That is
+ * normally the current procedure's own window, but the window may live in a class
+ * or another source, and the same name — `?Cancel` most of all — recurs across
+ * unrelated windows. Hover therefore resolves from the `FieldEquateLabel` token
+ * against the current procedure's windows first, labels anything found elsewhere
+ * in the file with its owner, and stays silent rather than choosing between
+ * same-named candidates.
+ */
+
+function hoverText(h: Hover | null | undefined): string {
+    if (!h) return '';
+    const c = h.contents;
+    if (typeof c === 'string') return c;
+    if (Array.isArray(c)) return c.map(p => (typeof p === 'string' ? p : p.value)).join('\n');
+    return (c as { value?: string }).value ?? '';
+}
+
+// The local `Cancel` EQUATE and the `LIST` control are deliberate: they are the
+// name collisions that made the old bare-word lookup answer wrongly rather than
+// silently, so they are what proves the fix resolves the control instead. The
+// second and third procedures cover a name shared between two windows and a
+// reference made from a procedure owning no window at all.
+const SOURCE = [
+    '  PROGRAM',
+    '  MAP',
+    'MyProc     PROCEDURE()',
+    'OtherProc  PROCEDURE()',
+    'ThirdProc  PROCEDURE()',
+    '  END',
+    '  CODE',
+    '  MyProc()',
+    '  RETURN',
+    '',
+    'MyProc  PROCEDURE()',
+    'Cancel    EQUATE(7)',
+    'Msg       STRING(32)',
+    "Window WINDOW('Caption'),AT(,,119,93),GRAY",
+    "      BUTTON('&OK'),AT(19,75,41,14),USE(?OkButton),DEFAULT",
+    "      BUTTON('&Cancel'),AT(64,75,42,14),USE(?Cancel)",
+    "      LIST,AT(8,105,273,90),USE(?List),FROM('One|Two')",
+    '      ENTRY(@s20),AT(55,23),USE(?Name:Entry)',
+    "      BUTTON('X'),AT(1,1),USE(?)",
+    '   END',
+    '  CODE',
+    '  OPEN(Window)',
+    '  ACCEPT',
+    '    CASE FIELD()',
+    '    OF ?OkButton',
+    '    OF ?Cancel',
+    '    END',
+    '    HIDE(?Cancel )',
+    '    IF FIELD() = ?NotDeclaredAnywhere',
+    '    END',
+    '    IF FIELD() = ?OnlyInOther',
+    '    END',
+    "    Msg = 'a ?Cancel inside a string'",
+    '  END',
+    '  RETURN',
+    '',
+    'OtherProc  PROCEDURE()',
+    "OtherWin WINDOW('Other'),AT(,,100,80),GRAY",
+    "      BUTTON('&Cancel'),AT(10,10,42,14),USE(?Cancel)",
+    "      CHECK('Flag'),AT(10,30),USE(?OnlyInOther)",
+    '   END',
+    '  CODE',
+    '  OPEN(OtherWin)',
+    '  RETURN',
+    '',
+    'ThirdProc  PROCEDURE()',
+    '  CODE',
+    '  IF FIELD() = ?Cancel',
+    '  END',
+    '  RETURN',
+].join('\n');
+
+const URI = 'file:///c:/fixtures/field-equate-hover.clw';
+const LINES = SOURCE.split('\n');
+
+suite('Hover — ?Name field equates (window controls)', () => {
+    let doc: TextDocument;
+    let provider: HoverProvider;
+
+    setup(() => {
+        setServerInitialized(true);
+        TokenCache.getInstance().clearAllTokens();
+        doc = TextDocument.create(URI, 'clarion', 1, SOURCE);
+        TokenCache.getInstance().getTokens(doc);
+        provider = new HoverProvider();
+    });
+
+    teardown(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    /** Index of the one line containing `marker` — ambiguity is a fixture bug, not a pass. */
+    function lineOf(marker: string): number {
+        const hits = LINES.map((l, i) => (l.includes(marker) ? i : -1)).filter(i => i >= 0);
+        assert.strictEqual(hits.length, 1,
+            `fixture marker ${JSON.stringify(marker)} must match exactly one line, matched ${hits.length}`);
+        return hits[0];
+    }
+
+    /** Hover text with the cursor `offsetInName` chars into the `feq` occurrence on `marker`'s line. */
+    async function hoverOn(marker: string, feq: string, offsetInName = 2): Promise<string> {
+        const line = lineOf(marker);
+        const at = LINES[line].indexOf(feq);
+        assert.ok(at >= 0, `line must contain ${feq}`);
+        return hoverText(await provider.provideHover(doc, { line, character: at + offsetInName }));
+    }
+
+    test('a ?Name reference resolves to its control, not a same-named EQUATE', async () => {
+        const text = await hoverOn('OF ?Cancel', '?Cancel');
+
+        assert.ok(text.length > 0, 'hover must fire on a ?Name reference');
+        assert.ok(text.includes('?Cancel'),
+            `card must name the control, not the bare word; got:\n${text}`);
+        assert.ok(text.includes('BUTTON'),
+            `card must report the control's own type keyword; got:\n${text}`);
+        assert.ok(!text.includes('EQUATE'),
+            `the local Cancel EQUATE is a name collision, not this control; got:\n${text}`);
+    });
+
+    test('a ?Name whose bare word names nothing still resolves (was: no hover)', async () => {
+        const text = await hoverOn('OF ?OkButton', '?OkButton');
+
+        assert.ok(text.length > 0,
+            'hover must fire — OkButton names nothing on its own, which is why this was silent');
+        assert.ok(text.includes('?OkButton') && text.includes('BUTTON'),
+            `card must name the control and its type; got:\n${text}`);
+    });
+
+    test('the cursor on the ? glyph itself resolves the control', async () => {
+        // offset 0 — directly on `?`, where the word range used to collapse to empty.
+        const text = await hoverOn('OF ?Cancel', '?Cancel', 0);
+
+        assert.ok(text.includes('?Cancel') && text.includes('BUTTON'),
+            `the sigil position must resolve like the name does; got:\n${text}`);
+    });
+
+    test('a control named after a Clarion keyword resolves to the control', async () => {
+        const text = await hoverOn('USE(?List)', '?List');
+
+        assert.ok(text.includes('?List'),
+            `card must name the control, not the LIST keyword it collides with; got:\n${text}`);
+        assert.ok(text.includes('WINDOW'),
+            `card must name the owning structure; got:\n${text}`);
+    });
+
+    test('hover on the USE(?Name) declaration itself resolves the control', async () => {
+        const text = await hoverOn("BUTTON('&Cancel'),AT(64,75", '?Cancel');
+
+        assert.ok(text.includes('?Cancel') && text.includes('BUTTON'),
+            `the declaration site must resolve too; got:\n${text}`);
+    });
+
+    test('a ?Name argument with trailing whitespace resolves', async () => {
+        const text = await hoverOn('HIDE(?Cancel )', '?Cancel');
+
+        assert.ok(text.includes('?Cancel') && text.includes('BUTTON'),
+            `\`HIDE(?Cancel )\` is the same reference; got:\n${text}`);
+    });
+
+    test('a compound ?Prefix:Suffix control resolves as one name', async () => {
+        const text = await hoverOn('USE(?Name:Entry)', '?Name:Entry');
+
+        assert.ok(text.includes('?Name:Entry'),
+            `the colon-bearing name is one field equate, not two; got:\n${text}`);
+        assert.ok(text.includes('ENTRY'),
+            `card must report the control type; got:\n${text}`);
+    });
+
+    test('the same ?Name in two windows resolves to the current procedure\'s own control', async () => {
+        const ownDecl = lineOf("BUTTON('&Cancel'),AT(64,75");
+        const otherDecl = lineOf("BUTTON('&Cancel'),AT(10,10");
+        const text = await hoverOn('OF ?Cancel', '?Cancel');
+
+        assert.ok(text.includes(`:${ownDecl + 1}]`),
+            `must point at this procedure's own ?Cancel (line ${ownDecl + 1}); got:\n${text}`);
+        assert.ok(!text.includes(`:${otherDecl + 1}]`),
+            `must not point at another window's identically named control; got:\n${text}`);
+    });
+
+    test('a ?Name owned by another procedure is labelled, not claimed as this one\'s', async () => {
+        const text = await hoverOn('IF FIELD() = ?OnlyInOther', '?OnlyInOther');
+
+        assert.ok(text.includes('?OnlyInOther'), `card must name the control; got:\n${text}`);
+        assert.ok(text.includes('CHECK'), `card must report the control type; got:\n${text}`);
+        assert.ok(/not in this procedure/i.test(text),
+            `a control found outside the current procedure must say so; got:\n${text}`);
+        assert.ok(text.includes('OtherProc'),
+            `card must name the owning procedure; got:\n${text}`);
+    });
+
+    test('an ambiguous ?Name lists candidates instead of picking one', async () => {
+        // ThirdProc declares no window, so its ?Cancel matches two unrelated windows.
+        const text = await hoverOn('IF FIELD() = ?Cancel', '?Cancel');
+
+        assert.ok(/2 windows/i.test(text),
+            `an ambiguous field equate must report how many candidates exist; got:\n${text}`);
+        assert.ok(text.includes('MyProc') && text.includes('OtherProc'),
+            `both owning procedures must be listed; got:\n${text}`);
+    });
+
+    test('a ?Name that is declared nowhere produces no card', async () => {
+        const text = await hoverOn('?NotDeclaredAnywhere', '?NotDeclaredAnywhere');
+
+        assert.strictEqual(text, '',
+            `an unresolvable field equate must stay silent rather than name something ` +
+            `that merely shares its spelling; got:\n${text}`);
+    });
+
+    test('a ?Name inside a string literal is not a control reference', async () => {
+        const text = await hoverOn("Msg = 'a ?Cancel inside", '?Cancel');
+
+        assert.ok(!text.includes('BUTTON'),
+            `text inside a string literal is not a field equate; got:\n${text}`);
+    });
+
+    test('the bare USE(?) anonymous-control marker produces no card', async () => {
+        const line = lineOf('USE(?)');
+        const got = hoverText(await provider.provideHover(
+            doc, { line, character: LINES[line].indexOf('USE(?)') + 4 }));
+
+        assert.ok(!got.includes('control'),
+            `a bare ? names nothing, so there is nothing to resolve; got:\n${got}`);
+    });
+
+    test('the hover range covers the whole ?Name, sigil included', async () => {
+        const line = lineOf('OF ?Cancel');
+        const at = LINES[line].indexOf('?Cancel');
+        const h = await provider.provideHover(doc, { line, character: at + 2 });
+
+        assert.ok(h?.range, 'card must carry a range');
+        assert.strictEqual(h!.range!.start.character, at,
+            'range must start at the ? — excluding it under-highlights the reference');
+        assert.strictEqual(h!.range!.end.character, at + '?Cancel'.length,
+            'range must span the whole field equate');
+    });
+});
+
+/**
+ * The generated-ABC shape, which is where most `?Name` references actually live: the
+ * procedure holds the WINDOW in its local data and its event handling in the methods
+ * of a locally declared `WindowManager` subclass. A `?Name` inside such a method is
+ * outside that method's own line range, so scoping to the innermost procedure alone
+ * never resolves it — the method has to climb to the procedure whose local data
+ * declared its CLASS.
+ */
+const ABC_SOURCE = [
+    "  MEMBER('main')",
+    '',
+    'MyFormProc PROCEDURE (LONG pId)',
+    '',
+    "Window WINDOW('Form'),AT(,,200,140),GRAY",
+    "       BUTTON('&OK'),AT(100,113,52,18),USE(?OkButton),DEFAULT",
+    "       BUTTON('&Cancel'),AT(160,113,51,18),USE(?CancelButton),STD(STD:Close)",
+    '     END',
+    '',
+    'ThisWindow           CLASS(WindowManager)',
+    'Init                   PROCEDURE(),BYTE,PROC,DERIVED',
+    'TakeAccepted           PROCEDURE(),BYTE,PROC,DERIVED',
+    '                     END',
+    '',
+    '  CODE',
+    '  ThisWindow.Run()',
+    '',
+    'ThisWindow.Init PROCEDURE',
+    'ReturnValue          BYTE,AUTO',
+    '  CODE',
+    '  ReturnValue = PARENT.Init()',
+    '  RETURN ReturnValue',
+    '',
+    'ThisWindow.TakeAccepted PROCEDURE',
+    'ReturnValue          BYTE,AUTO',
+    '  CODE',
+    '  CASE ACCEPTED()',
+    '  OF ?OkButton',
+    '    SELECT(?CancelButton)',
+    '  END',
+    '  ReturnValue = PARENT.TakeAccepted()',
+    '  RETURN ReturnValue',
+].join('\n');
+
+const ABC_URI = 'file:///c:/fixtures/field-equate-abc.clw';
+const ABC_LINES = ABC_SOURCE.split('\n');
+
+suite('Hover — ?Name field equates in generated-ABC local class methods', () => {
+    let doc: TextDocument;
+    let provider: HoverProvider;
+
+    setup(() => {
+        setServerInitialized(true);
+        TokenCache.getInstance().clearAllTokens();
+        doc = TextDocument.create(ABC_URI, 'clarion', 1, ABC_SOURCE);
+        TokenCache.getInstance().getTokens(doc);
+        provider = new HoverProvider();
+    });
+
+    teardown(() => {
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    function abcLineOf(marker: string): number {
+        const hits = ABC_LINES.map((l, i) => (l.includes(marker) ? i : -1)).filter(i => i >= 0);
+        assert.strictEqual(hits.length, 1,
+            `fixture marker ${JSON.stringify(marker)} must match exactly one line, matched ${hits.length}`);
+        return hits[0];
+    }
+
+    async function abcHoverOn(marker: string, feq: string): Promise<string> {
+        const line = abcLineOf(marker);
+        const at = ABC_LINES[line].indexOf(feq);
+        assert.ok(at >= 0, `line must contain ${feq}`);
+        return hoverText(await provider.provideHover(doc, { line, character: at + 2 }));
+    }
+
+    test('a ?Name used inside a local class method resolves to the procedure\'s window', async () => {
+        const decl = abcLineOf("USE(?CancelButton)");
+        const text = await abcHoverOn('SELECT(?CancelButton)', '?CancelButton');
+
+        assert.ok(text.includes('?CancelButton') && text.includes('BUTTON'),
+            `card must resolve the control; got:\n${text}`);
+        assert.ok(text.includes(`:${decl + 1}]`),
+            `card must point at the window's declaration (line ${decl + 1}); got:\n${text}`);
+        assert.ok(!/not in this procedure/i.test(text),
+            `the window belongs to the procedure declaring this method's CLASS — it is in scope, ` +
+            `so the card must not disclaim it; got:\n${text}`);
+    });
+
+    test('a ?Name in a CASE label inside a local class method resolves too', async () => {
+        const text = await abcHoverOn('OF ?OkButton', '?OkButton');
+
+        assert.ok(text.includes('?OkButton') && text.includes('BUTTON'),
+            `card must resolve the control; got:\n${text}`);
+        assert.ok(text.includes('WINDOW'),
+            `card must name the owning structure; got:\n${text}`);
+    });
+});

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -592,6 +592,31 @@ export class TokenHelper {
     }
 
     /**
+     * The `?Name` field-equate token at `line`/`character`, or null.
+     *
+     * Read from the token stream rather than re-scanned off the line, which buys
+     * two things for free. The span INCLUDES the leading `?`, so a cursor on the
+     * sigil itself resolves the control instead of returning nothing —
+     * `getWordRangeAtPosition` classifies `?` as a non-word character, so it
+     * collapses to an empty range there and its caller bails. And a `?` inside a
+     * string literal or a comment is never a `FieldEquateLabel` token, so those
+     * positions can't match without a separate guard.
+     *
+     * The bare `?` anonymous-control marker (`BUTTON('OK'),USE(?)`) is excluded:
+     * it names nothing, so there is no control to resolve.
+     */
+    public static getFieldEquateTokenAt(tokens: Token[], line: number, character: number): Token | null {
+        for (const t of tokens) {
+            if (t.line !== line || t.type !== TokenType.FieldEquateLabel) continue;
+            if (t.value.length <= 1) continue; // bare `?` — anonymous control marker
+            if (t.start <= character && character <= t.start + t.value.length) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    /**
      * True for any callable declaration token (Procedure or Function).
      * In modern Clarion both can return values; the distinction is a legacy
      * tokenizer artifact, so callers asking "is this a callable declaration?"


### PR DESCRIPTION
# fix(hover): resolve ?Name field equates to their window control

## What happened

Hover had no `?Name` field-equate handling at all. `TokenHelper.isWordCharacter`
treats `?` as a non-word character, so `getWordRangeAtPosition` either dropped the
sigil (leaving a bare word like `Cancel`, which the resolver ladder then matched
against any unrelated EQUATE, keyword, or local variable of that name) or, with the
cursor on the `?` itself, collapsed to an empty range and returned no hover at all.

Repro (see the new test file, `HoverProvider.FieldEquate.test.ts`):

- `USE(?Cancel)` on a control, referenced later via `OF ?Cancel` — hovered as an
  unrelated same-named EQUATE elsewhere in the file.
- `USE(?List)` on a LIST control, referenced via `USE(?List)` — hovered as the
  `LIST` language keyword's own card, not the control.
- `?OkButton`, which matches nothing else declared in scope — produced no hover at
  all.

## Root cause

The tokenizer already classifies `?Name` correctly, as one `FieldEquateLabel` token
(`TokenPatterns.ts`) — hover simply never consulted it. `HoverProvider` derives its
working "word" purely from `TokenHelper.getWordRangeAtPosition`, whose word-boundary
scan (`isWordCharacter`) excludes `?`. So by the time any resolver runs, the `?` is
already gone, and the resolver ladder has no way to know the word it's holding was
ever a field-equate reference rather than a plain identifier.

## Fix

A pre-context detector in `HoverProvider._provideHoverInternal`, in the same block
as the existing `#265` file-ref exception and for the same reason — it must run
*before* the word-based context builder, because the normal path can't represent
this reference at all. It reads the token straight from its `FieldEquateLabel` span
via a new `TokenHelper.getFieldEquateTokenAt` (inclusive of the `?` itself, so a
cursor directly on the sigil resolves the same as one on the name), then resolves
the control through the existing field-equate APIs on `DocumentStructure`
(`getContainerStructuresInProcedure` / `findControl` / new `findControlDeclarations`).

Resolution is scoped to the procedure whose window declares the control:

- It climbs to the class-declaring procedure via `ScopeResolver`'s
  `declaringProcedure` link, so a `?Name` referenced from inside a locally-declared
  `WindowManager`-derived class's methods — the common ABC-generated shape, where
  the WINDOW lives in the outer procedure's data and the event handling lives in the
  class's methods — still resolves against the procedure holding the window, not
  against the method's own (much narrower) line range alone.
- A `?Name` matching nothing in that resolvable scope produces no hover, rather than
  falling through to a same-named EQUATE/keyword/variable elsewhere.
- The same name declared in more than one window in the file (`?Cancel` is the
  everyday case) lists every candidate instead of guessing — there's no way to
  prefer one from the reference site alone, and ordinary Clarion code does this
  routinely.
- A control found elsewhere in the file, outside the resolvable procedure chain, is
  still shown, but labelled with its owning procedure rather than presented as this
  procedure's own control.

## Testing

16 new tests in `HoverProvider.FieldEquate.test.ts`, covering: a bare-word collision
with an unrelated EQUATE, a name matching nothing (previously silent), the cursor on
the `?` glyph itself, a control named after a Clarion keyword (`LIST`), the `USE()`
declaration site itself, trailing whitespace in the argument, a compound
`?Prefix:Suffix` name, the same name declared in two windows, a control owned by a
different procedure, an ambiguous multi-window name, a name inside a string literal,
the bare `USE(?)` anonymous-control marker, the hover range, and the ABC
local-class-method shape (both a `CASE` label and a bare reference).

Proved non-vacuous: reverted the fix and reran the suite against the same fixture —
13 of 16 cases fail, reproducing the exact reported symptom (a same-named EQUATE's
card, sourced from `ABWINDOW.INC`, in place of the control) — then restored and
confirmed all pass again.

Full server suite: 2565 passing, 0 failing, 4 pending (2549 passing before this
change).

## Scope

Explicitly out of scope, and not attempted here: `USE(BareVariable)` (no `?`) also
creates a field equate labelled after the variable, and array (`USE(Arr[1])` →
`?Arr_1`) and qualified-field (`USE(Grp.Field)` → `?Grp:Field`) USE() forms have
their own label-derivation rules — all per the Language Reference's "Field Equate
Labels" section. None of that derivation is implemented here. A `?Name` that only
exists via one of those implicit forms currently produces no hover, which is silent
rather than wrong, so shipping without it is safe. Tracked separately as an issue.
