### PR TITLE
fix(hover,definition): ascend into a QUEUE/GROUP parenthesised parent for member lookup

### DIFF
--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -17,7 +17,7 @@ import { getCrossFileEpoch } from '../utils/crossFileEpoch'; // #373
 import { TokenCache } from '../TokenCache';
 import { TokenHelper } from '../utils/TokenHelper';
 import { ProcedureUtils } from '../utils/ProcedureUtils';
-import { StructureDeclarationIndexer, StructureDeclarationInfo } from '../utils/StructureDeclarationIndexer';
+import { StructureDeclarationIndexer, StructureDeclarationInfo, inheritsMembersFromParent } from '../utils/StructureDeclarationIndexer';
 import { CrossFileCache } from '../providers/hover/CrossFileCache';
 import { MemberInfo, MemberEnumItem, OverloadCandidate, scanClassBodyForMember, scanClassBodyForAllMembers, selectBestMemberOverload, detectMemberAccess } from '../utils/ClassMemberResolver';
 import type { MethodOverloadResolver } from '../utils/MethodOverloadResolver';
@@ -1621,7 +1621,7 @@ export class MemberLocatorService {
             return result;
         }
 
-        if (classInfo.structureType === 'CLASS' && classInfo.parentName) {
+        if (inheritsMembersFromParent(classInfo.structureType) && classInfo.parentName) {
             this.trace(`walkParentChain ascend "${className}" -> "${classInfo.parentName}"`);
             return this.walkParentChain(classInfo.parentName, memberName, paramCount, visited, document);
         }

--- a/server/src/test/StructuredTypeParentAscent.DiskFixture.test.ts
+++ b/server/src/test/StructuredTypeParentAscent.DiskFixture.test.ts
@@ -1,0 +1,271 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Location, Hover } from 'vscode-languageserver-protocol';
+import { TokenCache } from '../TokenCache';
+import { DefinitionProvider } from '../providers/DefinitionProvider';
+import { HoverProvider } from '../providers/HoverProvider';
+import { SolutionManager } from '../solution/solutionManager';
+import { StructureDeclarationIndexer, inheritsMembersFromParent } from '../utils/StructureDeclarationIndexer';
+import { serverSettings } from '../serverSettings';
+
+/**
+ * A field inherited through `QUEUE(ParentType)` / `GROUP(ParentType)` was
+ * unresolvable on a chained access: hover and go-to-definition both returned
+ * nothing for `SELF.records.alpha` when `alpha` is declared in the parent
+ * GROUP rather than in the queue's own body, while a field declared directly
+ * in that body (`SELF.records.ownField`) resolved fine.
+ *
+ * Root cause: both entry points to the parent walk gated the ascent on the
+ * structure being a CLASS —
+ *   `MemberLocatorService.walkParentChain`            (chained-hover path)
+ *   `ClassMemberResolver.findMemberInNamedStructure`  (chained definition path)
+ * — so a QUEUE/GROUP whose `parentName` the indexer had already recorded
+ * correctly simply stopped at the child body. Everything downstream was
+ * already structure-agnostic: the recursive `findMemberInParentChain` ascends
+ * on `parentName` alone with no type check, and the body scans accept
+ * CLASS/GROUP/QUEUE. Only the two gates disagreed.
+ *
+ * The declaration-side unwrap for these same types was fixed earlier (PR #383,
+ * `extractClassName` unwrapping `GROUP(TypeName)`), so the producer understood
+ * structured-type parents while these two consumers did not — the drift shape
+ * that `inheritsMembersFromParent` now exists to prevent.
+ *
+ * Needs a disk fixture + mock solution for the same reason as
+ * ChainedOverloadResolution.DiskFixture.test.ts: the chained path resolves
+ * intermediate segments through the SDI, which only indexes on-disk files.
+ */
+
+interface DiskFixture {
+    tmpRoot: string;
+    callerUri: string;
+    callerDoc: TextDocument;
+}
+
+let _savedSm: SolutionManager | null = null;
+let _savedRedirectionFile = '';
+let _savedLibsrcPaths: string[] = [];
+let _active = false;
+
+/** 0-based lines in myclasses.inc, asserted against by the definition tests. */
+const INC_ALPHA_LINE = 1;           // in the parent GROUP body
+const INC_BETA_LINE = 2;            // in the parent GROUP body
+const INC_OWNFIELD_LINE = 6;        // in the QUEUE's own body
+const INC_OWNGROUPFIELD_LINE = 10;  // in the derived GROUP's own body
+
+/** 0-based call-site lines in caller.clw. */
+const CALL_OWNFIELD = 5;
+const CALL_ALPHA = 6;
+const CALL_OWNGROUPFIELD = 7;
+const CALL_BETA = 8;
+
+function buildDiskFixture(): DiskFixture {
+    if (_active) {
+        throw new Error('Structured-type parent-ascent fixture already active — teardown first');
+    }
+    _active = true;
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'parent-ascent-'));
+
+    const incContent = [
+        'BaseFieldsGroupType GROUP,TYPE',        // 0
+        'alpha               STRING(32)',        // 1  ← inherited target
+        'beta                LONG',              // 2  ← inherited target
+        '        END',                           // 3
+        '',                                      // 4
+        'DerivedQueueType    QUEUE(BaseFieldsGroupType),TYPE', // 5
+        'ownField            LONG',              // 6  ← own-body control
+        '        END',                           // 7
+        '',                                      // 8
+        'DerivedGroupType    GROUP(BaseFieldsGroupType),TYPE',  // 9
+        'ownGroupField       LONG',              // 10 ← own-body control
+        '        END',                           // 11
+        '',                                      // 12
+        'HolderClass CLASS,TYPE',                // 13
+        'records     &DerivedQueueType',         // 14
+        'layout      &DerivedGroupType',         // 15
+        'DoIt        PROCEDURE',                 // 16
+        '        END',                           // 17
+        '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpRoot, 'myclasses.inc'), incContent);
+
+    // Minimal redirection file — must exist + parse so the SDI gate passes; the
+    // scanned dir itself comes from serverSettings.libsrcPaths.
+    fs.writeFileSync(path.join(tmpRoot, 'test.red'), '[Copy]\n*.inc = .\n');
+
+    const callerContent = [
+        '  MEMBER()',                              // 0
+        "  INCLUDE('myclasses.inc')",              // 1
+        '',                                        // 2
+        'HolderClass.DoIt PROCEDURE',              // 3
+        '  CODE',                                  // 4
+        '  SELF.records.ownField = 1',             // 5  own body, QUEUE
+        "  SELF.records.alpha = 'x'",              // 6  inherited via QUEUE(parent)
+        '  SELF.layout.ownGroupField = 2',         // 7  own body, GROUP
+        '  SELF.layout.beta = 3',                  // 8  inherited via GROUP(parent)
+        '  RETURN',                                // 9
+    ].join('\n');
+    const callerPath = path.join(tmpRoot, 'caller.clw');
+    fs.writeFileSync(callerPath, callerContent);
+    const callerUri = `file:///${callerPath.replace(/\\/g, '/')}`;
+
+    _savedRedirectionFile = serverSettings.redirectionFile;
+    _savedLibsrcPaths = serverSettings.libsrcPaths;
+    serverSettings.redirectionFile = 'test.red';
+    serverSettings.libsrcPaths = [tmpRoot];
+
+    const fakeProject = {
+        name: 'TestProj',
+        path: tmpRoot,
+        sourceFiles: [
+            { relativePath: 'caller.clw', getAbsolutePath: () => callerPath }
+        ],
+        getRedirectionParser: () => ({ findFile: (_: string) => null })
+    };
+    const fakeSm = {
+        solution: { projects: [fakeProject] },
+        findProjectForFile: () => fakeProject,
+        getProjectPathForFile: () => tmpRoot,
+        getEquatesTokens: () => null,
+        getEquatesPath: () => null
+    } as unknown as SolutionManager;
+
+    _savedSm = (SolutionManager as unknown as { instance: SolutionManager | null }).instance;
+    (SolutionManager as unknown as { instance: SolutionManager | null }).instance = fakeSm;
+
+    StructureDeclarationIndexer.getInstance().clearCache();
+
+    const callerDoc = TextDocument.create(callerUri, 'clarion', 1, callerContent);
+    TokenCache.getInstance().getTokens(callerDoc);
+
+    return { tmpRoot, callerUri, callerDoc };
+}
+
+function teardownDiskFixture(fix: DiskFixture | null): void {
+    if (!_active) return;
+    (SolutionManager as unknown as { instance: SolutionManager | null }).instance = _savedSm;
+    _savedSm = null;
+    serverSettings.redirectionFile = _savedRedirectionFile;
+    serverSettings.libsrcPaths = _savedLibsrcPaths;
+    StructureDeclarationIndexer.getInstance().clearCache();
+    if (fix) {
+        TokenCache.getInstance().clearTokens(fix.callerUri);
+        try { fs.rmSync(fix.tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    _active = false;
+}
+
+function lineOf(result: Location | Location[] | null | undefined): number {
+    if (!result) return -1;
+    if (Array.isArray(result)) return result.length > 0 ? result[0].range.start.line : -1;
+    return result.range.start.line;
+}
+
+function hoverText(h: Hover | null | undefined): string {
+    if (!h) return '';
+    const c = h.contents as unknown;
+    if (typeof c === 'string') return c;
+    if (c && typeof (c as { value?: string }).value === 'string') return (c as { value: string }).value;
+    return '';
+}
+
+/** Cursor one char inside the field identifier at each call site. */
+const CHAR_AFTER_RECORDS = 16; // "  SELF.records." is 15 chars; field starts at 15
+const CHAR_AFTER_LAYOUT = 15;  // "  SELF.layout."  is 14 chars; field starts at 14
+
+suite('Structured-type parent ascent — QUEUE(Parent) / GROUP(Parent) inherited fields', () => {
+
+    let fix: DiskFixture | null = null;
+
+    teardown(() => {
+        teardownDiskFixture(fix);
+        fix = null;
+    });
+
+    // ── the predicate itself ──────────────────────────────────────────────────
+    test('inheritsMembersFromParent covers the field-inheriting structures only', () => {
+        assert.strictEqual(inheritsMembersFromParent('CLASS'), true);
+        assert.strictEqual(inheritsMembersFromParent('QUEUE'), true);
+        assert.strictEqual(inheritsMembersFromParent('GROUP'), true);
+        // VIEW(File) names a join's primary file, not an inherited layout.
+        assert.strictEqual(inheritsMembersFromParent('VIEW'), false);
+        assert.strictEqual(inheritsMembersFromParent('FILE'), false);
+        assert.strictEqual(inheritsMembersFromParent(undefined), false);
+    });
+
+    // ── the indexer already had the parent link ───────────────────────────────
+    test('indexer records the parenthesised parent for QUEUE and GROUP', async () => {
+        fix = buildDiskFixture();
+        const sdi = StructureDeclarationIndexer.getInstance();
+        await sdi.getOrBuildIndex(fix.tmpRoot);
+        const queueInfo = sdi.find('DerivedQueueType')[0];
+        const groupInfo = sdi.find('DerivedGroupType')[0];
+        assert.ok(queueInfo, 'DerivedQueueType must be indexed');
+        assert.ok(groupInfo, 'DerivedGroupType must be indexed');
+        assert.strictEqual(queueInfo.structureType, 'QUEUE');
+        assert.strictEqual(queueInfo.parentName, 'BaseFieldsGroupType',
+            'the parent link the ascent needs was always present — only the gate rejected it');
+        assert.strictEqual(groupInfo.structureType, 'GROUP');
+        assert.strictEqual(groupInfo.parentName, 'BaseFieldsGroupType');
+    });
+
+    // ── QUEUE(Parent): the reported shape ─────────────────────────────────────
+    test('go-to-definition resolves a field inherited through QUEUE(Parent)', async () => {
+        fix = buildDiskFixture();
+        const provider = new DefinitionProvider();
+        const line = lineOf(await provider.provideDefinition(
+            fix.callerDoc, { line: CALL_ALPHA, character: CHAR_AFTER_RECORDS }));
+        assert.strictEqual(line, INC_ALPHA_LINE,
+            `SELF.records.alpha must resolve into the parent GROUP (.inc line ${INC_ALPHA_LINE}); got ${line}`);
+    });
+
+    test('hover resolves a field inherited through QUEUE(Parent)', async () => {
+        fix = buildDiskFixture();
+        const provider = new HoverProvider();
+        const text = hoverText(await provider.provideHover(
+            fix.callerDoc, { line: CALL_ALPHA, character: CHAR_AFTER_RECORDS }));
+        assert.notStrictEqual(text, '', 'SELF.records.alpha must produce a hover, not nothing');
+        assert.ok(/alpha/i.test(text), `hover must describe alpha; got: ${text}`);
+    });
+
+    // ── GROUP(Parent): the same gate, the commoner declaration form ───────────
+    test('go-to-definition resolves a field inherited through GROUP(Parent)', async () => {
+        fix = buildDiskFixture();
+        const provider = new DefinitionProvider();
+        const line = lineOf(await provider.provideDefinition(
+            fix.callerDoc, { line: CALL_BETA, character: CHAR_AFTER_LAYOUT }));
+        assert.strictEqual(line, INC_BETA_LINE,
+            `SELF.layout.beta must resolve into the parent GROUP (.inc line ${INC_BETA_LINE}); got ${line}`);
+    });
+
+    test('hover resolves a field inherited through GROUP(Parent)', async () => {
+        fix = buildDiskFixture();
+        const provider = new HoverProvider();
+        const text = hoverText(await provider.provideHover(
+            fix.callerDoc, { line: CALL_BETA, character: CHAR_AFTER_LAYOUT }));
+        assert.notStrictEqual(text, '', 'SELF.layout.beta must produce a hover, not nothing');
+        assert.ok(/beta/i.test(text), `hover must describe beta; got: ${text}`);
+    });
+
+    // ── regression guards: own-body fields must keep resolving ────────────────
+    test('a field in the QUEUE own body still resolves (regression guard)', async () => {
+        fix = buildDiskFixture();
+        const provider = new DefinitionProvider();
+        const line = lineOf(await provider.provideDefinition(
+            fix.callerDoc, { line: CALL_OWNFIELD, character: CHAR_AFTER_RECORDS }));
+        assert.strictEqual(line, INC_OWNFIELD_LINE,
+            `SELF.records.ownField must still resolve to the queue's own body (.inc line ${INC_OWNFIELD_LINE}); got ${line}`);
+    });
+
+    test('a field in the derived GROUP own body still resolves (regression guard)', async () => {
+        fix = buildDiskFixture();
+        const provider = new DefinitionProvider();
+        const line = lineOf(await provider.provideDefinition(
+            fix.callerDoc, { line: CALL_OWNGROUPFIELD, character: CHAR_AFTER_LAYOUT }));
+        assert.strictEqual(line, INC_OWNGROUPFIELD_LINE,
+            `SELF.layout.ownGroupField must still resolve to its own body (.inc line ${INC_OWNGROUPFIELD_LINE}); got ${line}`);
+    });
+});

--- a/server/src/utils/ClassMemberResolver.ts
+++ b/server/src/utils/ClassMemberResolver.ts
@@ -6,7 +6,7 @@ import { TokenCache } from '../TokenCache';
 import { SolutionManager } from '../solution/solutionManager';
 import { resolveViaProjectRedirection, projectsOwnerFirst } from './RedirectionResolution';
 import { TokenHelper } from './TokenHelper';
-import { StructureDeclarationIndexer } from './StructureDeclarationIndexer';
+import { StructureDeclarationIndexer, inheritsMembersFromParent } from './StructureDeclarationIndexer';
 import { ClarionPatterns } from './ClarionPatterns';
 import { MethodOverloadResolver } from './MethodOverloadResolver';
 import { ProcedureUtils } from './ProcedureUtils';
@@ -916,8 +916,9 @@ export class ClassMemberResolver {
             const info = infos.find(d => !d.isType) || infos[0];
             const result = this.searchFileForMember(info.filePath, structureName, memberName, paramCount, info.structureType as 'CLASS' | 'GROUP' | 'QUEUE' | undefined);
             if (result) return result;
-            // Walk parent chain for CLASS types
-            if (info.structureType === 'CLASS' && info.parentName) {
+            // Walk the parent chain — CLASS(Base) inherits members, and
+            // QUEUE(Type)/GROUP(Type) inherit the parent's fields the same way.
+            if (inheritsMembersFromParent(info.structureType) && info.parentName) {
                 return this.findMemberInParentChain(info.parentName, memberName, paramCount, new Set([structureName.toLowerCase()]));
             }
         }

--- a/server/src/utils/StructureDeclarationIndexer.ts
+++ b/server/src/utils/StructureDeclarationIndexer.ts
@@ -58,6 +58,23 @@ export type StructureType =
     | 'ITEMIZE'
     | 'ITEMIZE_EQUATE';
 
+/**
+ * Structure kinds whose parenthesised parent contributes its members to the
+ * child, so a member miss on the child must continue into that parent:
+ * `CLASS(Base)` inherits methods and properties, and `QUEUE(Type)` /
+ * `GROUP(Type)` take the parent's field layout the same way.
+ *
+ * Kept as ONE predicate because the ascent is decided in two independent
+ * resolvers — two hand-maintained type lists drift, which is how a
+ * `QUEUE(Group)` field became silently unresolvable while `CLASS(Base)` worked.
+ *
+ * `VIEW(File)` is deliberately excluded: the parenthesised name there is a
+ * join's primary file, not a layout the VIEW inherits.
+ */
+export function inheritsMembersFromParent(structureType: StructureType | undefined): boolean {
+    return structureType === 'CLASS' || structureType === 'QUEUE' || structureType === 'GROUP';
+}
+
 /** A single declaration found during a file scan */
 export interface StructureDeclarationInfo {
     /** Original-case label as it appears in source (ITEMIZE_EQUATE names are PRE:Name expanded) */


### PR DESCRIPTION
# fix(hover,definition): ascend into a QUEUE/GROUP parenthesised parent for member lookup

## What happened

On a chained access, a field inherited through `QUEUE(ParentType)` or
`GROUP(ParentType)` produced **no hover and no go-to-definition at all** — not a
wrong answer, silence. A field declared in the child's own body resolved
normally, which made it look like the whole structure was fine.

```clarion
BaseFieldsGroupType GROUP,TYPE
alpha               STRING(32)
                    END

DerivedQueueType    QUEUE(BaseFieldsGroupType),TYPE
ownField            LONG
                    END

HolderClass CLASS,TYPE
records     &DerivedQueueType
DoIt        PROCEDURE
            END
```

```clarion
HolderClass.DoIt PROCEDURE
  CODE
  SELF.records.ownField = 1     ! hover + F12 work — field is in the queue body
  SELF.records.alpha    = 'x'   ! hover + F12 return NOTHING — field is in the parent GROUP
```

`GROUP(Parent)` behaves identically; it is the commoner of the two declaration
forms in real code.

## Root cause

Both entry points to the parent walk gated the ascent on the structure being a
CLASS, so a QUEUE or GROUP stopped at its own body and never looked at its
parent.

`MemberLocatorService.walkParentChain` — the chained hover path:

```ts
if (classInfo.structureType === 'CLASS' && classInfo.parentName) {
    this.trace(`walkParentChain ascend "${className}" -> "${classInfo.parentName}"`);
    return this.walkParentChain(classInfo.parentName, memberName, paramCount, visited, document);
}
this.trace(`walkParentChain stop at "${className}" (no parent/no hit)`);
return null;
```

`ClassMemberResolver.findMemberInNamedStructure` — the chained definition path,
whose own doc-comment says it is "Used by ChainedPropertyResolver for chained
access":

```ts
// Walk parent chain for CLASS types
if (info.structureType === 'CLASS' && info.parentName) {
    return this.findMemberInParentChain(info.parentName, memberName, paramCount, new Set([structureName.toLowerCase()]));
}
```

The parent link itself was never missing. `extractParent(keyword, line)` builds
its regex from whichever structure keyword is present, so the indexer already
recorded `structureType: 'QUEUE'`, `parentName: 'BaseFieldsGroupType'` for the
declaration above — the gates simply refused to use it.

Everything downstream was already structure-agnostic:

- the recursive `findMemberInParentChain` ascends on `parentName` alone, with no
  type check, so multi-level ascent worked the moment the first hop was allowed;
- `searchFileForMember` / `scanBodyForMember` both accept `'CLASS' | 'GROUP' | 'QUEUE'`.

Only the two entry gates disagreed with the rest of the pipeline.

This is the consumer half of a shape whose producer was already fixed: #383
taught `extractClassName` to unwrap `GROUP(TypeName)` / `QUEUE(TypeName)` /
`RECORD(TypeName)`, and that unwrap sits ~30 lines above the second gate in the
same file. The declaration side understood structured-type parents while these
two lookups did not.

## The fix

One predicate, exported from `StructureDeclarationIndexer` next to the
`StructureType` union it discriminates, used by both sites so the two lists
cannot drift apart again:

```ts
export function inheritsMembersFromParent(structureType: StructureType | undefined): boolean {
    return structureType === 'CLASS' || structureType === 'QUEUE' || structureType === 'GROUP';
}
```

```ts
if (inheritsMembersFromParent(classInfo.structureType) && classInfo.parentName) {
```

```ts
// Walk the parent chain — CLASS(Base) inherits members, and
// QUEUE(Type)/GROUP(Type) inherit the parent's fields the same way.
if (inheritsMembersFromParent(info.structureType) && info.parentName) {
```

Net diff: 23 insertions, 5 deletions across three files, plus one new test file.

## Testing

8 new tests in `server/src/test/StructuredTypeParentAscent.DiskFixture.test.ts`:
`QUEUE(Parent)` and `GROUP(Parent)` × hover and go-to-definition, the predicate
itself, an assertion that the indexer already carries the parent link, and two
own-body regression guards.

It uses a disk fixture with a mock loaded solution for the same reason
`ChainedOverloadResolution.DiskFixture.test.ts` does: the chained path resolves
intermediate segments through the SDI, which only indexes on-disk files and
cannot see an in-memory-only `TextDocument`.

Proved non-vacuous by reverting **only** the two gates — keeping the test and the
predicate — and recompiling. Exactly the four inherited-field tests fail, with
the reported symptom rather than a generic mismatch:

```
AssertionError: SELF.records.alpha must resolve into the parent GROUP (.inc line 1); got -1
AssertionError: SELF.records.alpha must produce a hover, not nothing
AssertionError: SELF.layout.beta must resolve into the parent GROUP (.inc line 2); got -1
AssertionError: SELF.layout.beta must produce a hover, not nothing
```

The two own-body guards and the predicate/indexer tests pass in both states, as
regression guards should.

Full server suite: **2612 passing / 0 failing / 4 pending** (2604 on the same tip
before this branch; the delta is exactly these 8 tests).

