### PR TITLE
fix(diagnostics): discarded-return check did not report multi-segment dot-call

### DIFF
--- a/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
+++ b/server/src/providers/diagnostics/ReturnValueDiagnostics.ts
@@ -4,7 +4,7 @@ import { Token, TokenType } from '../../ClarionTokenizer';
 import { extractReturnType } from '../../utils/AttributeKeywords';
 import { ProcedureSignatureUtils } from '../../utils/ProcedureSignatureUtils';
 import { MemberLocatorService } from '../../services/MemberLocatorService';
-import { selectBestMemberOverload, OverloadCandidate } from '../../utils/ClassMemberResolver';
+import { selectBestMemberOverload, OverloadCandidate, ClassMemberResolver } from '../../utils/ClassMemberResolver';
 import { TokenCache } from '../../TokenCache';
 import { TokenHelper } from '../../utils/TokenHelper';
 import { DocumentStructure } from '../../DocumentStructure';
@@ -909,7 +909,16 @@ export async function validateDiscardedReturnValues(
     // `My:My:Method` — see the tokenizer's own Label pattern), so both groups
     // must allow it, or a colon-named local/member silently falls out of this
     // whole diagnostic.
-    const DOTCALL_PREFIX = /^([A-Za-z_][A-Za-z0-9_:]*)\.([A-Za-z_][A-Za-z0-9_:]*)/;
+    //
+    // Group 1 captures the WHOLE receiver chain (one or more "segment." runs),
+    // not just the first segment — a call reached through an intermediate field,
+    // e.g. a QUEUE holding a reference to a CLASS instance (`RecordQ.Item.Recalculate(...)`),
+    // used to parse as objectName="RecordQ", methodName="Item", leaving ".Recalculate(...)"
+    // as unconsumed text that failed the "anything after the closing paren?" guard
+    // below and silently skipped the entire line. See the chain walk after the root
+    // class is resolved, which mirrors ChainedPropertyResolver.resolveFinalClassName's
+    // hover-side handling of the same shape.
+    const DOTCALL_PREFIX = /^((?:[A-Za-z_][A-Za-z0-9_:]*\.)+)([A-Za-z_][A-Za-z0-9_:]*)/;
 
     // #158 Phase B Priority 1 — per-call-site memoization. Pre-#158 this loop
     // called `memberLocator.findMemberInClass` / `resolveDotAccess` once PER
@@ -1082,7 +1091,11 @@ export async function validateDiscardedReturnValues(
         const prefixMatch = stripped.match(DOTCALL_PREFIX);
         if (!prefixMatch) continue;
 
-        const objectName = prefixMatch[1];
+        // prefixMatch[1] is the chain-with-trailing-dot ("RecordQ.Item." or just "St.");
+        // drop the trailing dot and split to get every segment before the method name.
+        const chainSegments = prefixMatch[1].slice(0, -1).split('.');
+        const objectName = chainSegments[0];
+        const intermediateSegments = chainSegments.slice(1); // [] for a plain object.method call
         const methodName = prefixMatch[2];
         const afterMatch = stripped.substring(prefixMatch[0].length).trimStart();
 
@@ -1161,6 +1174,31 @@ export async function validateDiscardedReturnValues(
             className = typeInfo.typeName;
         }
 
+        // Chain walk: for `RecordQ.Item.Recalculate`, intermediateSegments=["Item"] sits
+        // between the resolved root class (RecordQ's QUEUE type) and the final method —
+        // walk each one to the class that actually owns the final member. Uncached
+        // (unlike the root/type and class-member memos above): only chains deeper than
+        // the common object.method case pay this, and findMemberInClass already handles
+        // CLASS/QUEUE/GROUP intermediate fields (proven by ChainedPropertyResolver's
+        // identical hover-side walk).
+        let chainBroken = false;
+        for (const segmentName of intermediateSegments) {
+            const segMemberInfo = await memberLocator.findMemberInClass(className, segmentName, document);
+            if (!segMemberInfo) {
+                logger.debug(`🔍 Line ${lineIdx + 1}: chain segment "${segmentName}" not found in "${className}" (${objectName}.${methodName})`);
+                chainBroken = true;
+                break;
+            }
+            const nextClass = ClassMemberResolver.extractClassName(segMemberInfo.type);
+            if (!nextClass) {
+                logger.debug(`🔍 Line ${lineIdx + 1}: chain segment "${segmentName}" type "${segMemberInfo.type}" is not navigable`);
+                chainBroken = true;
+                break;
+            }
+            className = nextClass;
+        }
+        if (chainBroken) continue;
+
         let typeStr: string | null = null;
         const members = await getClassMembers(className);
         if (members) {
@@ -1176,7 +1214,10 @@ export async function validateDiscardedReturnValues(
             // GROUP/QUEUE types), memoized per (obj|method|paramCount|selfContext).
             fallbackSites++;
             const selfContext = isSelfOrParent ? (range.selfClassName ?? '') : '';
-            const cacheKey = `${objUpper}|${methodName.toUpperCase()}|${paramCount}|${selfContext}`;
+            // Keyed by the resolved (possibly chain-walked) class, not objUpper: two
+            // chains can share a root name but end at different classes (e.g.
+            // Holder.RefA.Foo vs Holder.RefB.Foo), and objUpper alone would collide them.
+            const cacheKey = `${className.toUpperCase()}|${methodName.toUpperCase()}|${paramCount}|${selfContext}`;
 
             let memberInfoPromise = memberCache.get(cacheKey);
             if (!memberInfoPromise) {
@@ -1208,7 +1249,7 @@ export async function validateDiscardedReturnValues(
                 start: { line: lineIdx, character: colStart >= 0 ? colStart : 0 },
                 end: { line: lineIdx, character: colStart + stripped.length }
             },
-            message: `Return value of '${objectName}.${methodName}' is discarded. Capture the return value or add the PROC attribute to the declaration to suppress this warning.`,
+            message: `Return value of '${prefixMatch[0]}' is discarded. Capture the return value or add the PROC attribute to the declaration to suppress this warning.`,
             source: 'clarion'
         });
     }

--- a/server/src/test/ReturnValueDiagnostics.ChainedReceiver.test.ts
+++ b/server/src/test/ReturnValueDiagnostics.ChainedReceiver.test.ts
@@ -1,0 +1,154 @@
+/**
+ * validateDiscardedReturnValues — chained (3+ segment) dot-call receiver.
+ *
+ * DOTCALL_PREFIX previously matched only a single dot pair (`object.method`),
+ * so a call reached through an intermediate field — e.g. a QUEUE holding a
+ * reference to a CLASS instance (`RecordQ.Item.Recalculate(...)`) — parsed as
+ * objectName="RecordQ", methodName="Item", leaving ".Recalculate(...)" as
+ * unconsumed trailing text after the presumed call. That failed the
+ * "anything after the closing paren?" guard, so the whole line was silently
+ * skipped: the compiler still warns ("Calling function as procedure"), the
+ * extension stayed silent. A 2-segment call on the same class continued to
+ * diagnose correctly, which is what made the gap chain-depth-specific.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TokenCache } from '../TokenCache';
+import { MemberLocatorService } from '../services/MemberLocatorService';
+import { validateDiscardedReturnValues } from '../providers/diagnostics/ReturnValueDiagnostics';
+import { setServerInitialized } from '../serverState';
+
+let tmpDir: string;
+
+function createDoc(filename: string, code: string): TextDocument {
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, code);
+    const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+    return TextDocument.create(uri, 'clarion', 1, code);
+}
+
+suite('ReturnValueDiagnostics — chained receiver (Queue.RefField.Method)', () => {
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rvdChain_'));
+    });
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+    teardown(() => TokenCache.getInstance().clearAllTokens());
+
+    const discarded = (diags: { message: string }[]) =>
+        diags.filter(d => /is discarded/.test(d.message));
+
+    test('3-segment chain through a QUEUE reference field: discarded non-PROC return warns', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'ItemClass   CLASS,TYPE',
+            'Recalculate   PROCEDURE(LONG p), LONG',
+            '            END',
+            'RecordQ     QUEUE(),PRE(RecordQ)',
+            'Item          &ItemClass',
+            '            END',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  RecordQ.Item.Recalculate(1)',
+        ].join('\n');
+        const doc = createDoc('rvdChain.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        const warns = discarded(diags);
+        assert.strictEqual(warns.length, 1,
+            `chained receiver call must warn; got: ${warns.map(w => w.message).join(' | ')}`);
+        assert.ok(warns[0].message.includes("'RecordQ.Item.Recalculate'"),
+            'warning must name the full chain, not just the first dot pair');
+    });
+
+    test('3-segment chain: PROC-attributed method at the end of the chain stays silent', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'ItemClass   CLASS,TYPE',
+            'Recalculate   PROCEDURE(LONG p), LONG, PROC',
+            '            END',
+            'RecordQ     QUEUE(),PRE(RecordQ)',
+            'Item          &ItemClass',
+            '            END',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  RecordQ.Item.Recalculate(1)',
+        ].join('\n');
+        const doc = createDoc('rvdChainProc.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        assert.strictEqual(discarded(diags).length, 0, 'PROC-attributed chained method must not warn');
+    });
+
+    test('2-segment call on the same class is unaffected by the chain-walk change', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'ItemClass   CLASS,TYPE',
+            'Recalculate   PROCEDURE(LONG p), LONG',
+            '            END',
+            'Item   ItemClass',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  Item.Recalculate(1)',
+        ].join('\n');
+        const doc = createDoc('rvdPlain.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        const warns = discarded(diags);
+        assert.strictEqual(warns.length, 1, `plain 2-segment call must still warn; got: ${warns.map(w => w.message).join(' | ')}`);
+        assert.ok(warns[0].message.includes("'Item.Recalculate'"));
+    });
+
+    test('two chains sharing a root but ending at different classes resolve independently (cache-key regression guard)', async () => {
+        const code = [
+            "  MEMBER('prog.clw')",
+            '  MAP',
+            '  END',
+            'ClassA   CLASS,TYPE',
+            'Foo   PROCEDURE(), LONG',
+            '     END',
+            'ClassB   CLASS,TYPE',
+            'Foo   PROCEDURE(), LONG, PROC',
+            '     END',
+            'Holder   QUEUE(),PRE(Holder)',
+            'RefA       &ClassA',
+            'RefB       &ClassB',
+            '         END',
+            'Caller PROCEDURE()',
+            '  CODE',
+            '  Holder.RefA.Foo()',
+            '  Holder.RefB.Foo()',
+        ].join('\n');
+        const doc = createDoc('rvdChainCacheGuard.clw', code);
+        const tokens = TokenCache.getInstance().getTokens(doc);
+        const locator = new MemberLocatorService();
+        const diags = await validateDiscardedReturnValues(tokens, doc, locator);
+
+        const warns = discarded(diags);
+        assert.strictEqual(warns.length, 1,
+            `only the non-PROC chain (RefA.Foo) may warn; got: ${warns.map(w => w.message).join(' | ')}`);
+        assert.ok(warns[0].message.includes("'Holder.RefA.Foo'"),
+            'RefA.Foo (ClassA, non-PROC) must warn');
+        assert.ok(!warns.some(w => w.message.includes('RefB')),
+            'RefB.Foo (ClassB, PROC) must not warn even though it shares a root and method name with RefA.Foo');
+    });
+});


### PR DESCRIPTION
## What happened

`validateDiscardedReturnValues`'s discarded-return-value diagnostic never fired for a
call reached through an intermediate field — e.g. a QUEUE holding a reference to a
CLASS instance:

```clarion
RecordQ.Item.Recalculate(1)   ! Recalculate returns LONG, non-PROC, return value discarded
```

The Clarion compiler warns on this ("Calling function as procedure"); the extension
stayed completely silent. A 2-segment call on the same class (`Item.Recalculate(1)`)
continued to diagnose correctly, which is what made the gap chain-depth-specific
rather than a general dot-call miss.

## Root cause

`DOTCALL_PREFIX` matched only a single `object.method` pair:

```ts
const DOTCALL_PREFIX = /^([A-Za-z_][A-Za-z0-9_:]*)\.([A-Za-z_][A-Za-z0-9_:]*)/;
```

For `RecordQ.Item.Recalculate(...)` this parsed `objectName="RecordQ"`,
`methodName="Item"`, leaving `.Recalculate(...)` as unconsumed trailing text after
the presumed call. That text fails the "anything after the closing paren?" guard a
few lines later, so the entire line is skipped via `continue` — no diagnostic, no
error, no log.

## Fix

`DOTCALL_PREFIX` now captures the whole receiver chain:

```ts
const DOTCALL_PREFIX = /^((?:[A-Za-z_][A-Za-z0-9_:]*\.)+)([A-Za-z_][A-Za-z0-9_:]*)/;
```

Group 1 is split into the root segment plus zero or more intermediate segments;
group 2 is the final method name. The root is resolved exactly as before (SELF/PARENT
via the code range, otherwise a memoized `resolveVariableType` call). A new chain-walk
step then resolves each intermediate segment — `memberLocator.findMemberInClass` +
`ClassMemberResolver.extractClassName` — to the class that actually owns the final
member, before the existing method lookup runs. This is the same mechanism
`ChainedPropertyResolver.resolveFinalClassName` already uses to walk this exact chain
shape for hover/go-to-definition, just wired into this diagnostic too. The walk is
deliberately uncached (unlike the root-type and class-member memos above it): only
chains deeper than the common `object.method` case pay the extra per-segment lookup.

**Also fixed in passing:** the chain support surfaced a latent cache-key collision.
The per-site fallback cache (used when a receiver's class isn't cleanly enumerable)
was keyed by the root receiver name alone. Two chains sharing a root but ending at
different classes — `Holder.RefA.Foo()` vs `Holder.RefB.Foo()` — would have
incorrectly shared one cached resolution. The cache key now uses the resolved class
instead of the root name.

## Testing

`ReturnValueDiagnostics.ChainedReceiver.test.ts`, 4 new tests:
- 3-segment chain through a QUEUE reference field: discarded non-PROC return warns
- 3-segment chain: PROC-attributed method at the end of the chain stays silent
- 2-segment call on the same class is unaffected by the chain-walk change
- two chains sharing a root but ending at different classes resolve independently
  (the cache-key regression guard)

Proved non-vacuous: reverted the fix alone (`ReturnValueDiagnostics.ts`), recompiled,
reran — the 2 tests exercising an actual chain failed with the exact reported symptom
(`0 !== 1`, no diagnostic fired); the PROC-attributed and 2-segment control tests held
in both states, as regression guards should.

Full suite: **2587 passing / 0 failing / 4 pending** (baseline on this branch's base,
`origin/version-1.0.3`: 2583).

Live-verified in the real IDE against the original repro (a QUEUE-of-class-reference
field access with a discarded non-PROC LONG return) — diagnostics now match the
Clarion compiler's own warning.

## Scope

Deliberately left out: the `validateDiscardedReturnValuesForPlainCalls` function
(undecorated global-procedure calls) already excludes any dotted receiver outright
and is unaffected by this change. General N-deep chain resolution elsewhere in the
codebase (hover, go-to-definition, completion) already has its own chain-walking via
`ChainedPropertyResolver`/`StructureFieldResolver` and was not touched here — this PR
only wires the same already-proven mechanism into the discarded-return-value check.
