### PR TITLE
fix(view): scope PROJECT fields to their JOIN, not the VIEW's FROM file (#464)

### DIFF
--- a/server/src/providers/diagnostics/StructureDiagnostics.ts
+++ b/server/src/providers/diagnostics/StructureDiagnostics.ts
@@ -493,26 +493,42 @@ export function validateViewProjectFields(
         const desc = ViewDescriptorParser.parse(headerText, bodyText);
         if (!desc.from) continue;
 
-        // PROJECT(...) field validation — fields are resolved against the FROM file.
+        // PROJECT(...) field validation — each field is resolved against the file that
+        // OWNS it: the JOIN's file when the PROJECT sits inside a JOIN ... END, and the
+        // VIEW's FROM file otherwise (#464). Resolving every PROJECT against FROM
+        // reported every joined field as missing.
+        //
+        // Owner resolution is cached: it is a cross-file lookup, and a generated browse
+        // projects many fields from the same two or three files.
         if (desc.projectedFields.length > 0) {
-            const fromFile = fileResolver.resolve(desc.from);
-            if (fromFile) {
-                const validFields = collectFieldNames(fromFile.fileToken);
-                if (validFields.size > 0) {
-                    for (const fieldToken of collectProjectFieldTokens(tokens, view)) {
-                        const value = fieldToken.value.toUpperCase();
-                        if (validFields.has(value)) continue;
-                        diagnostics.push({
-                            severity: DiagnosticSeverity.Warning,
-                            range: {
-                                start: { line: fieldToken.line, character: fieldToken.start },
-                                end: { line: fieldToken.line, character: fieldToken.start + fieldToken.value.length }
-                            },
-                            message: `'${fieldToken.value}' is not a field on FILE '${fromFile.fileLabel}'.`,
-                            source: 'clarion'
-                        });
-                    }
-                }
+            const ownerCache = new Map<string, { label: string; fields: Set<string> } | null>();
+            const resolveOwner = (name: string) => {
+                const key = name.toUpperCase();
+                if (ownerCache.has(key)) return ownerCache.get(key)!;
+                const resolved = fileResolver.resolveFileOrPrefixed(name);
+                const entry = resolved
+                    ? { label: resolved.fileLabel, fields: collectFieldNames(resolved.fileToken) }
+                    : null;
+                ownerCache.set(key, entry);
+                return entry;
+            };
+
+            for (const scoped of collectScopedProjectFieldTokens(tokens, view, desc.from)) {
+                const owner = resolveOwner(scoped.owner);
+                // An unresolvable owner, or one we know no fields for, proves nothing —
+                // stay silent rather than accuse a field of not existing.
+                if (!owner || owner.fields.size === 0) continue;
+                const fieldToken = scoped.token;
+                if (owner.fields.has(fieldToken.value.toUpperCase())) continue;
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Warning,
+                    range: {
+                        start: { line: fieldToken.line, character: fieldToken.start },
+                        end: { line: fieldToken.line, character: fieldToken.start + fieldToken.value.length }
+                    },
+                    message: `'${fieldToken.value}' is not a field on FILE '${owner.label}'.`,
+                    source: 'clarion'
+                });
             }
         }
 
@@ -613,6 +629,7 @@ interface JoinClause {
  */
 class FileResolver {
     private filesByName = new Map<string, ResolvedFile>();
+    private filesByPrefix = new Map<string, ResolvedFile>();
     private visitedUris = new Set<string>();
     private currentClwDir: string;
     private tokenCache = TokenCache.getInstance();
@@ -637,6 +654,26 @@ class FileResolver {
 
     private pendingExpansion?: Token[];
 
+    /**
+     * Resolve a VIEW/JOIN target that may be a FILE name (`Invoice`) or a prefixed
+     * reference to one (`CUS:Key` - a KEY, which is what a JOIN actually names). The
+     * literal name is tried first, so files whose label contains no colon are unaffected.
+     */
+    public resolveFileOrPrefixed(name: string): ResolvedFile | undefined {
+        const direct = this.resolve(name);
+        if (direct) return direct;
+        const colon = name.indexOf(':');
+        if (colon <= 0) return undefined;
+        const prefix = name.slice(0, colon).toUpperCase();
+        const byPrefix = this.filesByPrefix.get(prefix);
+        if (byPrefix) return byPrefix;
+        if (this.pendingExpansion) {
+            this.expandIncludes(this.pendingExpansion);
+            this.pendingExpansion = undefined;
+        }
+        return this.filesByPrefix.get(prefix);
+    }
+
     public resolve(name: string): ResolvedFile | undefined {
         const upper = name.toUpperCase();
         const local = this.filesByName.get(upper);
@@ -657,6 +694,12 @@ class FileResolver {
                 const key = t.label.toUpperCase();
                 if (!this.filesByName.has(key)) {
                     this.filesByName.set(key, { fileToken: t, fileLabel: t.label });
+                }
+                // Also index by PRE() prefix: a JOIN names a KEY, not a file --
+                // JOIN(CUS:Key, ...) -- so scoping a JOIN's fields needs prefix -> file.
+                const pre = t.structurePrefix?.toUpperCase();
+                if (pre && !this.filesByPrefix.has(pre)) {
+                    this.filesByPrefix.set(pre, { fileToken: t, fileLabel: t.label });
                 }
             }
         }
@@ -734,10 +777,100 @@ const crossTokensMemo = new Map<string, { content: string; tokens: Token[] }>();
 /**
  * Walks the body of a VIEW structure and returns every JOIN clause — the
  * joined-file name token (first arg) and any field-name tokens after it.
- * Mirrors the structure of `collectProjectFieldTokens` but separated because
+ * Mirrors the structure of `collectScopedProjectFieldTokens` but separated because
  * JOIN args have positional meaning (first = file; rest = fields) while
  * PROJECT args are flat field references.
  */
+/**
+ * PROJECT fields inside a VIEW, each paired with the file that OWNS it (#464).
+ *
+ * A PROJECT nested in a `JOIN(Key, ...) ... END` projects fields of the JOINED file,
+ * not of the VIEW's FROM file, and nested JOINs nest their ownership.
+ *
+ * The walk counts openers against ENDs itself rather than using token ranges, because
+ * neither is usable here: JOIN is tokenized as a Function and carries no `finishesAt`,
+ * and a VIEW containing a JOIN reports a `finishesAt` pointing at the JOIN's END rather
+ * than its own.
+ */
+function collectScopedProjectFieldTokens(
+    tokens: Token[],
+    view: Token,
+    primaryFile: string
+): Array<{ token: Token; owner: string }> {
+    const result: Array<{ token: Token; owner: string }> = [];
+
+    const viewIndex = tokens.findIndex(t => t === view);
+    if (viewIndex === -1) return result;
+
+    // Owner stack: the VIEW's FROM file, then one entry per enclosing JOIN.
+    const owners: string[] = [primaryFile];
+    let depth = 1; // the VIEW itself is open
+
+    for (let i = viewIndex + 1; i < tokens.length && depth > 0; i++) {
+        const t = tokens[i];
+        const upper = t.value.toUpperCase();
+
+        if (t.type === TokenType.EndStatement) {
+            depth--;
+            if (depth === 0) break;          // the VIEW's own END
+            if (owners.length > 1) owners.pop();
+            continue;
+        }
+
+        if (upper === 'JOIN' && tokens[i + 1]?.value === '(') {
+            // The first argument names the join target - a KEY, whose prefix resolves
+            // to the file. An unresolvable one still pushes, so the matching END pops
+            // the right entry and ownership downstream is not shifted by one.
+            const firstArg = firstNameInsideParens(tokens, i + 1);
+            owners.push(firstArg ?? owners[owners.length - 1]);
+            depth++;
+            continue;
+        }
+
+        // Any other structure opener inside a VIEW keeps the stack balanced.
+        if (t.type === TokenType.Structure) {
+            depth++;
+            owners.push(owners[owners.length - 1]);
+            continue;
+        }
+
+        if (upper === 'PROJECT' && tokens[i + 1]?.value === '(') {
+            const owner = owners[owners.length - 1];
+            for (const field of namesInsideParens(tokens, i + 1)) {
+                result.push({ token: field, owner });
+            }
+        }
+    }
+
+    return result;
+}
+
+/** Name tokens inside the parenthesised argument list starting at `openIndex`. */
+function namesInsideParens(tokens: Token[], openIndex: number): Token[] {
+    const names: Token[] = [];
+    let depth = 1;
+    for (let j = openIndex + 1; j < tokens.length && depth > 0; j++) {
+        const inner = tokens[j];
+        if (inner.value === '(') { depth++; continue; }
+        if (inner.value === ')') { depth--; if (depth === 0) break; continue; }
+        if (inner.value === ',' || inner.type === TokenType.Comment) continue;
+        if (
+            inner.type === TokenType.StructurePrefix ||
+            inner.type === TokenType.Variable ||
+            inner.type === TokenType.Label ||
+            inner.type === TokenType.StructureField
+        ) {
+            names.push(inner);
+        }
+    }
+    return names;
+}
+
+/** The first name token inside the argument list starting at `openIndex`, if any. */
+function firstNameInsideParens(tokens: Token[], openIndex: number): string | undefined {
+    return namesInsideParens(tokens, openIndex)[0]?.value;
+}
+
 function collectJoinClauses(tokens: Token[], view: Token): JoinClause[] {
     const result: JoinClause[] = [];
     if (view.finishesAt === undefined) return result;
@@ -793,44 +926,3 @@ function collectJoinClauses(tokens: Token[], view: Token): JoinClause[] {
     return result;
 }
 
-/**
- * Walks the body of a VIEW structure and returns every name token that sits
- * inside a PROJECT(...) argument list. Used by validateViewProjectFields to
- * place diagnostic ranges on the offending field token (not the PROJECT
- * keyword) and to ignore non-PROJECT references inside JOIN clauses.
- */
-function collectProjectFieldTokens(tokens: Token[], view: Token): Token[] {
-    const result: Token[] = [];
-    if (view.finishesAt === undefined) return result;
-
-    for (let i = 0; i < tokens.length; i++) {
-        const t = tokens[i];
-        if (t.line <= view.line || t.line >= view.finishesAt) continue;
-        if (t.value.toUpperCase() !== 'PROJECT') continue;
-
-        let j = i + 1;
-        if (j >= tokens.length || tokens[j].value !== '(') continue;
-        j++;
-        let depth = 1;
-        while (j < tokens.length && depth > 0) {
-            const inner = tokens[j];
-            if (inner.value === '(') {
-                depth++;
-            } else if (inner.value === ')') {
-                depth--;
-                if (depth === 0) break;
-            } else if (inner.value !== ',' && inner.type !== TokenType.Comment) {
-                if (
-                    inner.type === TokenType.StructurePrefix ||
-                    inner.type === TokenType.Variable ||
-                    inner.type === TokenType.Label ||
-                    inner.type === TokenType.StructureField
-                ) {
-                    result.push(inner);
-                }
-            }
-            j++;
-        }
-    }
-    return result;
-}

--- a/server/src/test/ViewProjectFields.JoinScope464.test.ts
+++ b/server/src/test/ViewProjectFields.JoinScope464.test.ts
@@ -1,0 +1,135 @@
+import * as assert from 'assert';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { ClarionTokenizer } from '../ClarionTokenizer';
+import { validateViewProjectFields } from '../providers/diagnostics/StructureDiagnostics';
+
+/**
+ * Issue #464 — every PROJECT in a VIEW was resolved against the VIEW's FROM file,
+ * so PROJECTs nested inside a JOIN ... END (which project fields of the JOINED
+ * file) were all reported as missing:
+ *
+ *     VIEW(Invoice)
+ *       PROJECT(INV:ID)
+ *       JOIN(CUS:Key,INV:CustomerId)
+ *         PROJECT(CUS:Name)        ! 'CUS:Name' is not a field on FILE 'Invoice'.
+ *       END
+ *     END
+ *
+ * This is generated browse code, so it was not rare: 12 false positives across 5
+ * files of one stock example that ships with Clarion (Capesoft\RecentLookups).
+ *
+ * Two things had to be true for the fix to be a fix rather than a mute:
+ *   1. joined fields stop being flagged against the wrong file, AND
+ *   2. a genuinely bad joined field is still flagged — against the JOINED file.
+ * The second is what the `Bogus` assertions below exist for. An early version of
+ * the fix passed (1) while silently skipping every JOIN-scoped field, because a
+ * JOIN names a KEY (`CUS:Key`), not a file, so the owner never resolved.
+ */
+
+function diagnose(lines: string[]) {
+    const doc = TextDocument.create('file:///c:/test464/view.clw', 'clarion', 1, lines.join('\n'));
+    const tokens = new ClarionTokenizer(doc.getText()).tokenize();
+    return validateViewProjectFields(tokens, doc);
+}
+
+/** Two FILEs with PRE() prefixes, as a dictionary-generated module declares them. */
+const FILES = [
+    "Invoice     FILE,DRIVER('TOPSPEED'),PRE(INV)",
+    'InvKey        KEY(INV:ID)',
+    'Record        RECORD',
+    'ID              LONG',
+    'CustomerId      LONG',
+    '              END',
+    '            END',
+    '',
+    "Customer    FILE,DRIVER('TOPSPEED'),PRE(CUS)",
+    'CusKey        KEY(CUS:CustomerID)',
+    'Record        RECORD',
+    'CustomerID      LONG',
+    'Name            STRING(30)',
+    '              END',
+    '            END',
+    ''
+];
+
+suite('Issue #464 — PROJECT fields are scoped to their JOIN', () => {
+
+    test('fields projected inside a JOIN are not flagged against the VIEW FROM file', () => {
+        const diags = diagnose([
+            ...FILES,
+            'BRW1::View:Browse    VIEW(Invoice)',
+            '                       PROJECT(INV:ID)',
+            '                       PROJECT(INV:CustomerId)',
+            '                       JOIN(CUS:Key,INV:CustomerId)',
+            '                         PROJECT(CUS:Name)',
+            '                         PROJECT(CUS:CustomerID)',
+            '                       END',
+            '                     END'
+        ]);
+
+        assert.deepStrictEqual(
+            diags.map(d => d.message), [],
+            'a correct VIEW with a JOIN should produce no diagnostics'
+        );
+    });
+
+    test('a bad field inside a JOIN is still flagged, against the JOINED file', () => {
+        const diags = diagnose([
+            ...FILES,
+            'BRW1::View:Browse    VIEW(Invoice)',
+            '                       PROJECT(INV:ID)',
+            '                       JOIN(CUS:Key,INV:CustomerId)',
+            '                         PROJECT(CUS:NoSuchField)',
+            '                       END',
+            '                     END'
+        ]);
+
+        assert.strictEqual(diags.length, 1, 'the bogus joined field must still be reported');
+        assert.ok(
+            diags[0].message.includes("'CUS:NoSuchField'"),
+            `expected the bogus field to be named, got: ${diags[0].message}`
+        );
+        assert.ok(
+            diags[0].message.includes("FILE 'Customer'"),
+            `must be attributed to the JOINED file, not the FROM file. Got: ${diags[0].message}`
+        );
+    });
+
+    test('a bad field outside any JOIN is still flagged against the FROM file', () => {
+        const diags = diagnose([
+            ...FILES,
+            'BRW1::View:Browse    VIEW(Invoice)',
+            '                       PROJECT(INV:NoSuchField)',
+            '                       JOIN(CUS:Key,INV:CustomerId)',
+            '                         PROJECT(CUS:Name)',
+            '                       END',
+            '                     END'
+        ]);
+
+        assert.strictEqual(diags.length, 1, 'the bogus primary field must still be reported');
+        assert.ok(
+            diags[0].message.includes("'INV:NoSuchField'") && diags[0].message.includes("FILE 'Invoice'"),
+            `expected INV:NoSuchField against Invoice, got: ${diags[0].message}`
+        );
+    });
+
+    test('ownership is restored after the JOIN ends', () => {
+        // A PROJECT that follows the JOIN's END belongs to the FROM file again. If the
+        // owner stack failed to pop, this would be checked against Customer and pass
+        // for the wrong reason — so the field chosen here exists on Invoice only.
+        const diags = diagnose([
+            ...FILES,
+            'BRW1::View:Browse    VIEW(Invoice)',
+            '                       JOIN(CUS:Key,INV:CustomerId)',
+            '                         PROJECT(CUS:Name)',
+            '                       END',
+            '                       PROJECT(INV:CustomerId)',
+            '                     END'
+        ]);
+
+        assert.deepStrictEqual(
+            diags.map(d => d.message), [],
+            'INV:CustomerId after the JOIN END should resolve against Invoice'
+        );
+    });
+});


### PR DESCRIPTION
Fixes #464.

### The problem

Every `PROJECT` in a VIEW was resolved against the VIEW's **FROM** file, so `PROJECT`s nested inside a `JOIN … END` — which project fields of the **joined** file — were all reported as missing.

```clarion
VIEW(Invoice)
  PROJECT(INV:ID)
  JOIN(CUS:Key,INV:CustomerId)
    PROJECT(CUS:Name)        ! 'CUS:Name' is not a field on FILE 'Invoice'.
  END
END
```

Generated browse code, so not rare: **12 false positives across 5 files** of one stock example that ships with Clarion (`Capesoft\RecentLookups`).

### The change

PROJECT collection is now scope-aware: ownership starts at the FROM file and becomes the JOIN's file inside each `JOIN … END`, so nested JOINs nest their ownership.

Two things made it more than a line-range change, and both are worth a look in review:

**1. A JOIN names a KEY, not a file.** `JOIN(CUS:Key, …)` cannot be resolved by file name, so `FileResolver` now also indexes FILEs by their `PRE()` prefix and exposes `resolveFileOrPrefixed()` (literal name tried first, so files without a colon in the label are unaffected).

Without this the fix *looked* complete while actually being a **mute** — joined fields stopped being flagged against the wrong file, but a genuinely bad joined field was not flagged either, because the owner never resolved. A deliberately bogus field caught it. That is why the tests assert the **file name in the message**, not merely the count.

**2. Neither available range could bound the walk.** `JOIN` is tokenized as a `Function` and carries no `finishesAt`; and a VIEW containing a JOIN reports a `finishesAt` pointing at the **JOIN's** END rather than its own. The walk therefore counts openers against ENDs itself. (That VIEW `finishesAt` value looks like a bug in its own right — I have not touched it, but you may want to know.)

### Measured — same file, both servers

| | stock `version-1.0.3` | with this change |
|---|---|---|
| `INV:ZZBogusPrimary` | → Invoice ✅ | → Invoice ✅ |
| `CUS:Name` | → Invoice ❌ | *gone* ✅ |
| `CUS:ZZBogusJoin` | → **Invoice** ❌ wrong file | → **Customer** ✅ |
| `CUS:CustomerID` | → Invoice ❌ | *gone* ✅ |

Two false positives removed, **both true positives kept**, and the surviving one re-attributed to the file that owns it. Across the 5 affected files: **12 → 0**, with no true positive lost.

### Tests

`ViewProjectFields.JoinScope464.test.ts` — red before, green after, against this branch's base:

```
without the fix    2583 passing, 4 failing
with the fix       2587 passing, 0 failing
```

Includes the two cases that stop this becoming a mute: a bad field inside the JOIN must still be flagged **and named against the joined file**, and ownership must be restored after the JOIN's END.

### Notes

- Based on and rebased onto `version-1.0.3`.
- `collectProjectFieldTokens()` is now unused and removed; a comment referring to it is repointed.
- **Left alone deliberately:** the JOIN-argument check just below resolves its first argument as a file name too, so it is inert for the same reason. Enabling it looked wrong rather than right — the arguments after the key belong to the *other* file (`JOIN(CUS:Key, INV:CustomerId)`), so making it live would *introduce* false positives. Happy to open a separate issue if you want it examined.
- Independent of #463; either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW5C3JkmN7eKk4XJxPWpwe
