### PR TITLE
fix(hover): keep statement context from swallowing a non-SELF chained member access

### DIFF
--- a/server/src/test/ChainedPropertyResolver.test.ts
+++ b/server/src/test/ChainedPropertyResolver.test.ts
@@ -6,6 +6,7 @@
 
 import * as assert from 'assert';
 import { ClassMemberResolver } from '../utils/ClassMemberResolver';
+import { ChainedPropertyResolver } from '../utils/ChainedPropertyResolver';
 
 // ─── extractClassName helper tests ───────────────────────────────────────────
 
@@ -119,5 +120,71 @@ suite('ClassMemberResolver.extractClassName', () => {
 
     test('GROUP keyword alone still returns null (unaffected by GROUP(TypeName) handling)', () => {
         assert.strictEqual(ClassMemberResolver.extractClassName('GROUP'), null);
+    });
+});
+
+// --- extractChain helper tests -------------------------------------------------
+
+/**
+ * Mirrors the `isPureChain` gate applied by the hover and definition callers to
+ * extractChain's result. A chain that fails this test is routed to the
+ * single-segment fallback instead of the chained resolver.
+ */
+const isPureChain = (s: string): boolean =>
+    /^[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/i.test(s.trim());
+
+suite('ChainedPropertyResolver.extractChain', () => {
+
+    test('SELF anchor — keeps only the rightmost SELF chain', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('SELF.Order.X &= SELF.Primary'), 'SELF.Primary');
+    });
+
+    test('PARENT anchor — keeps only the rightmost PARENT chain', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('x = PARENT.Owner'), 'PARENT.Owner');
+    });
+
+    test('bare chain with no statement context is returned unchanged', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('Obj.Prop'), 'Obj.Prop');
+    });
+
+    test('assignment context is stripped from a non-SELF chain root', () => {
+        // Regression: the whole prefix used to be returned, so the caller's
+        // pure-chain gate rejected it and multi-segment access never resolved.
+        assert.strictEqual(ChainedPropertyResolver.extractChain('rc = Obj.Prop'), 'Obj.Prop');
+    });
+
+    test('an extracted non-SELF chain satisfies the caller-side pure-chain gate', () => {
+        const extracted = ChainedPropertyResolver.extractChain('rc = Obj.Prop');
+        assert.ok(isPureChain(extracted), `expected a pure chain, got "${extracted}"`);
+    });
+
+    test('open-paren call context is stripped from a non-SELF chain root', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('Foo(Obj.Prop'), 'Obj.Prop');
+    });
+
+    test('keyword context is stripped from a non-SELF chain root', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('IF Obj.Prop'), 'Obj.Prop');
+    });
+
+    test('a colon-prefixed chain root survives extraction', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('rc = PRE:Field.Prop'), 'PRE:Field.Prop');
+    });
+
+    test('deeper non-SELF chains keep every segment', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('rc = Obj.Inner.Deeper'), 'Obj.Inner.Deeper');
+    });
+
+    test('a prefix not ending in an identifier is returned unchanged', () => {
+        // Nothing sensible to extract — must not mangle it into a bogus chain.
+        assert.strictEqual(ChainedPropertyResolver.extractChain('CLIP(a.b)'), 'CLIP(a.b)');
+    });
+
+    test('a single identifier with no dot is returned as-is', () => {
+        assert.strictEqual(ChainedPropertyResolver.extractChain('rc = Obj'), 'Obj');
+    });
+
+    test('SELF anchor still wins over the trailing-chain fallback', () => {
+        // The fallback must not shadow SELF handling when both could match.
+        assert.strictEqual(ChainedPropertyResolver.extractChain('rc = SELF.Owner'), 'SELF.Owner');
     });
 });

--- a/server/src/utils/ChainedPropertyResolver.ts
+++ b/server/src/utils/ChainedPropertyResolver.ts
@@ -35,14 +35,32 @@ export class ChainedPropertyResolver {
     private memberLocator = new MemberLocatorService();
 
     /**
-     * Extracts the rightmost SELF/PARENT chain from a full line prefix.
-     * Handles assignment expressions like "SELF.Order.X &= SELF.Primary"
-     * where we only want "SELF.Primary" (the rightmost chain).
+     * Extracts the rightmost member-access chain from a full line prefix.
+     *
+     * Anchors on SELF/PARENT when one is present, so an assignment expression
+     * like "SELF.Order.X &= SELF.Primary" yields only "SELF.Primary" (the
+     * rightmost chain).
+     *
+     * Without such an anchor the rightmost run of dot-separated identifiers is
+     * taken instead, so a chain rooted on an ordinary typed variable survives
+     * whatever statement context sits to its left ("rc = Obj.Prop" -> "Obj.Prop",
+     * "Foo(Obj.Prop" -> "Obj.Prop"). Callers gate the chained-resolution path on
+     * the result being a pure chain, so leaving that context attached silently
+     * routes a multi-segment access to the single-segment fallback, where it
+     * cannot resolve. The character class deliberately mirrors that caller-side
+     * pure-chain test, so anything extracted here is guaranteed to satisfy it.
+     *
+     * Anchored at end-of-string and requiring an identifier start character, so a
+     * prefix not ending in an identifier (e.g. "CLIP(a.b)") is returned unchanged
+     * rather than mangled.
      */
     public static extractChain(rawBeforeDot: string): string {
         const matches = [...rawBeforeDot.matchAll(/\b(self|parent)\b/gi)];
-        if (matches.length === 0) return rawBeforeDot;
-        return rawBeforeDot.substring(matches[matches.length - 1].index!);
+        if (matches.length > 0) {
+            return rawBeforeDot.substring(matches[matches.length - 1].index!);
+        }
+        const chain = rawBeforeDot.match(/[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/);
+        return chain ? chain[0] : rawBeforeDot;
     }
 
     /**


### PR DESCRIPTION
# fix(hover): keep statement context from swallowing a non-SELF chained member access

## What happened

Hover and go-to-definition both return nothing for the third-plus segment of an ordinary
(non-SELF/PARENT) chained property or method access, when the chain sits anywhere but the very
start of the line:

```clarion
SomeProc PROCEDURE()
rc          LONG
MyVar       &SomeClass
CODE
  rc = MyVar.SomeProperty.SomeMethod( pArg )   ! hovering SomeMethod: nothing
```

Hovering `MyVar` resolves fine (local variable). Hovering `MyVar.SomeProperty` resolves fine
(class property). Hovering `SomeMethod` — the third segment — returns nothing, and Ctrl-click
does nothing either. Written as its own statement with nothing to its left
(`MyVar.SomeProperty.SomeMethod( pArg )`), the same access hovers correctly — the failure is
specific to the chain having non-trivial statement context (an assignment, an enclosing call, a
keyword) immediately to its left.

## Root cause

`ChainedPropertyResolver.extractChain` trims everything left of a SELF/PARENT-anchored chain
(`"SELF.Order.X &= SELF.Primary"` → `"SELF.Primary"`), but has no equivalent handling when the
chain root is an ordinary typed variable instead of SELF/PARENT — in that case it returns the
**entire raw line prefix**, statement context and all:

```ts
public static extractChain(rawBeforeDot: string): string {
    const matches = [...rawBeforeDot.matchAll(/\b(self|parent)\b/gi)];
    if (matches.length === 0) return rawBeforeDot;   // <-- whole prefix, unstripped
    return rawBeforeDot.substring(matches[matches.length - 1].index!);
}
```

Every caller that walks a multi-segment chain (`StructureFieldResolver`, `DefinitionProvider`)
gates that branch on the extracted text being a **pure** dotted-identifier chain:

```ts
const isPureChain = /^[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/i.test(beforeDot.trim());
```

`"rc = MyVar.SomeProperty"` fails that test (the `=` and spaces aren't in the character class), so
control falls through to the single-segment `else` branch, which treats the text immediately
before the dot as a **local variable name** to look up. There is no local variable named
`SomeProperty` — it's a class property — so the lookup returns nothing and hover/go-to-definition
give up silently.

Two segments works by accident: hovering `SomeProperty` itself, the prefix is `"rc = MyVar"` —
still not a pure chain, but that case has no dot at all, so it goes through the same `else`
branch's `/([\w:]+)\s*$/` trailing-identifier match, which correctly isolates `MyVar` regardless of
what precedes it. The chain branch has no equivalent trimming step; that asymmetry is the bug.

## Fix

Give `extractChain` a fallback for the non-SELF/PARENT case: take the rightmost run of
dot-separated identifiers instead of the raw prefix.

```ts
public static extractChain(rawBeforeDot: string): string {
    const matches = [...rawBeforeDot.matchAll(/\b(self|parent)\b/gi)];
    if (matches.length > 0) {
        return rawBeforeDot.substring(matches[matches.length - 1].index!);
    }
    const chain = rawBeforeDot.match(/[A-Za-z_][A-Za-z0-9_:]*(?:\.[A-Za-z_][A-Za-z0-9_:]*)*$/);
    return chain ? chain[0] : rawBeforeDot;
}
```

The character class deliberately mirrors the callers' own `isPureChain` test, so anything this
returns is guaranteed to satisfy it — the extractor and the gate can't silently drift apart again.
Anchored at end-of-string and requiring an identifier-start character, so a prefix that doesn't
actually end in an identifier (e.g. `"CLIP(a.b)"`) is returned unchanged rather than mangled into a
bogus chain.

## Testing

12 new tests in `ChainedPropertyResolver.test.ts` covering: SELF/PARENT anchoring still wins and is
unaffected; a bare chain with no context is untouched; assignment (`rc = `), open-paren call
context (`Foo(`), and keyword context (`IF `) are all stripped from a non-SELF root; colon-prefixed
and multi-level (3+ segment) chains survive extraction intact; a prefix not ending in an identifier
is returned unchanged rather than mangled; and — the test that pins the actual bug mechanism rather
than just a literal string — the extracted result of a non-SELF chain is asserted to satisfy the
same `isPureChain` predicate the real callers use.

Proved non-vacuous: reverted the fix alone (tests unchanged), rebuilt, and reran just this file —
**7 of the 12 new tests fail**, each with the unstripped-context shape (e.g. expected `"Obj.Prop"`,
actual `"rc = Obj.Prop"`), including the pure-chain-gate test. The other 5 (SELF/PARENT anchoring,
non-mangling) pass in both states, as they should — they're regression guards, not the repro.
Restored the fix and reran: full suite 2561 passing, 0 failing, 4 pending.

## Scope

Fixes `ChainedPropertyResolver.extractChain` only, which is shared by every caller that walks a
chain (`StructureFieldResolver` for hover, `DefinitionProvider` for go-to-definition,
`ImplementationProvider`, `ReferencesProvider`, `ArgumentTypeResolver`) — so the fix applies to all
of them, not hover alone. Left deliberately out of scope: `ClassMemberResolver.extractClassName`
(the "what type does this segment's declaration resolve to" step later in the same chain walk) is
unrelated and untouched — this fix is purely about which text reaches the chain resolver in the
first place, not what it does with it once there.
