### PR TITLE
fix(hover): label a QUEUE/GROUP member as a field, not a "Class Property"

### DIFF
--- a/server/src/providers/hover/HoverFormatter.ts
+++ b/server/src/providers/hover/HoverFormatter.ts
@@ -49,6 +49,36 @@ export interface ClassMemberInfo {
     line: number;
     file: string;
     isInterface?: boolean;
+    structureType?: 'CLASS' | 'GROUP' | 'QUEUE' | 'INTERFACE';
+}
+
+/**
+ * Names a member the way its owning structure does: a CLASS has properties and
+ * methods, an INTERFACE has methods, and a QUEUE/GROUP has fields — calling a
+ * queue field a "Class Property" misreports what the reader is looking at.
+ *
+ * "Field" matches the noun already used for structure members elsewhere in
+ * hover (`**<Type> Field:** <name>` in StructureFieldResolver).
+ *
+ * Falls back to the previous CLASS/INTERFACE-only wording when the owner kind
+ * is unknown, so producers that don't set it are unaffected.
+ */
+export function describeMemberOwner(
+    structureType: 'CLASS' | 'GROUP' | 'QUEUE' | 'INTERFACE' | undefined,
+    isInterface: boolean | undefined,
+    isMethod: boolean
+): { category: string; noun: string } {
+    const kind = structureType ?? (isInterface ? 'INTERFACE' : 'CLASS');
+    switch (kind) {
+        case 'QUEUE':
+            return { category: 'Queue', noun: isMethod ? 'Method' : 'Field' };
+        case 'GROUP':
+            return { category: 'Group', noun: isMethod ? 'Method' : 'Field' };
+        case 'INTERFACE':
+            return { category: 'Interface', noun: isMethod ? 'Method' : 'Property' };
+        default:
+            return { category: 'Class', noun: isMethod ? 'Method' : 'Property' };
+    }
 }
 
 export interface MethodDeclarationInfo {
@@ -183,8 +213,8 @@ export class HoverFormatter {
      */
     formatClassMember(name: string, info: ClassMemberInfo): Hover {
         const isMethod = info.type.toUpperCase().includes('PROCEDURE') || info.type.toUpperCase().includes('FUNCTION');
-        const memberType = isMethod ? 'Method' : 'Property';
-        const memberCategory = info.isInterface ? 'Interface' : 'Class';
+        const { category: memberCategory, noun: memberType } =
+            describeMemberOwner(info.structureType, info.isInterface, isMethod);
 
         const header = this.buildMethodHeader(name, info.type, memberCategory, memberType, info.className, isMethod);
         const markdown = [header, ``];
@@ -213,7 +243,8 @@ export class HoverFormatter {
      * Constructs hover for a method call (SELF.method) with both declaration and implementation
      */
     formatMethodCall(name: string, declarationInfo: ClassMemberInfo, implementationLocation: string): Hover {
-        const memberCategory = declarationInfo.isInterface ? 'Interface' : 'Class';
+        const { category: memberCategory } =
+            describeMemberOwner(declarationInfo.structureType, declarationInfo.isInterface, true);
         const header = this.buildMethodHeader(name, declarationInfo.type, memberCategory, 'Method', declarationInfo.className, true);
         const markdown = [header, ``];
 

--- a/server/src/services/MemberLocatorService.ts
+++ b/server/src/services/MemberLocatorService.ts
@@ -1076,7 +1076,7 @@ export class MemberLocatorService {
         const best = selectBestMemberOverload(candidates, paramCount);
         if (!best) return null;
         const fileUri = `file:///${filePath.replace(/\\/g, '/')}`;
-        return { type: best.type, className: ifaceName, line: best.line, file: fileUri, signature: best.signature, isInterface: true };
+        return { type: best.type, className: ifaceName, line: best.line, file: fileUri, signature: best.signature, isInterface: true, structureType: 'INTERFACE' };
     }
 
     /** Walks the INCLUDE chain searching for an INTERFACE method declaration. */
@@ -1795,7 +1795,9 @@ export class MemberLocatorService {
         const bestMatch = selectBestMemberOverload(candidates, paramCount);
         if (bestMatch) {
             const fileUri = `file:///${filePath.replace(/\\/g, '/')}`;
-            return { type: bestMatch.type, className, line: bestMatch.line, file: fileUri, signature: bestMatch.signature };
+            // The structure token above was matched BY structureType, so it is the
+            // kind actually found here, not an assumption.
+            return { type: bestMatch.type, className, line: bestMatch.line, file: fileUri, signature: bestMatch.signature, structureType };
         }
         return null;
     }

--- a/server/src/test/StructuredTypeMemberLabel.DiskFixture.test.ts
+++ b/server/src/test/StructuredTypeMemberLabel.DiskFixture.test.ts
@@ -1,0 +1,220 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Hover } from 'vscode-languageserver-protocol';
+import { TokenCache } from '../TokenCache';
+import { HoverProvider } from '../providers/HoverProvider';
+import { describeMemberOwner } from '../providers/hover/HoverFormatter';
+import { SolutionManager } from '../solution/solutionManager';
+import { StructureDeclarationIndexer } from '../utils/StructureDeclarationIndexer';
+import { serverSettings } from '../serverSettings';
+
+/**
+ * Hover described every resolved member as a "Class Property" / "Class Method",
+ * including members of a QUEUE or GROUP — so `SELF.records.queueField` reported
+ * "Class Property · StandaloneQueueType", naming a queue field as a property of
+ * a class.
+ *
+ * Root cause: `MemberInfo` — the shape every member lookup returns — carried no
+ * record of the kind of structure the member was found in, only `className` and
+ * an `isInterface?` flag. `HoverFormatter` therefore had a binary choice,
+ * `info.isInterface ? 'Interface' : 'Class'`, and everything that was not an
+ * INTERFACE fell through to "Class".
+ *
+ * The kind was known at every producer: `scanClassBodyForMember` matches the
+ * declaration with a `(CLASS|QUEUE|GROUP|INTERFACE)` capture,
+ * `findClassMemberInIncludes` captures the same keyword, and
+ * `findMemberFromTokens` matches the structure token BY the requested kind. It
+ * was simply dropped on the way out.
+ *
+ * Fix: `MemberInfo.structureType` carries the kind that was actually matched,
+ * and `describeMemberOwner` turns it into the right pair of words — "Field" for
+ * QUEUE/GROUP members, matching the noun hover already uses for structure
+ * members elsewhere (`**<Type> Field:**` in StructureFieldResolver).
+ *
+ * The fixture deliberately uses fields declared in each structure's OWN body, so
+ * it exercises the labelling alone and does not depend on parent-type ascent.
+ */
+
+interface DiskFixture {
+    tmpRoot: string;
+    callerUri: string;
+    callerDoc: TextDocument;
+}
+
+let _savedSm: SolutionManager | null = null;
+let _savedRedirectionFile = '';
+let _savedLibsrcPaths: string[] = [];
+let _active = false;
+
+/** 0-based call-site lines in caller.clw. */
+const CALL_QUEUE_FIELD = 5;
+const CALL_GROUP_FIELD = 6;
+const CALL_CLASS_PROP = 7;
+const CALL_CLASS_METHOD = 8;
+
+/** Cursor one char inside the member identifier at each call site. */
+const CHAR_AFTER_RECORDS = 16;  // "  SELF.records." → member starts at 15
+const CHAR_AFTER_LAYOUT = 15;   // "  SELF.layout."  → member starts at 14
+const CHAR_AFTER_SELF = 8;      // "  SELF."         → member starts at 7
+
+function buildDiskFixture(): DiskFixture {
+    if (_active) {
+        throw new Error('Member-label fixture already active — teardown first');
+    }
+    _active = true;
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'member-label-'));
+
+    const incContent = [
+        'StandaloneQueueType QUEUE,TYPE',       // 0
+        'queueField          LONG',             // 1
+        '        END',                          // 2
+        '',                                     // 3
+        'StandaloneGroupType GROUP,TYPE',       // 4
+        'groupField          STRING(16)',       // 5
+        '        END',                          // 6
+        '',                                     // 7
+        'HolderClass CLASS,TYPE',               // 8
+        'records     &StandaloneQueueType',     // 9
+        'layout      &StandaloneGroupType',     // 10
+        'counter     LONG',                     // 11
+        'DoIt        PROCEDURE',                // 12
+        'Helper      PROCEDURE(LONG p)',        // 13
+        '        END',                          // 14
+        '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpRoot, 'myclasses.inc'), incContent);
+
+    // Minimal redirection file — must exist + parse so the SDI gate passes.
+    fs.writeFileSync(path.join(tmpRoot, 'test.red'), '[Copy]\n*.inc = .\n');
+
+    const callerContent = [
+        '  MEMBER()',                        // 0
+        "  INCLUDE('myclasses.inc')",        // 1
+        '',                                  // 2
+        'HolderClass.DoIt PROCEDURE',        // 3
+        '  CODE',                            // 4
+        '  SELF.records.queueField = 1',     // 5  QUEUE own body  → Queue Field
+        "  SELF.layout.groupField = 'x'",    // 6  GROUP own body  → Group Field
+        '  SELF.counter = 2',                // 7  CLASS property  → Class Property
+        '  SELF.Helper(1)',                  // 8  CLASS method    → Class Method
+        '  RETURN',                          // 9
+    ].join('\n');
+    const callerPath = path.join(tmpRoot, 'caller.clw');
+    fs.writeFileSync(callerPath, callerContent);
+    const callerUri = `file:///${callerPath.replace(/\\/g, '/')}`;
+
+    _savedRedirectionFile = serverSettings.redirectionFile;
+    _savedLibsrcPaths = serverSettings.libsrcPaths;
+    serverSettings.redirectionFile = 'test.red';
+    serverSettings.libsrcPaths = [tmpRoot];
+
+    const fakeProject = {
+        name: 'TestProj',
+        path: tmpRoot,
+        sourceFiles: [
+            { relativePath: 'caller.clw', getAbsolutePath: () => callerPath }
+        ],
+        getRedirectionParser: () => ({ findFile: (_: string) => null })
+    };
+    const fakeSm = {
+        solution: { projects: [fakeProject] },
+        findProjectForFile: () => fakeProject,
+        getProjectPathForFile: () => tmpRoot,
+        getEquatesTokens: () => null,
+        getEquatesPath: () => null
+    } as unknown as SolutionManager;
+
+    _savedSm = (SolutionManager as unknown as { instance: SolutionManager | null }).instance;
+    (SolutionManager as unknown as { instance: SolutionManager | null }).instance = fakeSm;
+
+    StructureDeclarationIndexer.getInstance().clearCache();
+
+    const callerDoc = TextDocument.create(callerUri, 'clarion', 1, callerContent);
+    TokenCache.getInstance().getTokens(callerDoc);
+
+    return { tmpRoot, callerUri, callerDoc };
+}
+
+function teardownDiskFixture(fix: DiskFixture | null): void {
+    if (!_active) return;
+    (SolutionManager as unknown as { instance: SolutionManager | null }).instance = _savedSm;
+    _savedSm = null;
+    serverSettings.redirectionFile = _savedRedirectionFile;
+    serverSettings.libsrcPaths = _savedLibsrcPaths;
+    StructureDeclarationIndexer.getInstance().clearCache();
+    if (fix) {
+        TokenCache.getInstance().clearTokens(fix.callerUri);
+        try { fs.rmSync(fix.tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+    _active = false;
+}
+
+function hoverText(h: Hover | null | undefined): string {
+    if (!h) return '';
+    const c = h.contents as unknown;
+    if (typeof c === 'string') return c;
+    if (c && typeof (c as { value?: string }).value === 'string') return (c as { value: string }).value;
+    return '';
+}
+
+suite('Structured-type member labelling — a QUEUE/GROUP member is a field, not a Class Property', () => {
+
+    let fix: DiskFixture | null = null;
+
+    teardown(() => {
+        teardownDiskFixture(fix);
+        fix = null;
+    });
+
+    // ── the mapping itself ────────────────────────────────────────────────────
+    test('describeMemberOwner names each owner kind correctly', () => {
+        assert.deepStrictEqual(describeMemberOwner('QUEUE', undefined, false), { category: 'Queue', noun: 'Field' });
+        assert.deepStrictEqual(describeMemberOwner('GROUP', undefined, false), { category: 'Group', noun: 'Field' });
+        assert.deepStrictEqual(describeMemberOwner('CLASS', undefined, false), { category: 'Class', noun: 'Property' });
+        assert.deepStrictEqual(describeMemberOwner('CLASS', undefined, true), { category: 'Class', noun: 'Method' });
+        assert.deepStrictEqual(describeMemberOwner('INTERFACE', undefined, true), { category: 'Interface', noun: 'Method' });
+    });
+
+    test('describeMemberOwner keeps the previous wording when the owner kind is unknown', () => {
+        // Producers that do not set structureType must be unaffected.
+        assert.deepStrictEqual(describeMemberOwner(undefined, undefined, false), { category: 'Class', noun: 'Property' });
+        assert.deepStrictEqual(describeMemberOwner(undefined, undefined, true), { category: 'Class', noun: 'Method' });
+        assert.deepStrictEqual(describeMemberOwner(undefined, true, true), { category: 'Interface', noun: 'Method' });
+    });
+
+    // ── the reported shape ────────────────────────────────────────────────────
+    test('a QUEUE member is labelled "Queue Field", not "Class Property"', async () => {
+        fix = buildDiskFixture();
+        const text = hoverText(await new HoverProvider().provideHover(
+            fix.callerDoc, { line: CALL_QUEUE_FIELD, character: CHAR_AFTER_RECORDS }));
+        assert.ok(/Queue Field/.test(text), `expected "Queue Field"; got: ${text}`);
+        assert.ok(!/Class Property/.test(text), `must not call a queue field a Class Property; got: ${text}`);
+    });
+
+    test('a GROUP member is labelled "Group Field", not "Class Property"', async () => {
+        fix = buildDiskFixture();
+        const text = hoverText(await new HoverProvider().provideHover(
+            fix.callerDoc, { line: CALL_GROUP_FIELD, character: CHAR_AFTER_LAYOUT }));
+        assert.ok(/Group Field/.test(text), `expected "Group Field"; got: ${text}`);
+        assert.ok(!/Class Property/.test(text), `must not call a group field a Class Property; got: ${text}`);
+    });
+
+    // ── regression guards: CLASS wording must not change ──────────────────────
+    test('a CLASS property is still labelled "Class Property" (regression guard)', async () => {
+        fix = buildDiskFixture();
+        const text = hoverText(await new HoverProvider().provideHover(
+            fix.callerDoc, { line: CALL_CLASS_PROP, character: CHAR_AFTER_SELF }));
+        assert.ok(/Class Property/.test(text), `expected "Class Property"; got: ${text}`);
+    });
+
+    test('a CLASS method is still labelled "Class Method" (regression guard)', async () => {
+        fix = buildDiskFixture();
+        const text = hoverText(await new HoverProvider().provideHover(
+            fix.callerDoc, { line: CALL_CLASS_METHOD, character: CHAR_AFTER_SELF }));
+        assert.ok(/Class Method/.test(text), `expected "Class Method"; got: ${text}`);
+    });
+});

--- a/server/src/utils/ClassMemberResolver.ts
+++ b/server/src/utils/ClassMemberResolver.ts
@@ -19,7 +19,16 @@ import LoggerManager from '../logger';
 const logger = LoggerManager.getLogger("ClassMemberResolver");
 logger.setLevel("error");
 
-export type MemberInfo = { type: string; className: string; line: number; file: string; signature?: string; isInterface?: boolean };
+/**
+ * The kind of structure a member was found in. Carried on MemberInfo so a
+ * consumer can describe the member accurately: a QUEUE/GROUP member is a field,
+ * not a "Class Property". Optional because not every producer of a MemberInfo
+ * knows the kind, and consumers keep their previous CLASS/INTERFACE assumption
+ * when it is absent.
+ */
+export type MemberOwnerKind = 'CLASS' | 'GROUP' | 'QUEUE' | 'INTERFACE';
+
+export type MemberInfo = { type: string; className: string; line: number; file: string; signature?: string; isInterface?: boolean; structureType?: MemberOwnerKind };
 
 /** Access level for a class member. */
 export type MemberAccess = 'public' | 'protected' | 'private';
@@ -160,7 +169,12 @@ export function scanClassBodyForMember(
         const headerPattern = new RegExp(`^${className}\\s+(CLASS|QUEUE|GROUP|INTERFACE)`, 'i');
 
         for (let j = 0; j < lines.length; j++) {
-            if (!headerPattern.test(lines[j])) continue;
+            const headerMatch = lines[j].match(headerPattern);
+            if (!headerMatch) continue;
+            // The keyword on the declaration itself, not the caller's hint: the
+            // header pattern accepts all four kinds, so a caller passing the
+            // default 'CLASS' can still land on a QUEUE/GROUP body.
+            const ownerKind = headerMatch[1].toUpperCase() as MemberOwnerKind;
 
             const candidates: { type: string; line: number; paramCount: number; signature?: string }[] = [];
             let nestDepth = 0;
@@ -198,7 +212,7 @@ export function scanClassBodyForMember(
             const bestMatch = selectBestOverload(candidates, paramCount);
             if (bestMatch) {
                 const fileUri = pathToCanonicalUri(filePath); // #251
-                return { type: bestMatch.type, className, line: bestMatch.line, file: fileUri, signature: bestMatch.signature };
+                return { type: bestMatch.type, className, line: bestMatch.line, file: fileUri, signature: bestMatch.signature, structureType: ownerKind };
             }
         }
     } catch (error) {
@@ -386,7 +400,9 @@ export class ClassMemberResolver {
                 // Select best match based on parameter count
                 const bestMatch = this.selectBestOverload(candidates, paramCount);
                 if (bestMatch) {
-                    return { type: bestMatch.type, className, line: bestMatch.line, file: document.uri };
+                    // findClassStructures filters to CLASS tokens, so this branch
+                    // can only ever have matched a CLASS body.
+                    return { type: bestMatch.type, className, line: bestMatch.line, file: document.uri, structureType: 'CLASS' };
                 }
 
                 // Member not in this class — walk the inheritance chain
@@ -512,7 +528,10 @@ export class ClassMemberResolver {
                         if (bestMatch) {
                             // Convert file path to URI format
                             const fileUri = pathToCanonicalUri(resolvedPath); // #251
-                            return { type: bestMatch.type, className, line: bestMatch.line, file: fileUri };
+                            return {
+                                type: bestMatch.type, className, line: bestMatch.line, file: fileUri,
+                                structureType: classMatch[1].toUpperCase() as MemberOwnerKind
+                            };
                         }
 
                         // Member not in this class/queue/group — walk the inheritance chain


### PR DESCRIPTION
# fix(hover): label a QUEUE/GROUP member as a field, not a "Class Property"

Branch: `geircodes/Clarion-Extension:fix/structured-type-member-label`
Target: `msarson/Clarion-Extension:version-1.0.3` (built on tip `70c5626`)

## What happened

Hover described every resolved member as a "Class Property" or "Class Method",
including members of a QUEUE or GROUP. A queue field read as:

```
**queueField** — Class Property · StandaloneQueueType
```

`StandaloneQueueType` is a QUEUE. It has fields, it has no properties, and it is
not a class — so all three words after the dash are wrong.

```clarion
StandaloneQueueType QUEUE,TYPE
queueField          LONG
                    END

HolderClass CLASS,TYPE
records     &StandaloneQueueType
counter     LONG
            END
```

```clarion
  SELF.records.queueField = 1   ! "Class Property · StandaloneQueueType"
  SELF.counter = 2              ! "Class Property · HolderClass"  ← correct
```

## Root cause

`MemberInfo` — the shape every member lookup returns — recorded no kind for the
structure the member was found in, only `className` plus an `isInterface?` flag:

```ts
export type MemberInfo = { type: string; className: string; line: number; file: string; signature?: string; isInterface?: boolean };
```

So `HoverFormatter` had a binary choice, and everything that was not an
INTERFACE fell through to "Class":

```ts
const memberType = isMethod ? 'Method' : 'Property';
const memberCategory = info.isInterface ? 'Interface' : 'Class';
```

The kind was already known at every producer and just dropped on the way out:

- `scanClassBodyForMember` matches the declaration with a
  `(CLASS|QUEUE|GROUP|INTERFACE)` capture;
- `findClassMemberInIncludes` captures the same keyword;
- `findMemberFromTokens` matches the structure token *by* the requested kind.

## The fix

`MemberInfo` gains an optional `structureType`, and all five construction sites
report the kind they actually matched:

```ts
export type MemberOwnerKind = 'CLASS' | 'GROUP' | 'QUEUE' | 'INTERFACE';
```

The two scanning sites use the **captured keyword** rather than the caller's
hint — the header pattern accepts all four kinds, so a caller passing the
default `'CLASS'` can still land on a QUEUE/GROUP body:

```ts
const headerMatch = lines[j].match(headerPattern);
if (!headerMatch) continue;
const ownerKind = headerMatch[1].toUpperCase() as MemberOwnerKind;
```

The current-document branch in `findClassMemberInfo` reports `'CLASS'`
unconditionally, which is exact rather than an assumption: it iterates
`TokenHelper.findClassStructures`, which filters to CLASS tokens.

`describeMemberOwner` then turns the kind into the right pair of words:

```ts
export function describeMemberOwner(
    structureType: 'CLASS' | 'GROUP' | 'QUEUE' | 'INTERFACE' | undefined,
    isInterface: boolean | undefined,
    isMethod: boolean
): { category: string; noun: string } {
    const kind = structureType ?? (isInterface ? 'INTERFACE' : 'CLASS');
    switch (kind) {
        case 'QUEUE':
            return { category: 'Queue', noun: isMethod ? 'Method' : 'Field' };
        case 'GROUP':
            return { category: 'Group', noun: isMethod ? 'Method' : 'Field' };
        case 'INTERFACE':
            return { category: 'Interface', noun: isMethod ? 'Method' : 'Property' };
        default:
            return { category: 'Class', noun: isMethod ? 'Method' : 'Property' };
    }
}
```

"Field" matches the noun hover already uses for structure members elsewhere —
`**<Type> Field:** <name>` in `StructureFieldResolver`. CLASS and INTERFACE
wording is unchanged, and an absent kind falls back to the previous
CLASS/INTERFACE behaviour, so any producer that does not set it is unaffected.

Net diff: 62 insertions, 10 deletions across three files, plus one new test file.

## Testing

6 new tests in `server/src/test/StructuredTypeMemberLabel.DiskFixture.test.ts`:
the QUEUE and GROUP shapes, the mapping itself, its unknown-kind fallback, and
two regression guards pinning the existing CLASS property/method wording.

The fixture deliberately uses fields declared in each structure's **own body**,
so it exercises labelling alone and does not depend on parent-type ascent.

Proved non-vacuous by reverting only the two formatter call sites: exactly the
two labelling tests fail, and with the reported symptom rather than a generic
mismatch:

```
AssertionError: expected "Queue Field"; got: **queueField** — Class Property · StandaloneQueueType
AssertionError: expected "Group Field"; got: **groupField** — Class Property · StandaloneGroupType
```

The mapping tests and both CLASS guards pass in either state, as regression
guards should.

Full server suite: **2610 passing / 0 failing / 4 pending** (2604 on the same tip
before this branch; the delta is exactly these 6 tests).

## Scope

- Independent of #468. That fix changes *what gets found* (parent-type ascent);
  this one changes *how something already found is described*. This branch is cut
  from the same `version-1.0.3` tip and its fixture needs no inherited field, so
  the two can land in either order. They touch adjacent but non-overlapping lines
  in `ClassMemberResolver.ts` and `MemberLocatorService.ts`.
- `RECORD` is not in `MemberOwnerKind`. The member lookups never scan a RECORD
  body — their header patterns cover CLASS/QUEUE/GROUP/INTERFACE only — so adding
  it would be an unreachable case.
- Other hover surfaces that build their own member text (for example
  `StructureFieldResolver`'s `**<Type> Field:**` card) already name the structure
  correctly and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


