### PR TITLE
fix(hover): render declaration location footers as clickable links

### DIFF
--- a/server/src/providers/HoverProvider.ts
+++ b/server/src/providers/HoverProvider.ts
@@ -856,9 +856,7 @@ export class HoverProvider {
             const hoverMarkdown = [
                 `**${info.name}** — ${typeLabel}`,
                 ``,
-                `📦 Defined in \`${fileName}\` at line ${info.line + 1}${parentLine}`,
-                ``,
-                `*(F12 to navigate to definition)*`
+                `📦 Defined in ${this.formatter.locationLink(info.filePath, info.line)}${parentLine}`
             ].join('\n');
 
             return {
@@ -928,7 +926,7 @@ export class HoverProvider {
         const loc = findSectionLocation(includeFile, sectionName, document.uri);
         const lines: string[] = [`**SECTION** \`'${sectionName}'\` — \`${includeFile}\``];
         if (loc) {
-            lines.push(`Resolves to: \`${loc.path}:${loc.line + 1}\``);
+            lines.push(`Resolves to: ${this.formatter.locationLink(loc.path, loc.line)}`);
         } else {
             lines.push(`⚠️ Section not found in the resolved include`);
         }
@@ -1253,7 +1251,7 @@ export class HoverProvider {
             const implementors = this.tokenCache.getStructure(document).getImplementors(ifaceName);
             if (implementors.length > 0) {
                 const list = implementors
-                    .map(c => `- \`${c.label ?? c.value}\` (line ${c.line + 1})`)
+                    .map(c => `- \`${c.label ?? c.value}\` — ${this.formatter.locationLink(document.uri, c.line)}`)
                     .join('\n');
                 implementorsFooter =
                     `\n\n**${implementors.length} class${implementors.length === 1 ? '' : 'es'} implement${implementors.length === 1 ? 's' : ''} this interface in this file:**\n${list}`;

--- a/server/src/providers/hover/MethodHoverResolver.ts
+++ b/server/src/providers/hover/MethodHoverResolver.ts
@@ -258,15 +258,15 @@ export class MethodHoverResolver {
         if (implLocation) {
             logger.info(`✅ Found implementation at ${implLocation}`);
             const lastColon = implLocation.lastIndexOf(':');
-            const implFile = path.basename(implLocation.substring(0, lastColon));
-            const implLine = parseInt(implLocation.substring(lastColon + 1)) + 1;
+            const implUri = implLocation.substring(0, lastColon);
+            const implLine0 = parseInt(implLocation.substring(lastColon + 1));
             return {
                 contents: {
                     kind: 'markdown',
                     value: [
                         `**${className}.${currentToken.label}** (Method Declaration)`,
                         ``,
-                        `${implFile}:${implLine}`
+                        this.formatter.locationLink(implUri, implLine0)
                     ].join('\n')
                 }
             };

--- a/server/src/providers/hover/RoutineHoverResolver.ts
+++ b/server/src/providers/hover/RoutineHoverResolver.ts
@@ -66,7 +66,7 @@ export class RoutineHoverResolver {
                     value: [
                         `**Routine:** \`${routineName}\``,
                         '',
-                        `📍 Line ${routineToken.line + 1}`,
+                        `📍 ${this.formatter.locationLink(document.uri, routineToken.line)}`,
                         '',
                         '```clarion',
                         ...allLines.slice(start, end),
@@ -119,7 +119,7 @@ export class RoutineHoverResolver {
                 value: [
                     `**Label:** \`${labelToken.value}\``,
                     '',
-                    `📍 Line ${labelToken.line + 1}`,
+                    `📍 ${this.formatter.locationLink(document.uri, labelToken.line)}`,
                     '',
                     '```clarion',
                     sourceLine,

--- a/server/src/test/GotoLabelNavigation321.test.ts
+++ b/server/src/test/GotoLabelNavigation321.test.ts
@@ -151,4 +151,17 @@ suite('GOTO statement labels — FAR/F12/hover (#321)', () => {
         assert.ok(text.includes(`${PROCA_LABEL_LINE + 1}`),
             `hover must cite the label's line ${PROCA_LABEL_LINE + 1}; got:\n${text}`);
     });
+
+    test('hover on the GOTO target renders its line as a clickable link, not plain text', async () => {
+        const doc = makeDoc();
+        const provider = new HoverProvider();
+        const hover = await provider.provideHover(doc, pos(PROCA_GOTO_LINE, SOURCE, 'Snag', 1));
+
+        assert.ok(hover, 'hover on GOTO target must resolve');
+        const contents = (hover as { contents: { value?: string } | string }).contents;
+        const text = typeof contents === 'string' ? contents : (contents.value ?? '');
+        const expectedLink = `[goto321.clw:${PROCA_LABEL_LINE + 1}](${URI}#L${PROCA_LABEL_LINE + 1})`;
+        assert.ok(text.includes(expectedLink),
+            `label location must be a clickable markdown link, not plain text; got:\n${text}`);
+    });
 });

--- a/server/src/test/HoverProvider.ClassTypeLocationLink.test.ts
+++ b/server/src/test/HoverProvider.ClassTypeLocationLink.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+import { SolutionManager } from '../solution/solutionManager';
+import { StructureDeclarationIndexer } from '../utils/StructureDeclarationIndexer';
+
+/**
+ * HoverProvider._checkClassTypeHoverInternal (the bare type-name hover, e.g.
+ * hovering `LinesGroupType` in `LIKE(LinesGroupType)`) used to hand-build its
+ * "Defined in" footer as `${fileName} at line ${line}` plain text, with a
+ * "(F12 to navigate to definition)" hint standing in for the missing link —
+ * unlike every other declaration hover, which already uses
+ * HoverFormatter.locationLink() to render a clickable footer. Fixed to call
+ * locationLink() too; the now-redundant F12 hint is dropped since the location
+ * links directly.
+ *
+ * Fixture mirrors HoverTypeIncludeChain.test.ts's disk-based #184 setup: a
+ * loose `.clw` (no solution loaded) that INCLUDEs a `.inc` declaring a TYPE.
+ */
+let tmpRoot = '';
+let savedSm: unknown;
+
+suite('HoverProvider — bare type-name hover "Defined in" footer is a clickable link', () => {
+    setup(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'classtype-link-'));
+        savedSm = (SolutionManager as unknown as { instance: unknown }).instance;
+        (SolutionManager as unknown as { instance: unknown }).instance = null;
+        StructureDeclarationIndexer.getInstance().clearCache();
+        TokenCache.getInstance().clearAllTokens();
+
+        fs.writeFileSync(path.join(tmpRoot, 'types.inc'), [
+            'LinesGroupType  CLASS,TYPE',
+            'count             LONG',
+            '                END',
+            '',
+        ].join('\n'));
+    });
+
+    teardown(() => {
+        (SolutionManager as unknown as { instance: unknown }).instance = savedSm;
+        StructureDeclarationIndexer.getInstance().clearCache();
+        TokenCache.getInstance().clearAllTokens();
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    test('"Defined in" footer renders as [file:line](file:///...#Lline), not plain text', async () => {
+        const consumerPath = path.join(tmpRoot, 'consumer.clw');
+        const consumerContent = [
+            '  MEMBER()',
+            "  INCLUDE('types.inc'),ONCE",
+            '',
+        ].join('\n');
+        fs.writeFileSync(consumerPath, consumerContent);
+        const uri = `file:///${consumerPath.replace(/\\/g, '/')}`;
+        const doc = TextDocument.create(uri, 'clarion', 1, consumerContent);
+        TokenCache.getInstance().getTokens(doc);
+
+        const provider = new HoverProvider();
+        // skipIncludeCheck=true: this test is about the footer's link shape, not
+        // the separate include-verification guard.
+        const hover = await (provider as unknown as {
+            checkClassTypeHover(word: string, document: TextDocument, skipIncludeCheck?: boolean): Promise<{ contents: { value: string } } | null>;
+        }).checkClassTypeHover('LinesGroupType', doc, true);
+
+        assert.ok(hover, 'expected a hover card for the type');
+        const text = hover!.contents.value;
+        assert.ok(/\[types\.inc:1\]\(file:\/\/\/.*types\.inc#L1\)/i.test(text),
+            `"Defined in" location must be a clickable markdown link, not plain text; got: ${text}`);
+        assert.ok(!/F12/.test(text),
+            `redundant F12 hint should be dropped now the location links directly; got: ${text}`);
+    });
+});

--- a/server/src/test/HoverProvider.InterfaceImplementorsLocationLink.test.ts
+++ b/server/src/test/HoverProvider.InterfaceImplementorsLocationLink.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+import { setServerInitialized } from '../serverState';
+
+/**
+ * HoverProvider.buildInterfaceHover()'s "classes implement this interface in
+ * this file" footer used to hand-build each entry as `` `label` (line N) ``
+ * plain text instead of calling HoverFormatter.locationLink() — unlike every
+ * other declaration hover, which already renders a clickable footer.
+ *
+ * Fixture is the same CSocketConn/IConn shape InterfaceFeatures.test.ts's
+ * "IMPLEMENTS references" suite already uses.
+ */
+const CODE = [
+    'IConn  INTERFACE,TYPE',                                            // line 0
+    '  CloseSocket  PROCEDURE',                                         // line 1
+    'END',                                                              // line 2
+    '',                                                                 // line 3
+    "CSocketConn  CLASS,IMPLEMENTS(IConn),TYPE,MODULE('test.clw')",     // line 4
+    '  CloseSocket  PROCEDURE,VIRTUAL',                                 // line 5
+    'END',                                                              // line 6
+].join('\n');
+
+const URI = 'file:///implementors-link-test.clw';
+
+suite('HoverProvider — INTERFACE implementors footer is a clickable link', () => {
+    setup(() => {
+        setServerInitialized(true);
+        TokenCache.getInstance().clearAllTokens();
+    });
+
+    function makeDoc(): TextDocument {
+        const doc = TextDocument.create(URI, 'clarion', 1, CODE);
+        TokenCache.getInstance().getTokens(doc);
+        return doc;
+    }
+
+    test('implementing class is listed as [file:line](file:///...#Lline), not plain text', async () => {
+        const doc = makeDoc();
+        const provider = new HoverProvider();
+
+        // Cursor on "IConn" in "IConn  INTERFACE,TYPE" (line 0) — hovering the
+        // interface's own declaration triggers buildInterfaceHover with the
+        // implementors footer.
+        const hover = await provider.provideHover(doc, { line: 0, character: 2 });
+
+        assert.ok(hover, 'expected a hover card for the INTERFACE');
+        const contents = (hover as { contents: { value?: string } | string }).contents;
+        const text = typeof contents === 'string' ? contents : (contents.value ?? '');
+
+        assert.ok(text.includes('CSocketConn'),
+            `footer must name the implementing class; got:\n${text}`);
+        const expectedLink = `[implementors-link-test.clw:5](${URI}#L5)`;
+        assert.ok(text.includes(expectedLink),
+            `implementor location must be a clickable markdown link, not plain text; got:\n${text}`);
+    });
+});

--- a/server/src/test/MethodHoverResolver.DeclarationLocationLink.test.ts
+++ b/server/src/test/MethodHoverResolver.DeclarationLocationLink.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-protocol';
+import { HoverProvider } from '../providers/HoverProvider';
+import { TokenCache } from '../TokenCache';
+
+/**
+ * resolveMethodDeclaration()'s "implementation found" footer must render as a CLICKABLE
+ * markdown link via HoverFormatter.locationLink() — the same helper every other
+ * declaration hover (class declaration, method call, chained call) already uses. It
+ * previously hand-built `${file}:${line}` as plain text instead, so hovering a method
+ * declaration showed its implementation location as dead text while a class-declaration
+ * hover a few lines away in the same resolver was already clickable.
+ *
+ * The fixture lives on a REAL file on disk (not a `test://` URI) — locationLink only
+ * produces a link for an openable `file:` URI (see HoverFormatter.LocationLink.test.ts),
+ * so an in-memory-only document would make the link assertion below pass vacuously
+ * regardless of whether the fix is present.
+ */
+const CLASS_WITH_IMPL = [
+    'PROGRAM',
+    '  MAP',
+    '  END',
+    '',
+    'MyClass CLASS',
+    'DoWork PROCEDURE',
+    '  END',
+    '',
+    'MyClass.DoWork PROCEDURE',
+    '  CODE',
+    ''
+].join('\n');
+
+suite('MethodHoverResolver — declaration hover implementation footer is a clickable link', () => {
+    let provider: HoverProvider;
+    let tokenCache: TokenCache;
+    let tmpRoot: string;
+
+    suiteSetup(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'method-decl-link-'));
+    });
+
+    suiteTeardown(() => {
+        try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    });
+
+    setup(() => {
+        provider = new HoverProvider();
+        tokenCache = TokenCache.getInstance();
+        tokenCache.clearAllTokens();
+    });
+
+    teardown(() => {
+        tokenCache.clearAllTokens();
+    });
+
+    function hoverText(hover: any): string {
+        if (!hover) return '';
+        return typeof hover.contents === 'string'
+            ? hover.contents
+            : 'value' in hover.contents ? hover.contents.value : '';
+    }
+
+    test('implementation location renders as [file:line](file:///...#Lline), not plain text', async () => {
+        const filePath = path.join(tmpRoot, 'class-with-impl.clw');
+        fs.writeFileSync(filePath, CLASS_WITH_IMPL, 'utf8');
+        const uri = `file:///${filePath.replace(/\\/g, '/')}`;
+        const doc = TextDocument.create(uri, 'clarion', 1, CLASS_WITH_IMPL);
+        tokenCache.getTokens(doc);
+
+        const hover = await provider.provideHover(doc, Position.create(5, 0)); // "DoWork" method declaration
+        const content = hoverText(hover);
+
+        assert.ok(!content.includes('Implementation not found'),
+            `should resolve the implementation; got: ${content}`);
+
+        const expectedLink = `[class-with-impl.clw:9](${uri}#L9)`;
+        assert.ok(content.includes(expectedLink),
+            `implementation footer must be a clickable markdown link, not plain text; got: ${content}`);
+    });
+});

--- a/server/src/test/RoutineScopeConsistency.test.ts
+++ b/server/src/test/RoutineScopeConsistency.test.ts
@@ -58,12 +58,12 @@ suite('Routine scoping — hover + Ctrl+F12 agree with F12 (#264)', () => {
             ? (hover!.contents as { value: string }).value
             : String(hover!.contents);
         assert.ok(
-            text.includes('Line 11'),
-            `hover should point at OtherProc's routine (display Line 11); got: ${text.replace(/\n/g, ' | ')}`
+            text.includes('#L11'),
+            `hover should point at OtherProc's routine (display #L11); got: ${text.replace(/\n/g, ' | ')}`
         );
         assert.ok(
-            !text.includes('Line 4'),
-            `hover must NOT point at MyProc's routine (display Line 4); got: ${text.replace(/\n/g, ' | ')}`
+            !text.includes('#L4'),
+            `hover must NOT point at MyProc's routine (display #L4); got: ${text.replace(/\n/g, ' | ')}`
         );
     });
 
@@ -92,7 +92,7 @@ suite('Routine scoping — hover + Ctrl+F12 agree with F12 (#264)', () => {
         const text = typeof hover!.contents === 'object' && 'value' in hover!.contents
             ? (hover!.contents as { value: string }).value
             : String(hover!.contents);
-        assert.ok(text.includes('Line 4'), `MyProc's DO should show Line 4; got: ${text.replace(/\n/g, ' | ')}`);
+        assert.ok(text.includes('#L4'), `MyProc's DO should show #L4; got: ${text.replace(/\n/g, ' | ')}`);
 
         const impl = await new ImplementationProvider().provideImplementation(doc, { line: 2, character: 8 });
         assert.ok(impl, 'Ctrl+F12 in MyProc should resolve');

--- a/server/src/test/SectionArgNavigation343.test.ts
+++ b/server/src/test/SectionArgNavigation343.test.ts
@@ -93,6 +93,14 @@ suite('Issue #343 — INCLUDE section-argument navigation', () => {
         assert.ok(text.includes(':4'), `card must carry the 1-based section line; got ${text.slice(0, 200)}`);
     });
 
+    test('hover on the section name renders the location as a clickable link, not plain text', async () => {
+        const hover = await new HoverProvider().provideHover(makeDoc(), posOn(1, 'SmokeSection'));
+        assert.ok(hover, 'expected a hover card');
+        const text = JSON.stringify(hover!.contents);
+        assert.ok(/\[sections\.clw:4\]\(file:\/\/\/.*sections\.clw#L4\)/i.test(text),
+            `section location must be a clickable markdown link, not plain text; got ${text.slice(0, 300)}`);
+    });
+
     test('hover on an unknown section still shows a card with the not-found note', async () => {
         const hover = await new HoverProvider().provideHover(makeDoc(), posOn(2, 'NoSuchSection'));
         assert.ok(hover, 'expected a hover card');


### PR DESCRIPTION
# fix(hover): render declaration location footers as clickable links

## What happened

Hovering a method declaration (e.g. `MyClass.MyMethod`) showed its implementation location
as plain text:

```
MyClass.MyMethod (Method Declaration)
MyClass.clw:781
```

`MyClass.clw:781` was not clickable, unlike other declaration hovers (e.g. a class-declaration hover a few lines away in the same resolver) which already render their location as `[file:line](file:///...#Lline)` — a link VS Code/Monaco opens on click, with no extra request.

## Root cause

`HoverFormatter.locationLink(fileOrUri, line0)` is the shared helper that renders that clickable link shape. Five hover sites bypassed it and hand-built their footer as a plain `${file}:${line}` (or bare `Line N`) string instead — the same oversight,  independently repeated at each site:

1. **`MethodHoverResolver.resolveMethodDeclaration()`** — a method declaration's "implementation found" footer:
   ```ts
   const implFile = path.basename(implLocation.substring(0, lastColon));
   const implLine = parseInt(implLocation.substring(lastColon + 1)) + 1;
   // ...
   `${implFile}:${implLine}`
   ```

2. **`RoutineHoverResolver.resolveRoutineReference()`** and  **`resolveGotoLabelReference()`** — the same-file line for a `DO Routine` / `GOTO Label`  target:
   ```ts
   `📍 Line ${routineToken.line + 1}`,
   // and
   `📍 Line ${labelToken.line + 1}`,
   ```

3. **`HoverProvider._checkClassTypeHoverInternal()`** — a bare type-name's "Defined in" footer, which additionally papered over the missing link with an F12 hint:
   ```ts
   `📦 Defined in \`${fileName}\` at line ${info.line + 1}${parentLine}`,
   ``,
   `*(F12 to navigate to definition)*`
   ```

4. **`HoverProvider.buildSectionRefHover()`** — the resolved file+line for a SECTION argument of `INCLUDE('file','section')`:
   ```ts
   lines.push(`Resolves to: \`${loc.path}:${loc.line + 1}\``);
   ```

5. **`HoverProvider.buildInterfaceHover()`** — each implementing class's location in an INTERFACE hover's "implements this interface in this file" list:
   ```ts
   .map(c => `- \`${c.label ?? c.value}\` (line ${c.line + 1})`)
   ```

## The fix

Each site now calls `this.formatter.locationLink(uri, line0)` instead of hand-building the footer string. Example (site 1):

```ts
const implUri = implLocation.substring(0, lastColon);
const implLine0 = parseInt(implLocation.substring(lastColon + 1));
// ...
this.formatter.locationLink(implUri, implLine0)
```

Site 3's now-redundant `*(F12 to navigate to definition)*` hint is dropped, since the location links directly.

`locationLink` itself needed no changes — its link-shape contract (already covered by `HoverFormatter.LocationLink.test.ts`) was correct; every site above simply never called it.

## Testing

Each of the five sites gets a dedicated test asserting the exact `[name:line](uri#Lline)` link shape, and each was proven real: verified failing against the pre-fix code (`git apply -R` on just that hunk), then passing again after restoring the fix.

- `MethodHoverResolver.DeclarationLocationLink.test.ts` (new)
- `GotoLabelNavigation321.test.ts` — new test added alongside the existing DO/GOTO tests
- `RoutineScopeConsistency.test.ts` — two pre-existing assertions checked the literal
  `Line N` text; updated to check the `#Lline` URI fragment instead, since the display
  format intentionally changed (their scoping assertions are otherwise unchanged)
- `HoverProvider.ClassTypeLocationLink.test.ts` (new)
- `SectionArgNavigation343.test.ts` — new test added alongside the existing SECTION-hover
  tests
- `HoverProvider.InterfaceImplementorsLocationLink.test.ts` (new)

Full suite: **2588 passing / 0 failing / 4 pending** on a clean `origin/version-1.0.3` base plus only this branch's commit.

Live-verified in a real IDE against a production Clarion codebase: the method-declaration, `DO`-routine, `GOTO`-label, and bare-type-name hovers (both `LIKE()` and direct type-as-datatype usage) all render clickable links end-to-end. The SECTION-argument and INTERFACE-implementors hovers weren't exercised live (that codebase doesn't currently use those shapes) but are covered by the new unit tests above.

## Scope

Deliberately unchanged: `HoverFormatter.locationLink()` itself, and every hover site that already called it correctly (`StructureFieldResolver`, `VariableHoverResolver`, `HoverProvider.buildFileRefHover`'s whole-file-path display, `HoverProvider.renderFieldEquateCard`, etc.) — this PR only touches the five sites that never called it.
