### PR TITLE
fix(references): report a ROUTINE declaration at its label, not the ROUTINE keyword

### DIFF
--- a/server/src/providers/DefinitionProvider.ts
+++ b/server/src/providers/DefinitionProvider.ts
@@ -1695,7 +1695,9 @@ export class DefinitionProvider {
         }
 
         logger.info(`✅ Found ROUTINE "${routineName}" at line ${routineToken.line}`);
-        return Location.create(document.uri, Range.create(routineToken.line, 0, routineToken.line, routineToken.value.length));
+        // `routineToken.value` is "ROUTINE"; the routine's name is on `.label`. See
+        // TokenHelper.getRoutineLabelRange.
+        return Location.create(document.uri, TokenHelper.getRoutineLabelRange(routineToken));
     }
 
 }

--- a/server/src/providers/ImplementationProvider.ts
+++ b/server/src/providers/ImplementationProvider.ts
@@ -368,13 +368,9 @@ export class ImplementationProvider {
         const routineToken = TokenHelper.findScopedRoutineToken(structure, routineName, position.line);
         if (routineToken) {
             logger.info(`✅ Found routine at line ${routineToken.line}`);
-            return Location.create(
-                document.uri,
-                {
-                    start: { line: routineToken.line, character: 0 },
-                    end: { line: routineToken.line, character: routineToken.value.length }
-                }
-            );
+            // `routineToken.value` is "ROUTINE"; the routine's name is on `.label`. See
+            // TokenHelper.getRoutineLabelRange.
+            return Location.create(document.uri, TokenHelper.getRoutineLabelRange(routineToken));
         }
 
         return null;

--- a/server/src/providers/ReferencesProvider.ts
+++ b/server/src/providers/ReferencesProvider.ts
@@ -1839,10 +1839,12 @@ export class ReferencesProvider {
     ): Location[] {
         const locations: Location[] = [];
         if (includeDeclaration) {
-            locations.push(Location.create(document.uri, {
-                start: { line: routineToken.line, character: routineToken.start },
-                end: { line: routineToken.line, character: routineToken.start + routineToken.value.length }
-            }));
+            // The routine token IS the ROUTINE keyword — `value` is "ROUTINE", `label` is the
+            // routine's name — so its own start and length describe the keyword, not the label.
+            // Reported that way, the declaration highlights the word ROUTINE, and a second
+            // extension contributing the label's range shows as a separate reference to the same
+            // place. See TokenHelper.getRoutineLabelRange.
+            locations.push(Location.create(document.uri, TokenHelper.getRoutineLabelRange(routineToken)));
         }
 
         const wordLower = word.toLowerCase();

--- a/server/src/test/ReferencesProvider.test.ts
+++ b/server/src/test/ReferencesProvider.test.ts
@@ -639,3 +639,125 @@ suite('ReferencesProvider – local CLASS label references', () => {
             `Should find method implementation headers at lines 10 and 14. Lines found: ${refLines}`);
     });
 });
+
+// ---------------------------------------------------------------------------
+// ReferencesProvider — ROUTINE declaration label
+// ---------------------------------------------------------------------------
+
+suite('ReferencesProvider – ROUTINE label references', () => {
+    let provider: ReferencesProvider;
+
+    setup(() => {
+        setServerInitialized(true);
+        TokenCache.getInstance().clearAllTokens();
+        provider = new ReferencesProvider();
+    });
+
+    /**
+     * Same shape as the local CLASS label case above, one keyword along.
+     *
+     * On "PrepareProcedure ROUTINE" the tokenizer emits TWO tokens that know the routine's name:
+     *
+     *     start | type    | value              | label
+     *         0 | Label   | "PrepareProcedure" | "PrepareProcedure"
+     *        17 | Keyword | "ROUTINE"          | "PrepareProcedure"
+     *
+     * The Label token matches by value and yields the correct range. The ROUTINE keyword token
+     * matches by `label` in findReferencesInFile, and that branch takes matchLength from the label
+     * while leaving matchStart at the KEYWORD's column — so it reports Range(line, 17)..(line, 33)
+     * on a 24-character line. The editor clamps it to end of line, which renders as a reference
+     * highlighting the word "ROUTINE".
+     *
+     * NOTE ON REPRODUCING THIS: a bare ROUTINE at the top of a file will NOT reproduce it. The
+     * tokenizer only attaches `label` to the ROUTINE keyword when the routine sits inside a
+     * procedure, so the surrounding PROCEDURE below is load-bearing rather than scenery.
+     */
+    test('Cursor on ROUTINE label reports the label position, not the ROUTINE keyword position', async () => {
+        const code = [
+            "  MEMBER('demoleg')",       // line 0
+            '',                           // line 1
+            'BrowseInvoice PROCEDURE',    // line 2
+            '  CODE',                     // line 3
+            '  DO PrepareProcedure',      // line 4 — call site
+            '  RETURN',                   // line 5
+            '',                           // line 6
+            'PrepareProcedure ROUTINE',   // line 7 — declaration, label at col 0
+            '  CODE',                     // line 8
+            '  RETURN',                   // line 9
+        ].join('\n');
+
+        const doc = createDocument(code, 'file:///routine-label.clw');
+        seedCache(doc);
+
+        // Cursor on the routine's label at line 7, col 2.
+        const refs = await provider.provideReferences(doc, { line: 7, character: 2 },
+            { includeDeclaration: true });
+
+        assert.ok(refs !== null, 'Should return results, not null');
+
+        const declarationRefs = refs!.filter(r => r.range.start.line === 7);
+        assert.ok(declarationRefs.length >= 1, 'Should report the declaration line');
+
+        // The declaration must be reported at the LABEL, col 0 — never at the ROUTINE keyword.
+        const wrongColRefs = declarationRefs.filter(r => r.range.start.character > 0);
+        assert.strictEqual(wrongColRefs.length, 0,
+            `Declaration reference must be at col 0 (the label), not the ROUTINE keyword position. Got: ${JSON.stringify(wrongColRefs)}`);
+
+        // And exactly one entry for that line: the label token and the keyword token both know the
+        // name, and reporting both makes one declaration look like two references.
+        assert.strictEqual(declarationRefs.length, 1,
+            `Declaration line should produce ONE reference, not one per token carrying the label. Got: ${JSON.stringify(declarationRefs)}`);
+
+        // The call site is unaffected and must still be found.
+        const refLines = refs!.map(r => r.range.start.line).sort((a, b) => a - b);
+        assert.ok(refLines.includes(4), `Should still find the DO call site on line 4. Lines found: ${refLines}`);
+    });
+
+    /**
+     * The same defect reached from the CALL SITE rather than the label, asserted as exact ranges.
+     *
+     * An earlier version of this test asserted only the COUNT — and passed before the fix, because
+     * the count was never wrong. One entry was simply in the wrong place. A test that cannot fail
+     * against the defect it names is worse than no test, so this one pins both ranges.
+     */
+    test('From a DO site, the declaration range covers the label and the call covers the name', async () => {
+        const code = [
+            "  MEMBER('demoleg')",       // line 0
+            '',                           // line 1
+            'BrowseInvoice PROCEDURE',    // line 2
+            '  CODE',                     // line 3
+            '  DO PrepareProcedure',      // line 4
+            '  RETURN',                   // line 5
+            '',                           // line 6
+            'PrepareProcedure ROUTINE',   // line 7
+            '  CODE',                     // line 8
+            '  RETURN',                   // line 9
+        ].join('\n');
+
+        const doc = createDocument(code, 'file:///routine-count.clw');
+        seedCache(doc);
+
+        const refs = await provider.provideReferences(doc, { line: 4, character: 6 },
+            { includeDeclaration: true });
+
+        assert.ok(refs !== null, 'Should return results, not null');
+        assert.strictEqual(refs!.length, 2,
+            `One declaration and one call site is two references. Got ${refs!.length}: ${JSON.stringify(refs!.map(r => `${r.range.start.line}:${r.range.start.character}`))}`);
+
+        const describe = (r: typeof refs extends null ? never : NonNullable<typeof refs>[number]) =>
+            `${r.range.start.line}:${r.range.start.character}-${r.range.end.character}`;
+
+        const declaration = refs!.find(r => r.range.start.line === 7);
+        const callSite = refs!.find(r => r.range.start.line === 4);
+
+        // "PrepareProcedure ROUTINE" — the label occupies columns 0..16.
+        assert.ok(declaration !== undefined, 'Should report the declaration');
+        assert.strictEqual(describe(declaration!), '7:0-16',
+            `Declaration must cover the label "PrepareProcedure", not the ROUTINE keyword. Got ${describe(declaration!)}`);
+
+        // "  DO PrepareProcedure" — the name occupies columns 5..21.
+        assert.ok(callSite !== undefined, 'Should report the DO call site');
+        assert.strictEqual(describe(callSite!), '4:5-21',
+            `Call site must cover the routine name. Got ${describe(callSite!)}`);
+    });
+});

--- a/server/src/utils/TokenHelper.ts
+++ b/server/src/utils/TokenHelper.ts
@@ -261,6 +261,28 @@ export class TokenHelper {
     }
 
     /**
+     * The range of a ROUTINE's LABEL, given the routine token.
+     *
+     * `findScopedRoutineToken` and `DocumentStructure.findRoutines` return the ROUTINE **keyword**
+     * token, whose `value` is `"ROUTINE"` and whose `label` is the routine's name. Building a range
+     * from `routineToken.value.length` therefore measures the keyword, not the label — and the three
+     * providers that navigate to a routine had each open-coded it slightly differently, producing
+     * three different wrong ranges for `PrepareProcedure ROUTINE`:
+     *
+     *     ReferencesProvider       cols 17-24   "ROUTINE"            (start and length both the keyword)
+     *     DefinitionProvider       cols  0-7    "Prepare"            (start right, length the keyword)
+     *     ImplementationProvider   cols  0-7    "Prepare"            (same)
+     *     correct                  cols  0-16   "PrepareProcedure"
+     *
+     * A Clarion label must begin in column 1, so the label starts at character 0 by language rule
+     * rather than by observation.
+     */
+    public static getRoutineLabelRange(routineToken: Token): Range {
+        const labelLength = (routineToken.label ?? routineToken.value).length;
+        return Range.create(routineToken.line, 0, routineToken.line, labelLength);
+    }
+
+    /**
      * #321 — resolve a GOTO target: a statement label visible from `cursorLine`
      * under GOTO's scope rule (Language Reference): the target must be the
      * label of another EXECUTABLE statement inside the currently executing


### PR DESCRIPTION
Hi Mark — found this while building CodeGraph-backed language features for the Clarion Assistant VS Code extension, and it seemed only fair to send a fix rather than a bug report given how many PRs have come the other way.

## What's wrong

`findScopedRoutineToken` and `DocumentStructure.findRoutines` return the ROUTINE **keyword** token — its `value` is `"ROUTINE"`, and the routine's name is on `.label`. Three providers build a navigation range from that token, each open-coded separately, so each gets it wrong differently. For `PrepareProcedure ROUTINE`:

| | range | covers |
|---|---|---|
| `ReferencesProvider` | cols 17–24 | `ROUTINE` |
| `DefinitionProvider` | cols 0–7 | `Prepare` |
| `ImplementationProvider` | cols 0–7 | `Prepare` |
| correct | cols 0–16 | `PrepareProcedure` |

The references one is what you'd notice: Find All References on a routine highlights the word `ROUTINE` instead of the routine's name.

## Why I hit it

Our extension registers its own reference provider alongside yours. VS Code de-duplicates reference results by URI **and range**, so your declaration entry (on the keyword) and ours (on the label) don't collapse — one declaration lists twice and the count reads one too high. I could have papered over it on our side, but yours is the range that's wrong, and hiding it would just move the problem.

## The fix

Adds `TokenHelper.getRoutineLabelRange()` and uses it at all three sites rather than patching them individually — three different wrong answers to one question is what open-coding it three times produced. A Clarion label must begin in column 1, so character 0 is by language rule rather than by observation.

## Tests

Two regression tests in the existing `ReferencesProvider` suite, next to your local-CLASS-label test that pins the same shape for `CLASS` declarations. Both fail before the change and pass after; your 2583 server tests are unaffected (2585 passing).

One trap worth flagging: **a bare `ROUTINE` at the top of a file does not reproduce this.** The tokenizer only attaches `label` to the ROUTINE keyword when the routine sits inside a procedure — my first fixture didn't, and passed against the defect. The enclosing `PROCEDURE` in the test fixtures is load-bearing rather than scenery.

Verified in the Extension Development Host against a real solution, not only in unit tests.
