### PR TITLE
fix(map): bare MAP entries are procedure declarations, not Variables (#462)

### DIFF
--- a/server/src/DocumentStructure.ts
+++ b/server/src/DocumentStructure.ts
@@ -1759,18 +1759,25 @@ export class DocumentStructure {
         // Find the END statement for this MAP
         let endIndex = -1;
         let depth = 1;
+        // Innermost enclosing structure, so a declaration inside MODULE('x.clw') is
+        // parented to that MODULE and not to the outer MAP. Consumers rely on the
+        // distinction: a bare entry parented to the MAP is a self-declaration (#338),
+        // one parented to a MODULE is implemented in the file that MODULE names.
+        const structureStack: Token[] = [mapToken];
         
         for (let i = mapIndex + 1; i < this.tokens.length; i++) {
             const token = this.tokens[i];
             
             if (token.type === TokenType.Structure) {
                 depth++;
+                structureStack.push(token);
             } else if (token.type === TokenType.EndStatement) {
                 depth--;
                 if (depth === 0) {
                     endIndex = i;
                     break;
                 }
+                if (structureStack.length > 1) structureStack.pop();
             }
             
             // Pattern 1: Look for tokens that contain an opening parenthesis in the same token value
@@ -1809,6 +1816,43 @@ export class DocumentStructure {
                 token.label = token.value;
                 
                 if (DOCSTRUCT_TRACE) logger.info(`📌 Found MAP shorthand procedure (separate tokens): ${token.value} at line ${token.line}`);
+            }
+            // Pattern 3: BARE declaration - a name alone on its line, with no parameter
+            // list at all. This is the shape template-generated apps emit for
+            // parameterless procedures:
+            //
+            //     MAP
+            //       MODULE('demoleg002.clw')
+            //         BrowseInvoice
+            //       END
+            //     END
+            //
+            // Patterns 1 and 2 both key off a '(', so a bare name matched neither and
+            // kept its tokenized type (Variable) with no subType. Every consumer that
+            // asks "is this a MAP declaration?" tests subType against MapProcedure, so
+            // the declaration was invisible to all of them: findMapDeclarationInMemberFile
+            // located the right MODULE block, found zero declarations inside it, and
+            // missing-map-declaration fired on a procedure that IS declared (#462).
+            // A MAP body holds only prototypes and MODULE blocks, so a lone identifier
+            // here is a prototype; requiring it to be alone on its line keeps attributes
+            // and multi-token forms out.
+            else if ((token.type === TokenType.Variable ||
+                      token.type === TokenType.Label ||
+                      token.type === TokenType.Function) &&
+                     token.subType === undefined &&
+                     !isAttributeKeyword(token.value) &&
+                     !/^(MODULE|MAP|END|PROCEDURE|FUNCTION)$/i.test(token.value) &&
+                     !token.value.startsWith("!") &&
+                     /^[A-Za-z_][A-Za-z0-9_:.]*$/.test(token.value) &&
+                     (this.tokens[i - 1] === undefined || this.tokens[i - 1].line !== token.line) &&
+                     (this.tokens[i + 1] === undefined || this.tokens[i + 1].line !== token.line)) {
+                const owner = structureStack[structureStack.length - 1];
+                token.subType = TokenType.MapProcedure;
+                token.label = token.value;
+                token.parent = owner;
+                this.addChildOnce(owner, token);
+
+                if (DOCSTRUCT_TRACE) logger.info(`Found MAP bare procedure declaration: ${token.value} at line ${token.line} inside ${owner.value.toUpperCase()}`);
             }
         }
     }

--- a/server/src/test/MapDeclaration.BareModuleDeclaration462.test.ts
+++ b/server/src/test/MapDeclaration.BareModuleDeclaration462.test.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { ClarionTokenizer } from '../ClarionTokenizer';
+import { TokenType } from '../tokenizer/TokenTypes';
+
+/**
+ * Issue #462 — a BARE MAP entry (no PROCEDURE keyword, no parameter list) was
+ * left with `subType === undefined`, so every consumer that asks "is this a MAP
+ * declaration?" — all of which test subType against MapProcedure — could not see
+ * it. `missing-map-declaration` then fired on procedures that ARE declared.
+ *
+ *     MAP
+ *       MODULE('demoleg002.clw')
+ *         BrowseInvoice          ! bare: no PROCEDURE keyword, no ( )
+ *       END
+ *     END
+ *
+ * processShorthandProcedures() had two patterns and both key off a '(' — the
+ * name-and-paren-in-one-token form, and the name-followed-by-'(' form. A bare
+ * name has no '(' at all and matched neither.
+ *
+ * This is the shape template-generated apps emit for parameterless procedures,
+ * so it reproduces on a stock example that ships with Clarion
+ * (Clarion10Examples\Capesoft\RecentLookups\Legacy\demoleg.sln): BrowseInvoice
+ * in demoleg002.clw and Main in demoleg001.clw were both flagged while both are
+ * declared in demoleg.clw's MAP.
+ *
+ * The parenting assertion is the half that protects #338: a bare entry directly
+ * in a MAP is a self-declaration, while one inside MODULE('other.clw') declares
+ * a procedure implemented in that file. Collapsing the two would trade this
+ * false positive for a different one.
+ */
+
+function tokenize(lines: string[]) {
+    const doc = TextDocument.create('file:///c:/test462/prog.clw', 'clarion', 1, lines.join('\n'));
+    return new ClarionTokenizer(doc.getText()).tokenize();
+}
+
+suite('Issue #462 — bare MAP entries are procedure declarations', () => {
+
+    test('bare entry inside MODULE(...) is a MapProcedure, parented to the MODULE', () => {
+        const tokens = tokenize([
+            '  PROGRAM',
+            '',
+            '  MAP',
+            "    MODULE('other.clw')",
+            '      BrowseInvoice',
+            '    END',
+            '  END',
+            '',
+            '  CODE',
+            '  RETURN'
+        ]);
+
+        const decl = tokens.find(t => t.value === 'BrowseInvoice');
+        assert.ok(decl, 'BrowseInvoice token should exist');
+        assert.strictEqual(
+            decl!.subType, TokenType.MapProcedure,
+            'a bare MODULE entry must be classified MapProcedure (was undefined => invisible to every MAP-declaration lookup)'
+        );
+        assert.strictEqual(decl!.label, 'BrowseInvoice', 'label should carry the procedure name');
+        assert.strictEqual(
+            decl!.parent?.value.toUpperCase(), 'MODULE',
+            'must be parented to the MODULE, not the outer MAP — #338 relies on that distinction'
+        );
+    });
+
+    test('bare entry directly in the MAP is a MapProcedure, parented to the MAP (#338 shape)', () => {
+        const tokens = tokenize([
+            "  MEMBER('sample.clw')",
+            '',
+            '  MAP',
+            '    ComputeIt',
+            '  END',
+            '',
+            'ComputeIt PROCEDURE',
+            '  CODE',
+            '  RETURN'
+        ]);
+
+        const decl = tokens.find(t => t.value === 'ComputeIt' && t.subType === TokenType.MapProcedure);
+        assert.ok(decl, 'bare module-level MAP entry should be a MapProcedure');
+        assert.strictEqual(
+            decl!.parent?.value.toUpperCase(), 'MAP',
+            'a bare entry with no MODULE wrapper stays parented to the MAP'
+        );
+    });
+
+    test('entries WITH a parameter list keep working (patterns 1 and 2 unchanged)', () => {
+        const tokens = tokenize([
+            '  PROGRAM',
+            '  MAP',
+            '    SaveRecord(LONG pId)',
+            "    MODULE('other.clw')",
+            '      Compute(LONG pA)',
+            '    END',
+            '  END',
+            '  CODE',
+            '  RETURN'
+        ]);
+
+        for (const name of ['SaveRecord', 'Compute']) {
+            const decl = tokens.find(t => (t.label === name || t.value.startsWith(name)) &&
+                                          t.subType === TokenType.MapProcedure);
+            assert.ok(decl, `${name} should still be a MapProcedure`);
+        }
+    });
+
+    test('does not claim attributes or multi-token lines as declarations', () => {
+        // A MAP entry carrying attributes is not a lone identifier on its line, so
+        // the bare-entry rule must not fire on the attribute tokens.
+        const tokens = tokenize([
+            '  PROGRAM',
+            '  MAP',
+            '    DoWork(LONG pId),PASCAL,RAW',
+            '  END',
+            '  CODE',
+            '  RETURN'
+        ]);
+
+        for (const attr of ['PASCAL', 'RAW']) {
+            const bogus = tokens.find(t => t.value.toUpperCase() === attr &&
+                                           t.subType === TokenType.MapProcedure);
+            assert.strictEqual(bogus, undefined, `${attr} must not be classified as a procedure declaration`);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #462.

### The problem

A MAP entry written as a **bare name** — no `PROCEDURE` keyword, no parameter list — was left with `subType === undefined`. Every consumer that asks *"is this a MAP declaration?"* tests `subType` against `MapProcedure`, so the declaration was invisible to all of them and `missing-map-declaration` fired on procedures that **are** declared.

```clarion
  MAP
    MODULE('demoleg002.clw')
      BrowseInvoice          ! bare: no PROCEDURE keyword, no ( )
    END
  END
```

`processShorthandProcedures()` had two patterns and both key off a `(` — the name-and-paren-in-one-token form, and the name-followed-by-`(` form. A bare name has no `(` at all and matched neither.

This is the shape template-generated apps emit for parameterless procedures, so it reproduces on a **stock example that ships with Clarion**: `Clarion10Examples\Capesoft\RecentLookups\Legacy\demoleg.sln`, where `BrowseInvoice` (demoleg002.clw) and `Main` (demoleg001.clw) are both flagged while both are declared in `demoleg.clw`'s MAP.

Instrumenting `findMapDeclarationInMemberFile` showed every surrounding step succeeding and only the last one failing:

```
resolvedPath = ...\Legacy\Source\demoleg.clw        correct parent
mapBlocks    = 1, mapStart 8, mapEnd 102            correct bounds
moduleBlocks = 19, including "demoleg002.clw"       correct MODULE
decls        = 0 in MODULE block 12..14             rejected on subType
```

### The change

One new pattern in `processShorthandProcedures()`: a lone identifier on its own line inside a MAP is a prototype — a MAP body holds only prototypes and MODULE blocks — parented to the **innermost** structure.

That last part is deliberate and is what preserves #338: a bare entry directly in a MAP is a self-declaration, while one inside `MODULE('other.clw')` is implemented in the file that MODULE names. Collapsing the two would trade this false positive for a different one.

Requiring the identifier to be alone on its line, plus the existing `isAttributeKeyword` guard, keeps attributes and multi-token forms out.

44 added lines in `DocumentStructure.ts`, no deletions.

### Tests

`MapDeclaration.BareModuleDeclaration462.test.ts` — red before, green after, on **this branch's base** (`version-1.0.3`, not just the tag I started from):

```
without the fix    2585 passing, 2 failing
with the fix       2587 passing, 0 failing
```

Two of the four tests are deliberately **unable** to detect this bug. They are there to stop an over-broad fix: parameterised entries must keep working, and `PASCAL` / `RAW` attributes must never be claimed as declarations. Both pass with and without the change.

Also verified end-to-end against the stock example over stdio: the false positive is gone on both files, and the unrelated diagnostics in `demoleg002.clw` (`'CUS:Name'` / `'CUS:CustomerID' is not a field on FILE 'Invoice'`) are untouched — so it is not over-suppressing.

### Notes

- Based on `version-1.0.3` and rebased onto it, so the numbers above are against your current code rather than the released tag.
- The `CUS:` diagnostics above look like the #347/#349 family; happy to open a separate issue with the same detail if that is useful.
- Entirely your call whether the fix belongs at this layer — if you would rather have the resolver tolerate the current classification, or fix it elsewhere in the tokenizer, please treat this as a detailed report with a reproduction rather than a fix you have to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW5C3JkmN7eKk4XJxPWpwe
