### PR TITLE
fix(hover): resolve a module-scope GROUP field to itself, not a same-named cross-file field

### DIFF
--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -269,6 +269,14 @@ export class HoverProvider {
                 mark('globalVar(noScope)');
                 if (globalVarHover) return globalVarHover;
 
+                // Cursor may be ON the declaration line of a module/global-scope
+                // structure field (e.g. a field inside a file-scope `GROUP,TYPE` in
+                // an .inc) — not a bare-name reference, so findGlobalVariableHover's
+                // PRE()/dot-qualifier exclusion above correctly doesn't match it.
+                const structureFieldHover = this.variableResolver.findStructureFieldDeclarationHover(word, tokens, document, position.line);
+                mark('structureFieldDecl(noScope)');
+                if (structureFieldHover) return structureFieldHover;
+
                 logger.info('No scope found and no global variable found - cannot provide hover');
 
                 const classTypeHover = await this.checkClassTypeHover(word, document);

--- a/server/src/providers/hover/VariableHoverResolver.ts
+++ b/server/src/providers/hover/VariableHoverResolver.ts
@@ -77,6 +77,32 @@ export class VariableHoverResolver {
     }
 
     /**
+     * Find and format hover for a module/global-scope structure field's OWN
+     * declaration line — a col-0 Label whose parent token is a GROUP/QUEUE/FILE/
+     * RECORD, declared outside any PROCEDURE (e.g. a field inside a module-level
+     * `SomeGroupType GROUP,TYPE` in an .inc file). `findLocalVariable`'s
+     * "exact token under the cursor wins" fast path only fires when a
+     * `currentScope` (PROCEDURE/ROUTINE) exists, so a field declared at true
+     * file scope never reaches it; `findGlobalVariableHover` also correctly
+     * excludes it from BARE-name lookups (structure fields need their
+     * PRE()/dot qualifier), but the cursor here is ON the declaration, not
+     * doing a bare-name reference. Without this, hovering such a field's own
+     * declaration showed nothing.
+     */
+    findStructureFieldDeclarationHover(word: string, tokens: Token[], document: TextDocument, hoverLine: number): Hover | null {
+        const symbolInfo = this.symbolFinder.findStructureField(word, tokens, hoverLine, document);
+        if (!symbolInfo) return null;
+
+        logger.info(`✅ Found structure field declaration for ${word} at line ${symbolInfo.location.line}`);
+        const variableInfo: VariableInfo = {
+            type: symbolInfo.type,
+            line: symbolInfo.location.line,
+            parentStructure: TokenHelper.getEnclosingDataStructure(symbolInfo.token, this.tokenCache.getStructure(document))
+        };
+        return this.formatter.formatVariable(word, variableInfo, symbolInfo.token, document, hoverLine);
+    }
+
+    /**
      * Find and format hover for a module-local variable
      */
     findModuleVariableHover(searchWord: string, tokens: Token[], document: TextDocument, hoverLine?: number): Hover | null {

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -988,6 +988,19 @@ export class MemberLocatorService {
         if (!(t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0)) {
             return false;
         }
+
+        // A field nested inside a GROUP/QUEUE/FILE/RECORD (t.parent set) is only
+        // reachable via its PRE()/dot qualifier — never as a bare name. Mirrors
+        // SymbolFinderService.findGlobalVariableInCurrentFile's `t.parent === undefined`
+        // exclusion for the exact same reason. Without this, a same-file lookup for a
+        // GROUP,TYPE field correctly comes up empty (fields need qualification) and falls
+        // through to this cross-file/include-chain walk — which had no such guard, so it
+        // matched the first same-named field in ANY unrelated structure reachable via the
+        // INCLUDE chain. Reported live: hovering a field's own declaration inside one
+        // GROUP,TYPE resolved to an unrelated same-named field of a completely different
+        // GROUP,TYPE several includes away.
+        if (t.parent !== undefined) return false;
+
         // A CLASS/INTERFACE member (property or method prototype) is only reachable via
         // qualified access (SELF.X / instance.X) — Clarion has no bare/global path to it,
         // even though its declaration token is column-0 and procedure-shaped exactly like a

--- a/server/src/test/HoverProvider.ModuleGroupFieldCrossFileCollision.test.ts
+++ b/server/src/test/HoverProvider.ModuleGroupFieldCrossFileCollision.test.ts
@@ -1,0 +1,136 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+import { setServerInitialized } from '../serverState';
+
+/**
+ * Real repro: a module/global-scope `GROUP,TYPE` field
+ * declared with no PRE() — e.g.
+ *
+ *   SomeErrorGroupType GROUP,TYPE
+ *   error                 STRING(256), NAME('error')
+ *   description           STRING(256), NAME('description')
+ *                       END
+ *
+ * Hovering `error`'s OWN declaration line showed an unrelated same-named field
+ * from a COMPLETELY DIFFERENT `GROUP,TYPE` reachable via the file's INCLUDE
+ * chain, several includes away — wrong type, wrong line, wrong file.
+ *
+ * Root cause: the same-file lookup (SymbolFinderService.findGlobalVariableInCurrentFile)
+ * correctly excludes a structure field from a BARE-name match (fields need their
+ * PRE()/dot qualifier — `t.parent === undefined` guard) and returns null, so
+ * resolution falls through to VariableHoverResolver.findGlobalVariableHover's
+ * cross-file INCLUDE-chain walk (MemberLocatorService.findVariableTokenInParentChain).
+ * That walk's candidate predicate, `isVariableLookupCandidate`, had NO equivalent
+ * `t.parent` exclusion — so it matched the first same-named field in ANY
+ * unrelated structure reachable via the chain, instead of reporting "not a bare
+ * global" the way the same-file check does.
+ *
+ * Fix: `isVariableLookupCandidate` now rejects any token with `t.parent` set,
+ * mirroring the same-file guard. A second, related gap this surfaces: with the
+ * wrong cross-file match now correctly rejected, hovering the field's own
+ * declaration returned NOTHING (no `currentScope` exists for module-scope data,
+ * so `findLocalVariable`'s "exact token under cursor" fast path — the local-
+ * procedure-GROUP equivalent of this fix — never runs). Added
+ * `VariableHoverResolver.findStructureFieldDeclarationHover`, wired into
+ * `HoverProvider`'s no-scope branch, so the declaration line resolves to
+ * itself via `SymbolFinderService.findStructureField` (a line-anchored lookup,
+ * immune to name collisions elsewhere).
+ */
+
+let tmpDir: string;
+
+function makeDoc(filename: string, content: string): TextDocument {
+    const uri = `file:///${path.join(tmpDir, filename).replace(/\\/g, '/')}`;
+    return TextDocument.create(uri, 'clarion', 1, content);
+}
+
+function cursorOn(source: string, needle: string, occurrence = 1): Position {
+    const lines = source.split(/\r?\n/);
+    let seen = 0;
+    for (let i = 0; i < lines.length; i++) {
+        const idx = lines[i].indexOf(needle);
+        if (idx !== -1) {
+            seen++;
+            if (seen === occurrence) return { line: i, character: idx };
+        }
+    }
+    throw new Error(`cursorOn: '${needle}' occurrence ${occurrence} not found`);
+}
+
+function hoverText(hover: any): string {
+    if (!hover) return '';
+    return typeof hover.contents === 'string' ? hover.contents : hover.contents.value ?? '';
+}
+
+suite('HoverProvider — module-scope GROUP,TYPE field declaration vs. cross-file name collision', () => {
+    const tokenCache = TokenCache.getInstance();
+
+    suiteSetup(() => {
+        setServerInitialized(true);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'group_field_xfile_'));
+
+        // Unrelated GROUP,TYPE in a totally different include, reachable via the
+        // host file's own INCLUDE chain.
+        fs.writeFileSync(path.join(tmpDir, 'Other.inc'), [
+            'OtherGroupType  GROUP, TYPE',
+            'Error             LONG',
+            '                END',
+        ].join('\n'));
+    });
+
+    suiteTeardown(() => {
+        tokenCache.clearAllTokens();
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    const HOST_CONTENT = [
+        "INCLUDE('Other.inc'), ONCE",
+        '',
+        'OwnGroupType  GROUP,TYPE',
+        "error           STRING(256), NAME('error')",
+        "description     STRING(256), NAME('description')",
+        '              END',
+    ].join('\n');
+
+    test('hovering the field\'s own declaration shows ITS OWN group/type, not the cross-file same-named field', async () => {
+        const doc = makeDoc('Host.inc', HOST_CONTENT);
+        const provider = new HoverProvider();
+
+        const pos = cursorOn(HOST_CONTENT, 'error');
+        const hover = await provider.provideHover(doc, pos);
+        const text = hoverText(hover);
+
+        assert.ok(text.length > 0, 'Expected a hover, got none');
+        assert.ok(text.includes('STRING'),
+            `Should show the field's own STRING(256) type, not the cross-file LONG; got:\n${text}`);
+        assert.ok(!text.includes('OtherGroupType'),
+            `Must not resolve to the unrelated cross-file OtherGroupType; got:\n${text}`);
+        assert.ok(text.includes('OwnGroupType'),
+            `Should note it belongs to its own OwnGroupType; got:\n${text}`);
+        assert.ok(text.includes('Host.inc:4') || /Host\.inc.*[:#]4\b/.test(text),
+            `Should cite its own declaration line (4, 1-based); got:\n${text}`);
+    });
+
+    test('hovering a field with no name collision anywhere still resolves to itself (not nothing)', async () => {
+        const doc = makeDoc('Host.inc', HOST_CONTENT);
+        const provider = new HoverProvider();
+
+        const pos = cursorOn(HOST_CONTENT, 'description');
+        const hover = await provider.provideHover(doc, pos);
+        const text = hoverText(hover);
+
+        assert.ok(text.length > 0, 'Expected a hover for the non-colliding field, got none');
+        assert.ok(text.includes('STRING'), `Should resolve the field's own STRING type; got:\n${text}`);
+        assert.ok(text.includes('OwnGroupType'), `Should note it belongs to OwnGroupType; got:\n${text}`);
+    });
+});


### PR DESCRIPTION
# fix(hover): resolve a module-scope GROUP field to itself, not a same-named cross-file field

Branch: `fix/group-field-crossfile-name-collision` (pushed to fork, targets `version-1.0.3`)

## What happened

A field inside a module/global-scope `GROUP,TYPE` declared with no `PRE()` —
e.g. a shared error-response GROUP declared in an `.inc` file, outside any
`PROCEDURE` — hovers over its OWN declaration line resolved to a completely
unrelated same-named field belonging to a DIFFERENT `GROUP,TYPE`, reached
several `INCLUDE`s away.

Repro shape:

```clarion
! Other.inc (reached via the host file's own INCLUDE chain)
OtherGroupType  GROUP, TYPE
Error             LONG
                END

! Host.inc
INCLUDE('Other.inc'), ONCE

OwnGroupType  GROUP,TYPE
error           STRING(256), NAME('error')
description     STRING(256), NAME('description')
              END
```

Hovering `error` on its own declaration line in `Host.inc` showed:

```
**Error** — `LONG`
🔷 `OtherGroupType` field
Error             LONG
Other.inc:2
```

— wrong type, wrong line, wrong file, presented with full confidence.

## Root cause

Two independent lookup tiers exist for a bare-name hover with no resolvable `currentScope` (module-level data has none — no enclosing `PROCEDURE`):

1. **Same-file lookup** — `SymbolFinderService.findGlobalVariableInCurrentFile`    requires `t.parent === undefined` before accepting a column-0 label as a   bare global match, specifically because a structure field always needs its
   `PRE()`/dot qualifier — it correctly rejects `error` here (its `.parent`   points at the `OwnGroupType` GROUP token) and returns `null`.

2. **Cross-file INCLUDE-chain fallback** — that correct rejection falls    through to `VariableHoverResolver.findGlobalVariableHover`'s call into   `MemberLocatorService.findVariableTokenInParentChain`, which walks every   file reachable via `INCLUDE(...)` looking for a bare-name match (this   exists for legitimate solution-wide globals declared in a shared `.inc`).
Its candidate predicate:

   ```ts
   private isVariableLookupCandidate(t: Token, doc: TextDocument, crossFile: boolean): boolean {
       if (!(t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0)) {
           return false;
       }
       // A CLASS/INTERFACE member ... is only reachable via qualified access
       const context = this.tokenCache.getStructure(doc).getStructureContextAt(t.line);
       if (context.inClass || context.inInterface) return false;
       ...
   }
   ```

   had NO equivalent `t.parent` exclusion. So it happily matched the first
   same-named field in *any* unrelated `GROUP`/`QUEUE`/`FILE`/`RECORD`
   reachable via the chain, instead of applying the same "fields need
   qualification" rule the same-file tier already enforces.

## The fix

`MemberLocatorService.isVariableLookupCandidate` now rejects any token with
`t.parent` set, mirroring the same-file guard:

```ts
private isVariableLookupCandidate(t: Token, doc: TextDocument, crossFile: boolean): boolean {
    if (!(t.type === TokenType.Structure || TokenHelper.isProcedureOrFunction(t) || t.start === 0)) {
        return false;
    }

    // A field nested inside a GROUP/QUEUE/FILE/RECORD (t.parent set) is only
    // reachable via its PRE()/dot qualifier — never as a bare name. Mirrors
    // SymbolFinderService.findGlobalVariableInCurrentFile's `t.parent === undefined`
    // exclusion for the exact same reason.
    if (t.parent !== undefined) return false;

    const context = this.tokenCache.getStructure(doc).getStructureContextAt(t.line);
    if (context.inClass || context.inInterface) return false;
    ...
```

### A second gap this surfaced

With the wrong cross-file match now correctly rejected, hovering the field's own declaration line returned **nothing at all**. Module-scope data has no `currentScope`, so `SymbolFinderService.findLocalVariable`'s "exact token under the cursor wins" fast path — already fixed for the analogous *procedure-local* GROUP case (`HoverProvider.GroupFieldDeclaration.test.ts`)
— never runs for a module-scope field, since that fast path is gated on having a `currentScope` in the first place.

Added `VariableHoverResolver.findStructureFieldDeclarationHover`, wired into `HoverProvider`'s existing no-`currentScope` branch, reusing the existing line-anchored `SymbolFinderService.findStructureField` (matches by declaration line, not by name — immune to collisions elsewhere):

```ts
findStructureFieldDeclarationHover(word: string, tokens: Token[], document: TextDocument, hoverLine: number): Hover | null {
    const symbolInfo = this.symbolFinder.findStructureField(word, tokens, hoverLine, document);
    if (!symbolInfo) return null;

    const variableInfo: VariableInfo = {
        type: symbolInfo.type,
        line: symbolInfo.location.line,
        parentStructure: TokenHelper.getEnclosingDataStructure(symbolInfo.token, this.tokenCache.getStructure(document))
    };
    return this.formatter.formatVariable(word, variableInfo, symbolInfo.token, document, hoverLine);
}
```

## Testing

2 new tests in `HoverProvider.ModuleGroupFieldCrossFileCollision.test.ts` (disk fixture — real `INCLUDE` resolution across two temp files):

- Hovering `error`'s own declaration shows its own `OwnGroupType`/`STRING`, not the cross-file `OtherGroupType`/`LONG`.
- Hovering `description` (no name collision anywhere) still resolves to itself, not nothing.

Proven non-vacuous: with the two fix files (`MemberLocatorService.ts`, `VariableHoverResolver.ts`, `HoverProvider.ts`) reverted and only the new test kept, both tests fail —

- Test 1 fails with the *exact* reported wrong-match shape (`OtherGroupType`   field, `LONG`, `Other.inc:2`).
- Test 2 fails with "expected a hover, got none".

— and both pass once the fix files are restored.

Full server suite: **2585 passing, 0 failing, 4 pending** (pending count unchanged from before this branch).

## Scope

- Deliberately does not touch `SymbolFinderService.findGlobalVariableInCurrentFile`   or the `#334`/`#344` include-chain-index path in `SymbolFinderService.ts`  (`buildIncludeChainIndex`) — both already carry the correct `t.parent`
  exclusion (the latter via its `structurePrefix`-qualified `pk` fallback for  legitimately `PRE()`-qualified fields). Only `MemberLocatorService`'s  separate, independently-implemented candidate predicate was missing it.
- `PRE()`-qualified `prefix:field` hover/lookup is untouched — it never  flowed through `isVariableLookupCandidate`/`tokenMatchesName` to begin  with (those have no colon handling); it resolves via
  `MemberLocatorService.findPrefixFieldTokenInChain`, a wholly separate path.
